### PR TITLE
Add Azure OpenAI support and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,21 +176,17 @@ droidrun "Open the settings app" --provider azure
 import asyncio
 import os
 from droidrun.agent.react_agent import ReActAgent
-from droidrun.agent.llm_reasoning import LLMReasoner
+from droidrun import AzureOpenAILLM  # Import the AzureOpenAILLM class directly
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
 load_dotenv()
 
 async def main():
-    # Create an Azure OpenAI LLM instance
-    llm = LLMReasoner(
-        llm_provider="azure",
-        model_name="gpt-4",  # The base model name
-        api_key=os.environ.get("AZURE_OPENAI_KEY"),
-        azure_endpoint=os.environ.get("AZURE_OPENAI_ENDPOINT"),
-        azure_deployment=os.environ.get("AZURE_OPENAI_DEPLOYMENT"),
-        azure_api_version=os.environ.get("AZURE_OPENAI_API_VERSION", "2023-05-15"),
+    # Create an Azure Open AI LLM instance using the dedicated class
+    llm = AzureOpenAILLM(
+        model="gpt-4",  # The base model name
+        # Environment variables are automatically loaded if not provided
         temperature=0.2
     )
     
@@ -233,7 +229,7 @@ If you want to use DroidRun in your Python code rather than via the CLI, you can
 import asyncio
 import os
 from droidrun.agent.react_agent import ReActAgent
-from droidrun.agent.llm_reasoning import LLMReasoner
+from droidrun import OpenAILLM, AnthropicLLM, GeminiLLM  # Import provider-specific classes
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -241,12 +237,23 @@ load_dotenv()
 
 async def main():
     # Create an LLM instance (choose your preferred provider)
-    llm = LLMReasoner(
-        llm_provider="gemini",  # Can be "openai", "anthropic", or "gemini"
-        model_name="gemini-2.0-flash",  # Choose appropriate model for your provider
-        api_key=os.environ.get("GEMINI_API_KEY"),  # Get API key from environment
+    # Example with Gemini
+    llm = GeminiLLM(
+        model="gemini-2.0-flash",  # Choose appropriate model for your provider
         temperature=0.2
     )
+    
+    # Or use OpenAI
+    # llm = OpenAILLM(
+    #     model="gpt-4o-mini",
+    #     temperature=0.2
+    # )
+    
+    # Or use Anthropic
+    # llm = AnthropicLLM(
+    #     model="claude-3-sonnet-20240229",
+    #     temperature=0.2
+    # )
     
     # Create and run the agent
     agent = ReActAgent(

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./static/droidrun-dark.png">
   <source media="(prefers-color-scheme: light)" srcset="./static/droidrun.png">
@@ -100,6 +99,12 @@ Create a `.env` file in your working directory or set environment variables:
 export OPENAI_API_KEY="your_openai_api_key_here"
 export ANTHROPIC_API_KEY="your_anthropic_api_key_here"
 export GEMINI_API_KEY="your_gemini_api_key_here"
+
+# For Azure OpenAI support
+export AZURE_OPENAI_KEY="your_azure_openai_key_here"
+export AZURE_OPENAI_ENDPOINT="https://your-resource-name.openai.azure.com"
+export AZURE_OPENAI_DEPLOYMENT="your_model_deployment_name"
+export AZURE_OPENAI_API_VERSION="2023-05-15"  # Optional, defaults to this version if not set
 ```
 
 To load the environment variables from the `.env` file:
@@ -152,6 +157,62 @@ droidrun "Check the battery level" --provider anthropic --model claude-3-sonnet-
 # Using Gemini
 droidrun "Install and open Instagram" --provider gemini --model gemini-2.0-flash
 ```
+
+## 🔷 Using Azure OpenAI
+
+You can use Azure OpenAI API instead of the standard OpenAI API. This requires a few additional environment variables:
+
+### Command Line Usage
+
+```bash
+# Using Azure OpenAI
+droidrun "Open the settings app" --provider azure
+```
+
+### Python API Usage
+
+```python
+#!/usr/bin/env python3
+import asyncio
+import os
+from droidrun.agent.react_agent import ReActAgent
+from droidrun.agent.llm_reasoning import LLMReasoner
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+async def main():
+    # Create an Azure OpenAI LLM instance
+    llm = LLMReasoner(
+        llm_provider="azure",
+        model_name="gpt-4",  # The base model name
+        api_key=os.environ.get("AZURE_OPENAI_KEY"),
+        azure_endpoint=os.environ.get("AZURE_OPENAI_ENDPOINT"),
+        azure_deployment=os.environ.get("AZURE_OPENAI_DEPLOYMENT"),
+        azure_api_version=os.environ.get("AZURE_OPENAI_API_VERSION", "2023-05-15"),
+        temperature=0.2
+    )
+    
+    # Create and run the agent
+    agent = ReActAgent(
+        task="Open the Settings app and check the Android version",
+        llm=llm
+    )
+    
+    steps = await agent.run()
+    print(f"Execution completed with {len(steps)} steps")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Make sure you have the required Azure OpenAI environment variables set:
+
+- `AZURE_OPENAI_KEY`: Your Azure OpenAI API key
+- `AZURE_OPENAI_ENDPOINT`: Your Azure OpenAI endpoint URL (e.g., `https://your-resource.openai.azure.com`)
+- `AZURE_OPENAI_DEPLOYMENT`: Your deployment name for the model
+- `AZURE_OPENAI_API_VERSION`: API version (optional, defaults to "2023-05-15")
 
 ### ⚙️ Additional Options
 
@@ -272,4 +333,4 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the LICENSE file for details. 
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/droidrun/__init__.py
+++ b/droidrun/__init__.py
@@ -7,7 +7,7 @@ __version__ = "0.1.0"
 # Import main classes for easier access
 from droidrun.agent.react_agent import ReActAgent as Agent
 from droidrun.agent.react_agent import ReActStep, ReActStepType
-from droidrun.llm import OpenAILLM, AnthropicLLM
+from droidrun.llm import OpenAILLM, AnthropicLLM, AzureOpenAILLM, GeminiLLM
 
 # Make main components available at package level
 __all__ = [
@@ -16,4 +16,6 @@ __all__ = [
     "ReActStepType",
     "OpenAILLM",
     "AnthropicLLM",
-] 
+    "AzureOpenAILLM",
+    "GeminiLLM",
+]

--- a/droidrun/agent/react_agent.py
+++ b/droidrun/agent/react_agent.py
@@ -516,7 +516,8 @@ async def run_agent(
     llm_provider: Optional[str] = None,
     model_name: Optional[str] = None,
     api_key: Optional[str] = None,
-    vision: bool = False
+    vision: bool = False,
+    **kwargs
 ) -> List[ReActStep]:
     """Run the ReAct agent with the given goal.
     
@@ -524,10 +525,11 @@ async def run_agent(
         task: The automation task to perform
         llm: LLM instance to use for reasoning
         device_serial: Serial number of the Android device
-        llm_provider: LLM provider name (openai, anthropic, or gemini)
+        llm_provider: LLM provider name (openai, azure, anthropic, or gemini)
         model_name: Name of the LLM model to use
         api_key: API key for accessing the LLM service
         vision: Whether to enable vision capabilities (screenshot tool)
+        **kwargs: Additional provider-specific parameters
     
     Returns:
         List of ReAct steps taken
@@ -542,7 +544,8 @@ async def run_agent(
             api_key=api_key,
             temperature=0.2,
             max_tokens=2000,
-            vision=vision
+            vision=vision,
+            **kwargs  # Pass additional provider-specific parameters
         )
     
     agent = ReActAgent(
@@ -553,4 +556,4 @@ async def run_agent(
     )
     
     steps = await agent.run()
-    return steps 
+    return steps

--- a/droidrun/llm/__init__.py
+++ b/droidrun/llm/__init__.py
@@ -4,21 +4,16 @@ DroidRun LLM Module.
 This module provides LLM providers for the Agent to use for reasoning.
 """
 
-from droidrun.agent.llm_reasoning import LLMReasoner as BaseLLM
+from .base import BaseLLM
+from .openai import OpenAILLM
+from .anthropic import AnthropicLLM 
+from .azure import AzureOpenAILLM
+from .gemini import GeminiLLM
 
-# Alias OpenAILLM and AnthropicLLM for backward compatibility
-class OpenAILLM(BaseLLM):
-    """
-    OpenAI-based LLM provider.
-    """
-    def __init__(self, model="gpt-4o", **kwargs):
-        super().__init__(provider="openai", model=model, **kwargs)
-
-class AnthropicLLM(BaseLLM):
-    """
-    Anthropic-based LLM provider.
-    """
-    def __init__(self, model="claude-3-opus-20240229", **kwargs):
-        super().__init__(provider="anthropic", model=model, **kwargs)
-
-__all__ = ["BaseLLM", "OpenAILLM", "AnthropicLLM"] 
+__all__ = [
+    "BaseLLM",
+    "OpenAILLM",
+    "AnthropicLLM",
+    "AzureOpenAILLM",
+    "GeminiLLM"
+]

--- a/droidrun/llm/anthropic.py
+++ b/droidrun/llm/anthropic.py
@@ -1,0 +1,54 @@
+"""
+Anthropic LLM provider for DroidRun.
+
+This module provides the Anthropic (Claude) implementation for the Agent to use for reasoning.
+"""
+
+import os
+from typing import Optional
+from .base import BaseLLM
+
+class AnthropicLLM(BaseLLM):
+    """
+    Anthropic-based LLM provider for Claude models.
+    """
+    
+    def __init__(
+        self, 
+        model: str = "claude-3-opus-20240229",
+        api_key: Optional[str] = None,
+        **kwargs
+    ):
+        """Initialize the Anthropic LLM provider.
+        
+        Args:
+            model: Model name to use (e.g., 'claude-3-opus-20240229')
+            api_key: Anthropic API key (defaults to ANTHROPIC_API_KEY env var)
+            **kwargs: Additional parameters to pass to the base LLM class
+        """
+        # Get API key from environment variable if not provided
+        api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        
+        # Validate required configuration
+        if not api_key:
+            raise ValueError("Anthropic API key not provided and not found in environment (ANTHROPIC_API_KEY)")
+        
+        # Initialize the base LLM with Anthropic configuration
+        super().__init__(
+            llm_provider="anthropic",
+            model_name=model,
+            api_key=api_key,
+            **kwargs
+        )
+    
+    @classmethod
+    def from_env(cls, **kwargs) -> 'AnthropicLLM':
+        """Create an instance using environment variables for configuration.
+        
+        Args:
+            **kwargs: Override parameters from environment variables
+            
+        Returns:
+            An AnthropicLLM instance configured from environment variables
+        """
+        return cls(**kwargs)

--- a/droidrun/llm/azure.py
+++ b/droidrun/llm/azure.py
@@ -1,0 +1,73 @@
+"""
+Azure OpenAI LLM provider for DroidRun.
+
+This module provides the Azure OpenAI implementation for the Agent to use for reasoning.
+"""
+
+import os
+from typing import Optional, Dict, Any
+from .base import BaseLLM
+
+class AzureOpenAILLM(BaseLLM):
+    """
+    Azure OpenAI-based LLM provider.
+    
+    This class provides integration with Azure OpenAI service,
+    allowing use of Azure-hosted models as an alternative to direct OpenAI API.
+    """
+    
+    def __init__(
+        self, 
+        model: str = "gpt-4o",
+        api_key: Optional[str] = None,
+        azure_endpoint: Optional[str] = None,
+        azure_deployment: Optional[str] = None,
+        azure_api_version: Optional[str] = None,
+        **kwargs
+    ):
+        """Initialize the Azure OpenAI LLM provider.
+        
+        Args:
+            model: Base model name (e.g., 'gpt-4')
+            api_key: Azure OpenAI API key (defaults to AZURE_OPENAI_KEY env var)
+            azure_endpoint: Azure OpenAI endpoint URL (defaults to AZURE_OPENAI_ENDPOINT env var)
+            azure_deployment: Azure OpenAI deployment name (defaults to AZURE_OPENAI_DEPLOYMENT env var)
+            azure_api_version: Azure OpenAI API version (defaults to AZURE_OPENAI_API_VERSION env var)
+            **kwargs: Additional parameters to pass to the base LLM class
+        """
+        # Get configuration from environment variables if not provided
+        api_key = api_key or os.environ.get("AZURE_OPENAI_KEY")
+        azure_endpoint = azure_endpoint or os.environ.get("AZURE_OPENAI_ENDPOINT")
+        azure_deployment = azure_deployment or os.environ.get("AZURE_OPENAI_DEPLOYMENT")
+        azure_api_version = azure_api_version or os.environ.get("AZURE_OPENAI_API_VERSION") or "2023-05-15"
+        
+        # Validate required configuration
+        if not api_key:
+            raise ValueError("Azure OpenAI API key not provided and not found in environment (AZURE_OPENAI_KEY)")
+        if not azure_endpoint:
+            raise ValueError("Azure OpenAI endpoint not provided and not found in environment (AZURE_OPENAI_ENDPOINT)")
+        if not azure_deployment:
+            raise ValueError("Azure OpenAI deployment name not provided and not found in environment (AZURE_OPENAI_DEPLOYMENT)")
+        
+        # Initialize the base LLM with Azure configuration
+        super().__init__(
+            llm_provider="azure",
+            model_name=model,
+            api_key=api_key,
+            azure_endpoint=azure_endpoint,
+            azure_deployment=azure_deployment,
+            azure_api_version=azure_api_version,
+            **kwargs
+        )
+    
+    @classmethod
+    def from_env(cls, **kwargs) -> 'AzureOpenAILLM':
+        """Create an instance using environment variables for configuration.
+        
+        Args:
+            **kwargs: Override parameters from environment variables
+            
+        Returns:
+            An AzureOpenAILLM instance configured from environment variables
+        """
+        return cls(**kwargs)

--- a/droidrun/llm/base.py
+++ b/droidrun/llm/base.py
@@ -1,0 +1,47 @@
+"""
+Base LLM provider for DroidRun.
+
+This module provides the base LLM class that all provider-specific implementations extend.
+"""
+
+from typing import Optional, Dict, Any, List
+from droidrun.agent.llm_reasoning import LLMReasoner
+
+class BaseLLM(LLMReasoner):
+    """
+    Base class for all LLM providers.
+    
+    This class extends the LLMReasoner and serves as a base for
+    provider-specific implementations.
+    """
+    
+    def __init__(
+        self,
+        llm_provider: str,
+        model_name: Optional[str] = None,
+        api_key: Optional[str] = None,
+        temperature: float = 0.2,
+        max_tokens: int = 2000,
+        vision: bool = False,
+        **kwargs
+    ):
+        """Initialize the base LLM provider.
+        
+        Args:
+            llm_provider: Provider name ('openai', 'azure', 'anthropic', or 'gemini')
+            model_name: Model name to use
+            api_key: API key for the LLM provider
+            temperature: Temperature for generation
+            max_tokens: Maximum tokens to generate
+            vision: Whether vision capabilities are enabled
+            **kwargs: Additional provider-specific parameters
+        """
+        super().__init__(
+            llm_provider=llm_provider,
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            vision=vision,
+            **kwargs
+        )

--- a/droidrun/llm/gemini.py
+++ b/droidrun/llm/gemini.py
@@ -1,0 +1,54 @@
+"""
+Google Gemini LLM provider for DroidRun.
+
+This module provides the Google Gemini implementation for the Agent to use for reasoning.
+"""
+
+import os
+from typing import Optional
+from .base import BaseLLM
+
+class GeminiLLM(BaseLLM):
+    """
+    Google Gemini-based LLM provider.
+    """
+    
+    def __init__(
+        self, 
+        model: str = "gemini-2.0-flash",
+        api_key: Optional[str] = None,
+        **kwargs
+    ):
+        """Initialize the Gemini LLM provider.
+        
+        Args:
+            model: Model name to use (e.g., 'gemini-2.0-flash')
+            api_key: Gemini API key (defaults to GEMINI_API_KEY env var)
+            **kwargs: Additional parameters to pass to the base LLM class
+        """
+        # Get API key from environment variable if not provided
+        api_key = api_key or os.environ.get("GEMINI_API_KEY")
+        
+        # Validate required configuration
+        if not api_key:
+            raise ValueError("Gemini API key not provided and not found in environment (GEMINI_API_KEY)")
+        
+        # Initialize the base LLM with Gemini configuration
+        super().__init__(
+            llm_provider="gemini",
+            model_name=model,
+            api_key=api_key,
+            **kwargs
+        )
+    
+    @classmethod
+    def from_env(cls, **kwargs) -> 'GeminiLLM':
+        """Create an instance using environment variables for configuration.
+        
+        Args:
+            **kwargs: Override parameters from environment variables
+            
+        Returns:
+            A GeminiLLM instance configured from environment variables
+        """
+        return cls(**kwargs)

--- a/droidrun/llm/openai.py
+++ b/droidrun/llm/openai.py
@@ -1,0 +1,54 @@
+"""
+OpenAI LLM provider for DroidRun.
+
+This module provides the OpenAI implementation for the Agent to use for reasoning.
+"""
+
+import os
+from typing import Optional
+from .base import BaseLLM
+
+class OpenAILLM(BaseLLM):
+    """
+    OpenAI-based LLM provider.
+    """
+    
+    def __init__(
+        self, 
+        model: str = "gpt-4o",
+        api_key: Optional[str] = None,
+        **kwargs
+    ):
+        """Initialize the OpenAI LLM provider.
+        
+        Args:
+            model: Model name to use (e.g., 'gpt-4o', 'gpt-4o-mini')
+            api_key: OpenAI API key (defaults to OPENAI_API_KEY env var)
+            **kwargs: Additional parameters to pass to the base LLM class
+        """
+        # Get API key from environment variable if not provided
+        api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        
+        # Validate required configuration
+        if not api_key:
+            raise ValueError("OpenAI API key not provided and not found in environment (OPENAI_API_KEY)")
+        
+        # Initialize the base LLM with OpenAI configuration
+        super().__init__(
+            llm_provider="openai",
+            model_name=model,
+            api_key=api_key,
+            **kwargs
+        )
+    
+    @classmethod
+    def from_env(cls, **kwargs) -> 'OpenAILLM':
+        """Create an instance using environment variables for configuration.
+        
+        Args:
+            **kwargs: Override parameters from environment variables
+            
+        Returns:
+            An OpenAILLM instance configured from environment variables
+        """
+        return cls(**kwargs)


### PR DESCRIPTION
**Add Azure OpenAI API support**
This PR adds support for Azure OpenAI API as an alternative to the standard OpenAI API. The implementation includes:

- Add new environment variables: `AZURE_OPENAI_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT`, and `AZURE_OPENAI_API_VERSION`
- Implement Azure OpenAI client initialization in the LLMReasoner class
- Update the CLI to handle the Azure provider option and related parameters
- Add documentation and examples for Azure OpenAI integration
- Users can now leverage their Azure OpenAI resources by specifying `--provider` azure in the CLI or setting `llm_provider="azure"` in the Python API.