### PR TITLE
import from typing_extensions

### DIFF
--- a/droidrun/tools/adb.py
+++ b/droidrun/tools/adb.py
@@ -7,7 +7,7 @@ import json
 import time
 import asyncio
 import logging
-from typing import Optional, Dict, Tuple, List, Any, Type, Self
+from typing_extensions import Optional, Dict, Tuple, List, Any, Type, Self
 from droidrun.adb.device import Device
 from droidrun.adb.manager import DeviceManager
 from droidrun.tools.tools import Tools


### PR DESCRIPTION
## issue

Reproducing steps:
1. On Windows system, create a brand new python3.10 env, and install latest `droidrun` and connect adb

    ```powershell
    conda create -n py310 python=3.10`
    conda activate py310
    pip install droidrun

    adb devices
    adb connect <ip:port>
    ```
1. Now run setup, we see error `ImportError: cannot import name 'Self' from 'typing'`
![image](https://github.com/user-attachments/assets/ec3f6bbb-ac61-4cd1-816e-3e07353db93c)

##  proposing a fix

Verified on Windows that this error can be fixed by importing from `typing_extensions` instead of `typing`


