### PR TITLE
feature: add start and stop function for DroidRun Portal service

### DIFF
--- a/droidrun/cli/main.py
+++ b/droidrun/cli/main.py
@@ -188,7 +188,7 @@ async def disconnect(serial: str):
 @click.option('--device', '-d', help='Device serial number or IP address', default=None)
 @coro
 async def setup(path: str, device: str | None):
-    """Install an APK file and enable it as an accessibility service."""
+    """Install the DroidRun Portal APK file onto the device."""
     try:
         # Check if APK file exists
         if not os.path.exists(path):
@@ -209,14 +209,8 @@ async def setup(path: str, device: str | None):
         os.environ["DROIDRUN_DEVICE_SERIAL"] = device
         console.print(f"[blue]Set DROIDRUN_DEVICE_SERIAL to:[/] {device}")
         
-        # Get a device object for ADB commands
-        device_obj = await device_manager.get_device(device)
-        if not device_obj:
-            console.print(f"[bold red]Error:[/] Could not get device object for {device}")
-            return
-        
-        # Step 1: Install the APK file
-        console.print(f"[bold blue]Step 1/2: Installing APK:[/] {path}")
+        # Install the APK file
+        console.print(f"[bold blue]Installing APK:[/] {path} onto {device}")
         result = await install_app(path, False, True, device)
         
         if "Error" in result:
@@ -224,22 +218,69 @@ async def setup(path: str, device: str | None):
             return
         else:
             console.print(f"[bold green]Installation successful![/]")
+            console.print(f"\n[yellow]Next step:[/]")
+            console.print(f"  Run [bold]droidrun start --device {device}[/] to enable the accessibility service.")
+            console.print(f"  Or manually enable '[bold]com.droidrun.portal[/]' in your device's Accessibility settings.")
+
+    except Exception as e:
+        console.print(f"[bold red]Error during setup:[/] {e}")
+        import traceback
+        traceback.print_exc()
+
+@cli.command()
+@click.option('--device', '-d', help='Device serial number or IP address', default=None)
+@coro
+async def start(device: str | None):
+    """Enable the DroidRun Portal accessibility service"""
+    service_component = "com.droidrun.portal/com.droidrun.portal.DroidrunPortalService"
+    package = "com.droidrun.portal" # For messages
+
+    try:
+        # Try to find a device if none specified
+        if not device:
+            devices = await device_manager.list_devices()
+            if not devices:
+                console.print("[yellow]No devices connected.[/]")
+                return
+            
+            device = devices[0].serial
+            console.print(f"[blue]Using device:[/] {device}")
+
+        # Get a device object for ADB commands
+        device_obj = await device_manager.get_device(device)
+        if not device_obj:
+            console.print(f"[bold red]Error:[/] Could not get device object for {device}")
+            return
         
-        # Step 2: Enable the accessibility service with the specific command
-        console.print(f"[bold blue]Step 2/2: Enabling accessibility service[/]")
-        
-        # Package name for reference in error message
-        package = "com.droidrun.portal"
+        console.print(f"[bold blue]Attempting to enable DroidRun service on {device}...[/]")
         
         try:
-            # Use the exact command provided
-            await device_obj._adb.shell(device, "settings put secure enabled_accessibility_services com.droidrun.portal/com.droidrun.portal.DroidrunPortalService")
+            # Get current enabled services
+            current_services_str = await device_obj._adb.shell(device, "settings get secure enabled_accessibility_services")
+            current_services_str = current_services_str.strip() if current_services_str else ""
+            
+            # Check if already enabled
+            if service_component in current_services_str.split(':'):
+                console.print(f"[green]DroidRun service ({service_component}) is already enabled on {device}.[/]")
+                # Ensure accessibility is globally enabled too
+                await device_obj._adb.shell(device, "settings put secure accessibility_enabled 1")
+                console.print("[green]Confirmed global accessibility setting is enabled.[/]")
+                return
+
+            # Add our service to the list
+            if current_services_str:
+                new_services_str = f"{current_services_str}:{service_component}"
+            else:
+                new_services_str = service_component
+
+            # Use the exact command to enable the specific service
+            await device_obj._adb.shell(device, f"settings put secure enabled_accessibility_services '{new_services_str}'")
             
             # Also enable accessibility services globally
             await device_obj._adb.shell(device, "settings put secure accessibility_enabled 1")
             
             console.print("[green]Accessibility service enabled successfully![/]")
-            console.print("\n[bold green]Setup complete![/] The DroidRun Portal is now installed and ready to use.")
+            console.print("\n[bold green]DroidRun Portal is now active.[/]")
             
         except Exception as e:
             console.print(f"[yellow]Could not automatically enable accessibility service: {e}[/]")
@@ -249,15 +290,70 @@ async def setup(path: str, device: str | None):
             await device_obj._adb.shell(device, "am start -a android.settings.ACCESSIBILITY_SETTINGS")
             
             console.print("\n[yellow]Please complete the following steps on your device:[/]")
-            console.print(f"1. Find [bold]{package}[/] in the accessibility services list")
+            console.print(f"1. Find [bold]{package}[/] in the accessibility services list (may be under 'Downloaded apps')")
             console.print("2. Tap on the service name")
             console.print("3. Toggle the switch to [bold]ON[/] to enable the service")
             console.print("4. Accept any permission dialogs that appear")
             
-            console.print("\n[bold green]APK installation complete![/] Please manually enable the accessibility service using the steps above.")
+            console.print("\n[yellow]Please manually enable the accessibility service using the steps above.")
             
     except Exception as e:
-        console.print(f"[bold red]Error:[/] {e}")
+        console.print(f"[bold red]Error starting service:[/] {e}")
+        import traceback
+        traceback.print_exc()
+
+@cli.command()
+@click.option('--device', '-d', help='Device serial number or IP address', default=None)
+@coro
+async def stop(device: str | None):
+    """Disable the DroidRun Portal accessibility service."""
+    service_component = "com.droidrun.portal/com.droidrun.portal.DroidrunPortalService"
+    
+    try:
+        # Try to find a device if none specified
+        if not device:
+            devices = await device_manager.list_devices()
+            if not devices:
+                console.print("[yellow]No devices connected.[/]")
+                return
+            
+            device = devices[0].serial
+            console.print(f"[blue]Using device:[/] {device}")
+        
+        # Get a device object for ADB commands
+        device_obj = await device_manager.get_device(device)
+        if not device_obj:
+            console.print(f"[bold red]Error:[/] Could not get device object for {device}")
+            return
+
+        console.print(f"[bold blue]Attempting to disable DroidRun service on {device}...[/]")
+
+        # Get the current list of enabled accessibility services
+        current_services_str = await device_obj._adb.shell(device, "settings get secure enabled_accessibility_services")
+        current_services_str = current_services_str.strip() if current_services_str else ""
+
+        if not current_services_str or service_component not in current_services_str:
+            console.print(f"[yellow]DroidRun service ({service_component}) is not currently enabled on {device}.[/]")
+            return
+
+        # Parse the list, remove our service, and join back
+        services_list = [s for s in current_services_str.split(':') if s and s != service_component]
+        new_services_str = ':'.join(services_list)
+
+        # Update the setting
+        if new_services_str:
+            await device_obj._adb.shell(device, f"settings put secure enabled_accessibility_services '{new_services_str}'")
+            console.print(f"[green]Successfully disabled DroidRun service by removing it from the enabled list.[/]")
+        else:
+            # If our service was the only one, clear the setting and potentially disable accessibility globally
+            # Clearing the setting is safer than setting accessibility_enabled to 0, as the user might have enabled it for other reasons.
+            await device_obj._adb.shell(device, "settings delete secure enabled_accessibility_services")
+            # Optional: Disable global accessibility if needed, but might affect other things.
+            # await device_obj._adb.shell(device, "settings put secure accessibility_enabled 0")
+            console.print(f"[green]Successfully disabled DroidRun service. No other accessibility services were enabled.[/]")
+
+    except Exception as e:
+        console.print(f"[bold red]Error stopping service:[/] {e}")
         import traceback
         traceback.print_exc()
 

--- a/droidrun/cli/main.py
+++ b/droidrun/cli/main.py
@@ -218,9 +218,9 @@ async def setup(path: str, device: str | None):
             return
         else:
             console.print(f"[bold green]Installation successful![/]")
-            console.print(f"\n[yellow]Next step:[/]")
-            console.print(f"  Run [bold]droidrun start --device {device}[/] to enable the accessibility service.")
-            console.print(f"  Or manually enable '[bold]com.droidrun.portal[/]' in your device's Accessibility settings.")
+            # Directly call the start function to enable the service
+            console.print("\n[bold blue]Proceeding to enable the accessibility service...[/]")
+            await start(device=device)
 
     except Exception as e:
         console.print(f"[bold red]Error during setup:[/] {e}")


### PR DESCRIPTION
Added two new functions, `start` and `stop,` which will start and stop the service. 
The stop function is useful for stopping a service; otherwise, the service will keep running and keep showing the bounding rectangle.

