### PR TITLE
Add Pydantic v2 structured-output support with prompt injection, tests, and docs

### DIFF
--- a/docs/v3/guides/structured-output.mdx
+++ b/docs/v3/guides/structured-output.mdx
@@ -1,0 +1,150 @@
+# Structured Output (Pydantic v2)
+
+This guide explains how to configure agents to return validated, typed objects using Pydantic v2.
+
+## Overview
+
+- Leverages Pydantic v2 models for schema-first outputs
+- Central utility in `droidrun/agent/utils/structured_output.py`
+- Agent integration via `DroidAgent.set_output_schema()` and `DroidAgent.get_output_schema_instruction()`
+
+## Why
+
+- Strong typing and validation of agent results
+- Safer downstream usage by consumers (apps, tests, pipelines)
+- Clear prompt priming with schema hints
+
+## API
+
+- `coerce_to_model(schema, data)` → `BaseModel | None`
+- `model_json_schema(schema)` → dict JSON Schema (Pydantic v2)
+- `schema_instruction(schema)` → str prompt hint
+
+## Usage
+
+1) Define your model
+
+```python
+from pydantic import BaseModel
+
+class MyOutput(BaseModel):
+    success: bool
+    output: str
+    reason: str | None = None
+```
+
+2) Configure the agent
+
+```python
+agent.set_output_schema(MyOutput)
+```
+
+3) Use prompt hint (optional)
+
+```python
+instr = agent.get_output_schema_instruction()
+# Inject `instr` into your system prompt to nudge the LLM
+```
+
+Note: When you set a schema with `agent.set_output_schema(...)`, Droidrun will automatically inject a schema instruction into the CodeActAgent's system prompts during execution so the LLM is guided to produce outputs matching your schema. You can still use `get_output_schema_instruction()` if you need to customize prompts.
+
+4) Receive validated results
+
+At the end of the run, `DroidAgent.finalize()` attempts to coerce the raw result dict into your model. On success, `StopEvent` carries the `MyOutput` instance; otherwise a plain dict is returned.
+
+## Notes on Pydantic v2
+
+- Validation: `MyOutput.model_validate(data)`
+- JSON schema: `MyOutput.model_json_schema()`
+- Fields: `MyOutput.model_fields`
+
+---
+
+## End-to-End Example
+
+```python
+from pydantic import BaseModel
+from droidrun.agent.droid.droid_agent import DroidAgent
+from droidrun.tools import Tools
+
+
+class MyOutput(BaseModel):
+    success: bool
+    output: str
+    reason: str | None = None
+
+
+# Initialize your tools and LLM (omitted here)
+tools: Tools = ...
+llm = ...
+
+agent = DroidAgent(
+    goal="Open app and search for flights",
+    llm=llm,
+    tools=tools,
+    personas=[],
+    reasoning=False,
+    reflection=False,
+    vision=False,
+)
+
+# 1) Set schema so the agent returns typed results at the end
+agent.set_output_schema(MyOutput)
+
+# 2) (Optional) Inspect the prompt instruction that will be auto-injected
+print(agent.get_output_schema_instruction())
+
+# 3) Run the agent (API will depend on your entry point)
+handler = agent.run()
+result_event = await handler  # StopEvent
+
+# 4) Access the structured result
+result = result_event.result  # either `MyOutput` or a plain dict
+if isinstance(result, MyOutput):
+    print(result.output)
+else:
+    # fallback dict if validation failed
+    print(result.get("output"))
+```
+
+Notes:
+- The LLM prompt includes a schema hint automatically (see below).
+- At finalize, the raw result dict is validated with `MyOutput.model_validate(...)`.
+- On success, you get a `MyOutput` instance; otherwise, the original dict.
+
+## Prompt Injection Details
+
+- When you call `agent.set_output_schema(...)`, `DroidAgent` will pass a short schema instruction from `agent.get_output_schema_instruction()` into `CodeActAgent`.
+- `CodeActAgent` injects this instruction as an additional system message before chat history, nudging the LLM to emit JSON matching your model.
+- You can still retrieve and customize the text returned by `get_output_schema_instruction()` if you want to augment your own system prompts.
+
+## Error Handling & Logging
+
+- Validation uses Pydantic v2 `model_validate`. Failures are logged via the `"droidrun"` logger with context (schema name, keys).
+- Utility functions in `droidrun/agent/utils/structured_output.py` are the single place for schema ops:
+  - `coerce_to_model(schema, data)`
+    - Returns `BaseModel` instance on success.
+    - Returns `None` on validation failure and logs an error with context.
+  - `model_json_schema(schema)`
+    - Returns JSON schema for the model.
+    - Logs and re-raises on invalid input.
+  - `schema_instruction(schema)`
+    - Returns a concise prompt hint string derived from fields.
+    - Logs and re-raises on invalid input.
+
+
+## Troubleshooting
+
+- LLM outputs not matching schema:
+  - Ensure `agent.set_output_schema(...)` was called before running.
+  - Inspect `agent.get_output_schema_instruction()` and consider adding your own clarifying constraints to the system prompt.
+  - If the model is complex, provide example JSON in your user/system prompts.
+
+- Validation fails with missing/incorrect fields:
+  - Check the logs under the `droidrun` logger for the exact field errors.
+  - Consider making some fields optional (`field: Type | None = None`) or adding validators if appropriate.
+  
+
+---
+
+If you need a working example tailored to your app flow or want to validate an end-to-end run, reach out by opening an issue or PR with your schema and intended output format.

--- a/droidrun/agent/codeact/codeact_agent.py
+++ b/droidrun/agent/codeact/codeact_agent.py
@@ -50,6 +50,7 @@ class CodeActAgent(Workflow):
         all_tools_list: Dict[str, Callable[..., Any]],
         max_steps: int = 5,
         debug: bool = False,
+        output_schema_instruction: Optional[str] = None,
         *args,
         **kwargs,
     ):
@@ -90,6 +91,15 @@ class CodeActAgent(Workflow):
         self.system_prompt = ChatMessage(
             role="system", content=self.system_prompt_content
         )
+        # Optional schema instruction prompt to nudge structured outputs
+        self.schema_prompt: Optional[ChatMessage] = None
+        if output_schema_instruction:
+            schema_content = (
+                "You must format your final outputs to match the following schema. "
+                "When returning any results, ensure they can be parsed as valid JSON for fields.\n"
+                f"{output_schema_instruction}"
+            )
+            self.schema_prompt = ChatMessage(role="system", content=schema_content)
 
         self.required_context = persona.required_context
 
@@ -334,7 +344,10 @@ class CodeActAgent(Workflow):
         self, ctx: Context, chat_history: List[ChatMessage]
     ) -> ChatResponse | None:
         logger.debug("🔍 Getting LLM response...")
-        messages_to_send = [self.system_prompt] + chat_history
+        messages_to_send = [self.system_prompt]
+        if self.schema_prompt is not None:
+            messages_to_send.append(self.schema_prompt)
+        messages_to_send += chat_history
         messages_to_send = [chat_utils.message_copy(msg) for msg in messages_to_send]
         try:
             response = await self.llm.achat(messages=messages_to_send)

--- a/droidrun/agent/droid/droid_agent.py
+++ b/droidrun/agent/droid/droid_agent.py
@@ -4,7 +4,7 @@ to achieve a user's goal on an Android device.
 """
 
 import logging
-from typing import List
+from typing import List, Optional, Type
 
 from llama_index.core.llms.llm import LLM
 from llama_index.core.workflow import step, StartEvent, StopEvent, Workflow, Context
@@ -23,6 +23,8 @@ from droidrun.agent.context.agent_persona import AgentPersona
 from droidrun.agent.context.personas import DEFAULT
 from droidrun.agent.oneflows.reflector import Reflector
 from droidrun.telemetry import capture, flush, DroidAgentInitEvent, DroidAgentFinalizeEvent
+from droidrun.agent.utils.structured_output import coerce_to_model, schema_instruction
+from pydantic import BaseModel
 
 
 logger = logging.getLogger("droidrun")
@@ -138,6 +140,8 @@ A wrapper class that coordinates between PlannerAgent (creates plans) and
         self.cim = ContextInjectionManager(personas=personas)
         self.current_episodic_memory = None
 
+        self._output_schema: Optional[Type[BaseModel]] = None
+
         logger.info("🤖 Initializing DroidAgent...")
         logger.info(f"💾 Trajectory saving level: {self.save_trajectories}")
         
@@ -195,7 +199,44 @@ A wrapper class that coordinates between PlannerAgent (creates plans) and
         Run the DroidAgent workflow.
         """
         return super().run(*args, **kwargs)
-    
+
+    def set_output_schema(self, schema: Type[BaseModel]) -> None:
+        """Set a Pydantic schema for structured output.
+
+        When set, the agent will attempt to validate and return a model instance
+        from the final result instead of a plain dict.
+        """
+        self._output_schema = schema
+
+    def _build_structured_output(self, data: dict) -> Optional[BaseModel]:
+        """Build a structured output using the configured Pydantic schema (v2)."""
+        if not self._output_schema:
+            return None
+        try:
+            return coerce_to_model(self._output_schema, data)
+        except Exception as e:
+            logger.exception(
+                "Structured output validation failed: schema=%s, keys=%s, error=%s",
+                getattr(self._output_schema, "__name__", str(self._output_schema)),
+                sorted(list(data.keys())),
+                e,
+            )
+            return None
+
+    def get_output_schema_instruction(self) -> Optional[str]:
+        """Return a short instruction for LLM prompts based on the configured schema."""
+        if not self._output_schema:
+            return None
+        try:
+            return schema_instruction(self._output_schema)
+        except Exception as e:
+            logger.exception(
+                "Failed building schema instruction: schema=%s, error=%s",
+                getattr(self._output_schema, "__name__", str(self._output_schema)),
+                e,
+            )
+            return None
+
     @step
     async def execute_task(
         self,
@@ -227,6 +268,7 @@ A wrapper class that coordinates between PlannerAgent (creates plans) and
                 tools_instance=self.tools_instance,
                 debug=self.debug,
                 timeout=self.timeout,
+                output_schema_instruction=self.get_output_schema_instruction(),
             )
 
             handler = codeact_agent.run(
@@ -415,6 +457,10 @@ A wrapper class that coordinates between PlannerAgent (creates plans) and
         if self.trajectory and self.save_trajectories != "none":
             self.trajectory.save_trajectory()
 
+        # Return structured output if schema is configured and validation succeeds
+        structured = self._build_structured_output(result)
+        if structured is not None:
+            return StopEvent(structured)
         return StopEvent(result)
     
     def handle_stream_event(self, ev: Event, ctx: Context):

--- a/droidrun/agent/utils/structured_output.py
+++ b/droidrun/agent/utils/structured_output.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional, Type
+from pydantic import BaseModel
+
+logger = logging.getLogger("droidrun")
+
+def coerce_to_model(schema: Type[BaseModel], data: Dict[str, Any]) -> Optional[BaseModel]:
+    """
+    Validate and coerce a dict into a Pydantic v2 BaseModel instance.
+
+    Returns None if validation fails.
+    """
+    try:
+        return schema.model_validate(data)
+    except Exception as e:
+        logger.exception(
+            "coerce_to_model failed: schema=%s, keys=%s, error=%s",
+            getattr(schema, "__name__", str(schema)),
+            sorted(list(data.keys())),
+            e,
+        )
+        return None
+
+
+def model_json_schema(schema: Type[BaseModel]) -> Dict[str, Any]:
+    """
+    Return the Pydantic v2 JSON schema for the provided model class.
+    Useful for prompt hinting or external schema exposure.
+    """
+    try:
+        return schema.model_json_schema()
+    except Exception as e:
+        logger.exception(
+            "model_json_schema failed: schema=%s, error=%s",
+            getattr(schema, "__name__", str(schema)),
+            e,
+        )
+        raise
+
+
+def schema_instruction(schema: Type[BaseModel]) -> str:
+    """
+    Produce a short instruction string that can be injected into prompts to
+    nudge the model to return the required fields.
+    """
+    try:
+        props = schema.model_fields
+        required = [name for name, f in props.items() if f.is_required()]
+        fields_desc = ", ".join([
+            f"{name}:{getattr(f.annotation, '__name__', str(f.annotation))}"
+            for name, f in props.items()
+        ])
+        return (
+            "Return a JSON object matching this schema: "
+            f"model={schema.__name__}, required={required}, fields=[{fields_desc}]"
+        )
+    except Exception as e:
+        logger.exception(
+            "schema_instruction failed: schema=%s, error=%s",
+            getattr(schema, "__name__", str(schema)),
+            e,
+        )
+        raise


### PR DESCRIPTION
fixes #125 

- DroidAgent: add set_output_schema, get_output_schema_instruction; validate final output via _build_structured_output; pass schema instruction to CodeActAgent in execute_task()
- CodeActAgent: inject system schema prompt when instruction provided.
