### PR TITLE
add secure CredentialManager with profiles, env/file loading, deep resolution, and redaction

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -31,7 +31,8 @@
                   "v3/guides/gemini",
                   "v3/guides/openailike",
                   "v3/guides/ollama",
-                  "v3/guides/telemetry"
+                  "v3/guides/telemetry",
+                  "v3/guides/credentials"
                 ]
               },
               {

--- a/docs/v3/guides/credentials.mdx
+++ b/docs/v3/guides/credentials.mdx
@@ -1,9 +1,9 @@
 ---
-title: Credentials
+title: Credential Manager
 description: Securely manage and use credentials in DroidRun via placeholders, files, and environment variables.
 ---
 
-# Credentials
+# Credential-Manager
 
 DroidRun lets you securely use secrets without exposing them in prompts, agent reasoning, logs, or telemetry.
 

--- a/docs/v3/guides/credentials.mdx
+++ b/docs/v3/guides/credentials.mdx
@@ -1,0 +1,109 @@
+---
+title: Credentials
+description: Securely manage and use credentials in DroidRun via placeholders, files, and environment variables.
+---
+
+# Credentials
+
+DroidRun lets you securely use secrets without exposing them in prompts, agent reasoning, logs, or telemetry.
+
+- Secrets are referenced by placeholders like `{{API_TOKEN}}`.
+- They are resolved only at tool-execution time by the `CredentialManager`.
+- All logs and telemetry go through a redactor that replaces known values with placeholders.
+
+## Sources
+
+The `CredentialManager` merges secrets from multiple sources (later ones override earlier ones):
+
+1. File `~/.droidrun/credentials.json` (or `--credentials-file`)
+2. `DROIDRUN_CREDENTIALS_JSON` (JSON string)
+3. Flat env vars `DROIDRUN_CREDENTIALS_*`
+4. Explicit dict passed programmatically
+
+### Profiles
+
+If your JSON is an object of objects, the top-level keys are treated as profiles:
+
+```json
+{
+  "default": {
+    "USER_NAME": "alice",
+    "PASSWORD": "s3cr3t",
+    "API_TOKEN": "tok_abc123"
+  },
+  "work": {
+    "API_TOKEN": "tok_work_456"
+  }
+}
+```
+
+Select a profile via `--credentials-profile work` or `DROIDRUN_CREDENTIALS_PROFILE=work`.
+
+### Flat env vars
+
+Set individual secrets with `DROIDRUN_CREDENTIALS_*`:
+
+```
+export DROIDRUN_CREDENTIALS_USER_NAME=alice
+export DROIDRUN_CREDENTIALS_PASSWORD=s3cr3t
+export DROIDRUN_CREDENTIALS_API_TOKEN=tok_abc123
+```
+
+### JSON env var
+
+```
+export DROIDRUN_CREDENTIALS_JSON='{"USER_NAME":"alice","PASSWORD":"s3cr3t"}'
+```
+
+## CLI usage
+
+All commands accept the following options:
+
+- `--credentials-file` Path to a credentials JSON file
+- `--credentials-profile` Profile name in the credentials file/JSON
+
+Example:
+
+```
+droidrun run "login to the app" \
+  --credentials-file ~/.droidrun/credentials.json \
+  --credentials-profile work
+```
+
+## Placeholders
+
+Placeholders are `{{UPPER_SNAKE_CASE}}` identifiers. Use them anywhere in tool parameters:
+
+```json
+{
+  "tool": "fill_credentials",
+  "params": {
+    "username": "{{USER_NAME}}",
+    "password": "{{PASSWORD}}"
+  }
+}
+```
+
+Or through the helper exposed to the agent:
+
+```python
+# inside agent-executed code
+creds = fill_credentials(username="{{USER_NAME}}", password="{{PASSWORD}}")
+input_text(creds["username"])  # resolved value at call-time
+```
+
+Resolution happens only when executing the tool call. The agent continues to see placeholders in its context.
+
+## Security and redaction
+
+- The CLI installs a log filter that redacts secrets in all `droidrun` logs.
+- Telemetry events are redacted before sending.
+- The Python executor output is redacted before returning.
+
+No secret values are printed or captured in prompts/telemetry when configured.
+
+## Troubleshooting
+
+- If placeholders do not resolve, verify the key names (they must be upper-case) and that sources are loaded.
+- Use `--credentials-profile` to ensure the intended profile is active.
+- Enable debug logs with `--debug` to see key-only diagnostics from `CredentialManager`.

--- a/droidrun/agent/utils/credential_manager.py
+++ b/droidrun/agent/utils/credential_manager.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+PLACEHOLDER_RE = re.compile(r"\{\{([A-Z0-9_\.\-]+)\}\}")
+
+
+logger = logging.getLogger("droidrun")
+
+
+class CredentialManager:
+    """Load and manage secrets, resolve placeholders, and redact outputs.
+
+    Supports:
+    - Environment variables (DROIDRUN_CREDENTIALS_*, DROIDRUN_CREDENTIALS_JSON)
+    - JSON file at ~/.droidrun/credentials.json or a provided path
+    - Profiles via top-level object keys, selected by name
+    - Deep placeholder resolution in arbitrary Python data structures
+    - Redaction of known secret values from text/logs
+    """
+
+    def __init__(
+        self,
+        *,
+        credentials: Mapping[str, str] | None = None,
+        file_path: str | os.PathLike[str] | None = None,
+        profile: str | None = None,
+    ) -> None:
+        self._raw: Dict[str, Any] = {}
+        self._secrets: Dict[str, str] = {}
+
+        # Load from file first (lowest precedence)
+        file_data = self._load_from_file(file_path)
+        if isinstance(file_data, dict):
+            self._raw = file_data
+
+        # Load from env JSON (overrides file)
+        env_json_data = self._load_from_env_json()
+        if isinstance(env_json_data, dict):
+            # merge
+            self._raw.update(env_json_data)
+
+        # Choose profile view
+        if self._looks_profiled(self._raw):
+            active = profile or os.getenv("DROIDRUN_CREDENTIALS_PROFILE", "default")
+            selected = self._raw.get(active) or {}
+            logger.debug(
+                "CredentialManager: using profile '%s' (keys: %s)",
+                active,
+                list(selected.keys()),
+            )
+        else:
+            selected = self._raw
+            logger.debug("CredentialManager: using flat secret map (no profiles detected)")
+
+        # Overlay flat env vars (highest precedence)
+        flat_env = self._load_from_env_flat()
+        selected = {**selected, **flat_env}
+
+        # Overlay explicit credentials argument if given
+        if credentials:
+            selected.update(dict(credentials))
+
+        # Normalize keys to UPPER_SNAKE_CASE
+        normalize_keys: Dict[str, str] = {}
+        for k, v in selected.items():
+            if v is None:
+                continue
+            if not isinstance(v, (str, int, float, bool)):
+                # Only scalar secrets are supported; JSON can store nested
+                # structures but we only keep scalars here.
+                continue
+            key = str(k).upper()
+            normalize_keys[key] = str(v)
+
+        self._secrets = normalize_keys
+        logger.debug(
+            "CredentialManager: initialized secrets (keys only) -> %s",
+            sorted(self._secrets.keys()),
+        )
+        # Precompute redaction pairs sorted by descending length to avoid partial overlaps
+        self._redaction_pairs = sorted(
+            ((value, f"{{{{{key}}}}}") for key, value in self._secrets.items()),
+            key=lambda p: len(p[0]),
+            reverse=True,
+        )
+
+    # ---------------------------- Loading helpers ----------------------------
+    def _default_file_path(self) -> Path:
+        return Path.home() / ".droidrun" / "credentials.json"
+
+    def _load_from_file(self, file_path: str | os.PathLike[str] | None) -> Dict[str, Any]:
+        path = Path(file_path) if file_path else self._default_file_path()
+        if not path.exists():
+            logger.debug(f"CredentialManager: credentials file not found at {path}")
+            return {}
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+                logger.debug(
+                    "CredentialManager: loaded credentials file %s (top-level keys: %s)",
+                    path,
+                    list(data.keys()),
+                )
+                return data
+        except Exception as e:
+            logger.debug(f"CredentialManager: failed to load credentials file {path}: {e}")
+            return {}
+
+    def _load_from_env_json(self) -> Dict[str, Any]:
+        raw = os.getenv("DROIDRUN_CREDENTIALS_JSON")
+        if not raw:
+            return {}
+        try:
+            data = json.loads(raw)
+            logger.debug(
+                "CredentialManager: loaded secrets from DROIDRUN_CREDENTIALS_JSON "
+                "(top-level keys: %s)",
+                list(data.keys()) if isinstance(data, dict) else type(data).__name__,
+            )
+            return data
+        except Exception as e:
+            logger.debug("CredentialManager: invalid DROIDRUN_CREDENTIALS_JSON: %s", e)
+            return {}
+
+    def _load_from_env_flat(self) -> Dict[str, str]:
+        out: Dict[str, str] = {}
+        prefix = "DROIDRUN_CREDENTIALS_"
+        for k, v in os.environ.items():
+            if not k.startswith(prefix):
+                continue
+            key = k[len(prefix) :].upper()
+            if key in ("JSON", "FILE", "PROFILE"):
+                continue
+            out[key] = v
+        if out:
+            logger.debug(
+                "CredentialManager: loaded %d flat env secrets (keys only)", len(out)
+            )
+        return out
+
+    def _looks_profiled(self, data: Dict[str, Any]) -> bool:
+        # Heuristic: if any value is a dict of scalars, treat as profiles
+        return any(isinstance(v, dict) for v in data.values())
+
+    # ------------------------------ Public API --------------------------------
+    def get(self, name: str, default: str | None = None) -> str | None:
+        return self._secrets.get(name.upper(), default)
+
+    def known_placeholders(self) -> Dict[str, str]:
+        return {f"{{{{{k}}}}}": v for k, v in self._secrets.items()}
+
+    def resolve_placeholders(self, obj: Any) -> Any:
+        """Deep-resolve placeholders in strings, lists, and dicts."""
+        if isinstance(obj, str):
+            return self._resolve_in_string(obj)
+        if isinstance(obj, list):
+            return [self.resolve_placeholders(x) for x in obj]
+        if isinstance(obj, tuple):
+            return tuple(self.resolve_placeholders(x) for x in obj)
+        if isinstance(obj, dict):
+            return {k: self.resolve_placeholders(v) for k, v in obj.items()}
+        return obj
+
+    def _resolve_in_string(self, s: str) -> str:
+        def _replace(m: re.Match[str]) -> str:
+            key = m.group(1).upper()
+            return self._secrets.get(key, m.group(0))
+
+        return PLACEHOLDER_RE.sub(_replace, s)
+
+    def redact(self, text: str) -> str:
+        """Replace known secret values with their placeholders."""
+        if not text:
+            return text
+        redacted = text
+        for value, placeholder in self._redaction_pairs:
+            if not value:
+                continue
+            redacted = redacted.replace(value, placeholder)
+        return redacted
+
+    def redact_obj(self, obj: Any) -> Any:
+        if isinstance(obj, str):
+            return self.redact(obj)
+        if isinstance(obj, list):
+            return [self.redact_obj(x) for x in obj]
+        if isinstance(obj, tuple):
+            return tuple(self.redact_obj(x) for x in obj)
+        if isinstance(obj, dict):
+            return {k: self.redact_obj(v) for k, v in obj.items()}
+        return obj

--- a/droidrun/agent/utils/executer.py
+++ b/droidrun/agent/utils/executer.py
@@ -145,4 +145,11 @@ class SimpleCodeExecutor:
             'screenshots': self.globals['step_screenshots'],
             'ui_states': self.globals['step_ui_states'],
         }
+        # Redact output if a credential manager is attached to the tools instance
+        try:
+            cm = getattr(self.tools_instance, "credential_manager", None)
+            if cm is not None:
+                result['output'] = cm.redact(result['output'])
+        except Exception:
+            logger.exception("Error while redacting output.")
         return result

--- a/droidrun/tools/tools.py
+++ b/droidrun/tools/tools.py
@@ -46,6 +46,24 @@ class Tools(ABC):
                         exc_info=sys.exc_info(),
                     )
 
+            result = func(*args, **kwargs)
+
+            # Check if save_trajectories attribute exists and is set to "action"
+            if hasattr(self, 'save_trajectories') and self.save_trajectories == "action":
+                frame = sys._getframe(1)
+                caller_globals = frame.f_globals
+
+                step_screenshots = caller_globals.get('step_screenshots')
+                step_ui_states = caller_globals.get('step_ui_states')
+
+                if step_screenshots is not None:
+                    step_screenshots.append(self.take_screenshot()[1])
+                if step_ui_states is not None:
+                    step_ui_states.append(self.get_state())
+            return result
+
+        return wrapper
+
     # Helper (non-abstract) tool to resolve placeholders using CredentialManager
     def fill_credentials(self, **kwargs) -> Dict[str, Any]:
         """
@@ -64,24 +82,6 @@ class Tools(ABC):
         except Exception:
             # On any error, return the original kwargs
             return kwargs
-
-            result = func(*args, **kwargs)
-
-            # Check if save_trajectories attribute exists and is set to "action"
-            if hasattr(self, 'save_trajectories') and self.save_trajectories == "action":
-                frame = sys._getframe(1)
-                caller_globals = frame.f_globals
-
-                step_screenshots = caller_globals.get('step_screenshots')
-                step_ui_states = caller_globals.get('step_ui_states')
-
-                if step_screenshots is not None:
-                    step_screenshots.append(self.take_screenshot()[1])
-                if step_ui_states is not None:
-                    step_ui_states.append(self.get_state())
-            return result
-
-        return wrapper
 
     @abstractmethod
     def get_state(self) -> Dict[str, Any]:


### PR DESCRIPTION
Fixes #127 


- Wire CLI: --credentials-file/--credentials-profile, log filter redaction, telemetry redactor
- Resolve placeholders at tool-call time via Tools.ui_action
- Add fill_credentials helper tool and export in describe_tools
- Redact Python executor output
- Add docs/v3/guides/credentials.mdx


I have run the required security checks on this PR:
Bandit (bandit -r droidrun) → No new security issues detected (only existing warnings already present in the codebase).
Safety (safety scan) → No new dependency vulnerabilities introduced by this PR.
This PR does not introduce any additional security risks beyond the existing issues in the project.


