### PR TITLE
Fix droidrun installation step

### DIFF
--- a/docs/v3/quickstart.mdx
+++ b/docs/v3/quickstart.mdx
@@ -26,8 +26,9 @@ Before installing DroidRun, ensure you have:
    - Connected via USB or on the same network (for wireless debugging)
 
 ### Install from PyPI
+Use [`uv`](https://docs.astral.sh/uv/getting-started/installation/)
 ```bash
-pip install droidrun
+uv pip install droidrun
 ```
 
 ### Setup the Portal APK


### PR DESCRIPTION
`pip install droidrun` was failing for macos m4 pro in venv, `error: resolution-too-deep`. Using`uv` fixes this