### PR TITLE
Fix for issue #172: retry handling for Anthropic

### DIFF
--- a/droidrun/agent/codeact/codeact_agent.py
+++ b/droidrun/agent/codeact/codeact_agent.py
@@ -403,6 +403,20 @@ class CodeActAgent(Workflow):
                     time.sleep(40)
                 logger.debug("🔍 Retrying call to LLM...")
                 response = await self.llm.achat(messages=messages_to_send)
+            elif (
+                self.llm.class_name() == "Anthropic_LLM"
+                and "overloaded_error" in str(e)
+            ):
+                # Use exponential backoff for Anthropic errors
+                if not hasattr(self, '_anthropic_retry_count'):
+                    self._anthropic_retry_count = 0
+                self._anthropic_retry_count += 1
+                seconds = min(2 ** self._anthropic_retry_count, 60)  # Cap at 60 seconds
+                logger.error(f"Anthropic rate limit or overload error. Retrying in {seconds} seconds... (attempt {self._anthropic_retry_count})")
+                time.sleep(seconds)
+                logger.debug("🔍 Retrying call to LLM...")
+                response = await self.llm.achat(messages=messages_to_send)
+                self._anthropic_retry_count = 0  # Reset on success
             else:
                 logger.error(f"Could not get an answer from LLM: {repr(e)}")
                 raise e

--- a/droidrun/agent/codeact/codeact_agent.py
+++ b/droidrun/agent/codeact/codeact_agent.py
@@ -412,7 +412,7 @@ class CodeActAgent(Workflow):
                     self._anthropic_retry_count = 0
                 self._anthropic_retry_count += 1
                 seconds = min(2 ** self._anthropic_retry_count, 60)  # Cap at 60 seconds
-                logger.error(f"Anthropic rate limit or overload error. Retrying in {seconds} seconds... (attempt {self._anthropic_retry_count})")
+                logger.error(f"Anthropic overload error. Retrying in {seconds} seconds... (attempt {self._anthropic_retry_count})")
                 time.sleep(seconds)
                 logger.debug("🔍 Retrying call to LLM...")
                 response = await self.llm.achat(messages=messages_to_send)


### PR DESCRIPTION
This is a fix for #172 where if the Anthropic/Claude API is overloaded, Droidrun falls back to Google Gen AI even if it's not installed or configured. It uses exponential backoff.

[will add testing details momentarily...]