### PR TITLE
Record the a11y_tree during execution

### DIFF
--- a/droidrun/agent/codeact/codeact_agent.py
+++ b/droidrun/agent/codeact/codeact_agent.py
@@ -257,7 +257,7 @@ class CodeActAgent(Workflow):
                 ctx.write_event_to_stream(ScreenshotEvent(screenshot=screenshot))
 
             ui_states = result['ui_states']
-            for ui_state in ui_states:
+            for ui_state in ui_states[:-1]:
                 ctx.write_event_to_stream(RecordUIStateEvent(ui_state=ui_state['a11y_tree']))
 
             actions = result['actions']

--- a/droidrun/agent/codeact/codeact_agent.py
+++ b/droidrun/agent/codeact/codeact_agent.py
@@ -18,7 +18,7 @@ from droidrun.agent.codeact.events import (
     TaskThinkingEvent,
     EpisodicMemoryEvent,
 )
-from droidrun.agent.common.events import ScreenshotEvent
+from droidrun.agent.common.events import ScreenshotEvent, RecordActionEvent, RecordUIStateEvent
 from droidrun.agent.utils import chat_utils
 from droidrun.agent.utils.executer import SimpleCodeExecutor
 from droidrun.agent.codeact.prompts import (
@@ -182,6 +182,7 @@ class CodeActAgent(Workflow):
                 try:
                     state = self.tools.get_state()
                     await ctx.set("ui_state", state["a11y_tree"])
+                    ctx.write_event_to_stream(RecordUIStateEvent(ui_state=state["a11y_tree"]))
                     chat_history = await chat_utils.add_ui_text_block(
                         state["a11y_tree"], chat_history
                     )
@@ -254,6 +255,14 @@ class CodeActAgent(Workflow):
             screenshots = result['screenshots']
             for screenshot in screenshots[:-1]: # the last screenshot will be captured by next step
                 ctx.write_event_to_stream(ScreenshotEvent(screenshot=screenshot))
+
+            ui_states = result['ui_states']
+            for ui_state in ui_states:
+                ctx.write_event_to_stream(RecordUIStateEvent(ui_state=ui_state['a11y_tree']))
+
+            actions = result['actions']
+            for action in actions:
+                ctx.write_event_to_stream(RecordActionEvent(action=action['action'], args=action['args'], kwargs=action['kwargs']))
 
             if self.tools.finished == True:
                 logger.debug("  - Task completed.")

--- a/droidrun/agent/codeact/codeact_agent.py
+++ b/droidrun/agent/codeact/codeact_agent.py
@@ -18,7 +18,7 @@ from droidrun.agent.codeact.events import (
     TaskThinkingEvent,
     EpisodicMemoryEvent,
 )
-from droidrun.agent.common.events import ScreenshotEvent, RecordActionEvent, RecordUIStateEvent
+from droidrun.agent.common.events import ScreenshotEvent, RecordUIStateEvent
 from droidrun.agent.utils import chat_utils
 from droidrun.agent.utils.executer import SimpleCodeExecutor
 from droidrun.agent.codeact.prompts import (
@@ -259,10 +259,6 @@ class CodeActAgent(Workflow):
             ui_states = result['ui_states']
             for ui_state in ui_states[:-1]:
                 ctx.write_event_to_stream(RecordUIStateEvent(ui_state=ui_state['a11y_tree']))
-
-            actions = result['actions']
-            for action in actions:
-                ctx.write_event_to_stream(RecordActionEvent(action=action['action'], args=action['args'], kwargs=action['kwargs']))
 
             if self.tools.finished == True:
                 logger.debug("  - Task completed.")

--- a/droidrun/agent/common/events.py
+++ b/droidrun/agent/common/events.py
@@ -45,3 +45,6 @@ class StartAppEvent(MacroEvent):
     """"Event for starting an app"""
     package: str
     activity: str = None
+
+class RecordUIStateEvent(Event):
+    ui_state: dict

--- a/droidrun/agent/common/events.py
+++ b/droidrun/agent/common/events.py
@@ -1,4 +1,5 @@
 from llama_index.core.workflow import Event
+from typing import Dict, Any
 
 class ScreenshotEvent(Event):
     screenshot: bytes
@@ -47,4 +48,4 @@ class StartAppEvent(MacroEvent):
     activity: str = None
 
 class RecordUIStateEvent(Event):
-    ui_state: dict
+    ui_state: list[Dict[str, Any]]

--- a/droidrun/agent/droid/droid_agent.py
+++ b/droidrun/agent/droid/droid_agent.py
@@ -16,7 +16,7 @@ from droidrun.agent.planner import PlannerAgent
 from droidrun.agent.context.task_manager import TaskManager
 from droidrun.agent.utils.trajectory import Trajectory
 from droidrun.tools import Tools, describe_tools
-from droidrun.agent.common.events import ScreenshotEvent, MacroEvent
+from droidrun.agent.common.events import ScreenshotEvent, MacroEvent, RecordUIStateEvent
 from droidrun.agent.common.default import MockWorkflow
 from droidrun.agent.context import ContextInjectionManager
 from droidrun.agent.context.agent_persona import AgentPersona
@@ -424,6 +424,9 @@ A wrapper class that coordinates between PlannerAgent (creates plans) and
                 self.trajectory.screenshots.append(ev.screenshot)
             elif isinstance(ev, MacroEvent):
                 self.trajectory.macro.append(ev)
+            elif isinstance(ev, RecordUIStateEvent):
+                self.trajectory.ui_states.append(ev.ui_state)
+
             else:
                 self.trajectory.events.append(ev)
 

--- a/droidrun/agent/planner/planner_agent.py
+++ b/droidrun/agent/planner/planner_agent.py
@@ -179,7 +179,7 @@ class PlannerAgent(Workflow):
                 for action in actions:
                     ctx.write_event_to_stream(RecordActionEvent(action=action['action'], args=action['args'], kwargs=action['kwargs']))
                 ui_states = result['ui_states']
-                for ui_state in ui_states:
+                for ui_state in ui_states[:-1]:
                     ctx.write_event_to_stream(RecordUIStateEvent(ui_state=ui_state['a11y_tree']))
 
                 await self.chat_memory.aput(

--- a/droidrun/agent/planner/planner_agent.py
+++ b/droidrun/agent/planner/planner_agent.py
@@ -17,7 +17,7 @@ from droidrun.agent.utils.executer import SimpleCodeExecutor
 from droidrun.agent.utils import chat_utils
 from droidrun.agent.context.task_manager import TaskManager
 from droidrun.tools import Tools
-from droidrun.agent.common.events import ScreenshotEvent, RecordActionEvent, RecordUIStateEvent
+from droidrun.agent.common.events import ScreenshotEvent, RecordUIStateEvent
 from droidrun.agent.planner.events import (
     PlanInputEvent,
     PlanCreatedEvent,
@@ -175,9 +175,7 @@ class PlannerAgent(Workflow):
                 screenshots = result['screenshots']
                 for screenshot in screenshots[:-1]: # the last screenshot will be captured by next step
                     ctx.write_event_to_stream(ScreenshotEvent(screenshot=screenshot))
-                actions = result['actions']
-                for action in actions:
-                    ctx.write_event_to_stream(RecordActionEvent(action=action['action'], args=action['args'], kwargs=action['kwargs']))
+                
                 ui_states = result['ui_states']
                 for ui_state in ui_states[:-1]:
                     ctx.write_event_to_stream(RecordUIStateEvent(ui_state=ui_state['a11y_tree']))

--- a/droidrun/agent/utils/executer.py
+++ b/droidrun/agent/utils/executer.py
@@ -101,7 +101,6 @@ class SimpleCodeExecutor:
         self.globals['ui_state'] = await ctx.get("ui_state", None)
         self.globals['step_screenshots'] = []
         self.globals['step_ui_states'] = []
-        self.globals['step_actions'] = []
         
         if self.tools_instance and isinstance(self.tools_instance, AdbTools):
             self.tools_instance._set_context(ctx)
@@ -145,6 +144,5 @@ class SimpleCodeExecutor:
             'output': output,
             'screenshots': self.globals['step_screenshots'],
             'ui_states': self.globals['step_ui_states'],
-            'actions': self.globals['step_actions']
         }
         return result

--- a/droidrun/agent/utils/executer.py
+++ b/droidrun/agent/utils/executer.py
@@ -101,6 +101,7 @@ class SimpleCodeExecutor:
         self.globals['ui_state'] = await ctx.get("ui_state", None)
         self.globals['step_screenshots'] = []
         self.globals['step_ui_states'] = []
+        self.globals['step_actions'] = []
         
         if self.tools_instance and isinstance(self.tools_instance, AdbTools):
             self.tools_instance._set_context(ctx)
@@ -143,6 +144,7 @@ class SimpleCodeExecutor:
         result = {
             'output': output,
             'screenshots': self.globals['step_screenshots'],
-            'ui_states': self.globals['step_ui_states']
+            'ui_states': self.globals['step_ui_states'],
+            'actions': self.globals['step_actions']
         }
         return result

--- a/droidrun/agent/utils/trajectory.py
+++ b/droidrun/agent/utils/trajectory.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import time
+import uuid
 from typing import Dict, List, Any
 from PIL import Image
 import io
@@ -26,6 +27,7 @@ class Trajectory:
         """
         self.events: List[Event] = [] 
         self.screenshots: List[bytes] = [] 
+<<<<<<< HEAD
         self.macro: List[Event] = []
         self.goal = goal or "DroidRun automation sequence"
 
@@ -37,6 +39,10 @@ class Trajectory:
         """
         self.goal = goal
 
+=======
+        self.actions: List[Dict[str, Any]] = []
+        self.ui_states: List[Dict[str, Any]] = []
+>>>>>>> 5b5fde0 (save UI states)
 
     def create_screenshot_gif(self, output_path: str, duration: int = 1000) -> str:
         """
@@ -60,7 +66,7 @@ class Trajectory:
             images.append(img)
         
         # Save as GIF
-        gif_path = f"{output_path}.gif"
+        gif_path = os.path.join(output_path, "trajectory.gif")
         images[0].save(
             gif_path,
             save_all=True,
@@ -86,11 +92,16 @@ class Trajectory:
         Returns:
             Path to the trajectory folder
         """
-        os.makedirs(directory, exist_ok=True)
-        
+        # timestamp may be the same for multiple processes, using uuid to ensure uniqueness
         timestamp = time.strftime("%Y%m%d_%H%M%S")
+<<<<<<< HEAD
         trajectory_folder = os.path.join(directory, f"trajectory_{timestamp}")
         os.makedirs(trajectory_folder, exist_ok=True)
+=======
+        unique_id = str(uuid.uuid4())[:8]
+        base_path = os.path.join(directory, f"{timestamp}_{unique_id}")
+        os.makedirs(base_path, exist_ok=True)
+>>>>>>> 5b5fde0 (save UI states)
         
         def make_serializable(obj):
             """Recursively make objects JSON serializable."""
@@ -128,6 +139,7 @@ class Trajectory:
             }
             serializable_events.append(event_dict)
         
+<<<<<<< HEAD
         trajectory_json_path = os.path.join(trajectory_folder, "trajectory.json")
         with open(trajectory_json_path, "w") as f:
             json.dump(serializable_events, f, indent=2)
@@ -154,12 +166,37 @@ class Trajectory:
                 }, f, indent=2)
             
             logger.info(f"💾 Saved macro sequence with {len(macro_data)} actions to {macro_json_path}")
+=======
+        events_path = os.path.join(base_path, "events.json")
+        with open(events_path, "w") as f:
+            json.dump(serializable_events, f, ensure_ascii=False, indent=2)
+
+        actions_path = os.path.join(base_path, "actions.json")
+        with open(actions_path, "w") as f:
+            json.dump(self.actions, f, ensure_ascii=False, indent=2)
+
+        if len(self.ui_states) != len(self.screenshots):
+            logger.warning("UI states and screenshots are not the same length!")
+        
+        os.makedirs(os.path.join(base_path, "ui_states"), exist_ok=True)
+        for idx, ui_state in enumerate(self.ui_states):
+            ui_states_path = os.path.join(base_path, "ui_states", f"{idx}.json")
+            with open(ui_states_path, "w", encoding="utf-8") as f:
+                json.dump(ui_state, f, ensure_ascii=False, indent=2)
+                
+        os.makedirs(os.path.join(base_path, "screenshots"), exist_ok=True)
+        for idx, screenshot in enumerate(self.screenshots):
+            screenshot_path = os.path.join(base_path, "screenshots", f"{idx}.png")
+            with open(screenshot_path, "wb") as f:
+                f.write(screenshot)
+>>>>>>> 5b5fde0 (save UI states)
 
         # Create screenshot GIF
         gif_path = self.create_screenshot_gif(os.path.join(trajectory_folder, "screenshots"))
         if gif_path:
             logger.info(f"🎬 Saved screenshot GIF to {gif_path}")
 
+<<<<<<< HEAD
         logger.info(f"📁 Trajectory saved to folder: {trajectory_folder}")
         return trajectory_folder
 
@@ -331,6 +368,9 @@ class Trajectory:
             print(f"Total events: {len(folder_data['trajectory_data'])}")
         
         print("=================================")
+=======
+        return base_path
+>>>>>>> 5b5fde0 (save UI states)
 
     def get_trajectory_statistics(trajectory_data: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/droidrun/agent/utils/trajectory.py
+++ b/droidrun/agent/utils/trajectory.py
@@ -26,8 +26,8 @@ class Trajectory:
             goal: The goal/prompt that this trajectory is trying to achieve
         """
         self.events: List[Event] = [] 
-        self.screenshots: List[bytes] = [] 
-<<<<<<< HEAD
+        self.screenshots: List[bytes] = []
+        self.ui_states: List[Dict[str, Any]] = []
         self.macro: List[Event] = []
         self.goal = goal or "DroidRun automation sequence"
 
@@ -38,11 +38,6 @@ class Trajectory:
             goal: The new goal/prompt description
         """
         self.goal = goal
-
-=======
-        self.actions: List[Dict[str, Any]] = []
-        self.ui_states: List[Dict[str, Any]] = []
->>>>>>> 5b5fde0 (save UI states)
 
     def create_screenshot_gif(self, output_path: str, duration: int = 1000) -> str:
         """
@@ -94,14 +89,9 @@ class Trajectory:
         """
         # timestamp may be the same for multiple processes, using uuid to ensure uniqueness
         timestamp = time.strftime("%Y%m%d_%H%M%S")
-<<<<<<< HEAD
-        trajectory_folder = os.path.join(directory, f"trajectory_{timestamp}")
-        os.makedirs(trajectory_folder, exist_ok=True)
-=======
         unique_id = str(uuid.uuid4())[:8]
-        base_path = os.path.join(directory, f"{timestamp}_{unique_id}")
-        os.makedirs(base_path, exist_ok=True)
->>>>>>> 5b5fde0 (save UI states)
+        trajectory_folder = os.path.join(directory, f"{timestamp}_{unique_id}")
+        os.makedirs(trajectory_folder, exist_ok=True)
         
         def make_serializable(obj):
             """Recursively make objects JSON serializable."""
@@ -139,7 +129,6 @@ class Trajectory:
             }
             serializable_events.append(event_dict)
         
-<<<<<<< HEAD
         trajectory_json_path = os.path.join(trajectory_folder, "trajectory.json")
         with open(trajectory_json_path, "w") as f:
             json.dump(serializable_events, f, indent=2)
@@ -166,38 +155,22 @@ class Trajectory:
                 }, f, indent=2)
             
             logger.info(f"💾 Saved macro sequence with {len(macro_data)} actions to {macro_json_path}")
-=======
-        events_path = os.path.join(base_path, "events.json")
-        with open(events_path, "w") as f:
-            json.dump(serializable_events, f, ensure_ascii=False, indent=2)
-
-        actions_path = os.path.join(base_path, "actions.json")
-        with open(actions_path, "w") as f:
-            json.dump(self.actions, f, ensure_ascii=False, indent=2)
-
-        if len(self.ui_states) != len(self.screenshots):
-            logger.warning("UI states and screenshots are not the same length!")
-        
-        os.makedirs(os.path.join(base_path, "ui_states"), exist_ok=True)
-        for idx, ui_state in enumerate(self.ui_states):
-            ui_states_path = os.path.join(base_path, "ui_states", f"{idx}.json")
-            with open(ui_states_path, "w", encoding="utf-8") as f:
-                json.dump(ui_state, f, ensure_ascii=False, indent=2)
-                
-        os.makedirs(os.path.join(base_path, "screenshots"), exist_ok=True)
-        for idx, screenshot in enumerate(self.screenshots):
-            screenshot_path = os.path.join(base_path, "screenshots", f"{idx}.png")
-            with open(screenshot_path, "wb") as f:
-                f.write(screenshot)
->>>>>>> 5b5fde0 (save UI states)
 
         # Create screenshot GIF
-        gif_path = self.create_screenshot_gif(os.path.join(trajectory_folder, "screenshots"))
+        gif_path = self.create_screenshot_gif(trajectory_folder)
         if gif_path:
             logger.info(f"🎬 Saved screenshot GIF to {gif_path}")
 
-<<<<<<< HEAD
         logger.info(f"📁 Trajectory saved to folder: {trajectory_folder}")
+
+        if len(self.ui_states) != len(self.screenshots):
+            logger.warning("UI states and screenshots are not the same length!")
+
+        os.makedirs(os.path.join(trajectory_folder, "ui_states"), exist_ok=True)
+        for idx, ui_state in enumerate(self.ui_states):
+            ui_states_path = os.path.join(trajectory_folder, "ui_states", f"{idx}.json")
+            with open(ui_states_path, "w", encoding="utf-8") as f:
+                json.dump(ui_state, f, ensure_ascii=False, indent=2)
         return trajectory_folder
 
     @staticmethod
@@ -368,9 +341,6 @@ class Trajectory:
             print(f"Total events: {len(folder_data['trajectory_data'])}")
         
         print("=================================")
-=======
-        return base_path
->>>>>>> 5b5fde0 (save UI states)
 
     def get_trajectory_statistics(trajectory_data: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/droidrun/cli/logs.py
+++ b/droidrun/cli/logs.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.live import Live
 from typing import List
 
-from droidrun.agent.common.events import ScreenshotEvent
+from droidrun.agent.common.events import ScreenshotEvent, RecordActionEvent, RecordUIStateEvent
 from droidrun.agent.planner.events import (
     PlanInputEvent,
     PlanThinkingEvent,
@@ -176,6 +176,12 @@ class LogHandler(logging.Handler):
         # Log different event types with proper names
         if isinstance(event, ScreenshotEvent):
             logger.debug("📸 Taking screenshot...")
+        
+        elif isinstance(event, RecordActionEvent):
+            logger.debug(f"✏️ Recording action: {event.action}")
+
+        elif isinstance(event, RecordUIStateEvent):
+            logger.debug(f"✏️ Recording UI state")
 
         # Planner events
         elif isinstance(event, PlanInputEvent):

--- a/droidrun/cli/logs.py
+++ b/droidrun/cli/logs.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.live import Live
 from typing import List
 
-from droidrun.agent.common.events import ScreenshotEvent, RecordActionEvent, RecordUIStateEvent
+from droidrun.agent.common.events import ScreenshotEvent, RecordUIStateEvent
 from droidrun.agent.planner.events import (
     PlanInputEvent,
     PlanThinkingEvent,
@@ -176,9 +176,6 @@ class LogHandler(logging.Handler):
         # Log different event types with proper names
         if isinstance(event, ScreenshotEvent):
             logger.debug("📸 Taking screenshot...")
-        
-        elif isinstance(event, RecordActionEvent):
-            logger.debug(f"✏️ Recording action: {event.action}")
 
         elif isinstance(event, RecordUIStateEvent):
             logger.debug(f"✏️ Recording UI state")

--- a/droidrun/tools/tools.py
+++ b/droidrun/tools/tools.py
@@ -32,12 +32,13 @@ class Tools(ABC):
                 
                 step_screenshots = caller_globals.get('step_screenshots')
                 step_ui_states = caller_globals.get('step_ui_states')
+                step_actions = caller_globals.get('step_actions')
                 
                 if step_screenshots is not None:
                     step_screenshots.append(self.take_screenshot()[1])
                 if step_ui_states is not None:
                     step_ui_states.append(self.get_state())
-            
+                step_actions.append({"action": func.__name__, "args": args[1:], "kwargs": kwargs})
             return result
         return wrapper
 

--- a/droidrun/tools/tools.py
+++ b/droidrun/tools/tools.py
@@ -32,13 +32,11 @@ class Tools(ABC):
                 
                 step_screenshots = caller_globals.get('step_screenshots')
                 step_ui_states = caller_globals.get('step_ui_states')
-                step_actions = caller_globals.get('step_actions')
                 
                 if step_screenshots is not None:
                     step_screenshots.append(self.take_screenshot()[1])
                 if step_ui_states is not None:
                     step_ui_states.append(self.get_state())
-                step_actions.append({"action": func.__name__, "args": args[1:], "kwargs": kwargs})
             return result
         return wrapper
 


### PR DESCRIPTION
1. Record a11y_tree during execution

Captures and streams the accessibility tree (a11y_tree) as part of UI state during task execution for better context tracking and analysis.

2. Fix trajectory folder naming conflict in multi-process runs

Original folder names were timestamp-based and could collide during parallel execution. Now appends a UUID to ensure uniqueness.