### PR TITLE
[DRO-389] docs - Examples in template section

### DIFF
--- a/docs/guides/overview.mdx
+++ b/docs/guides/overview.mdx
@@ -33,6 +33,18 @@ Welcome to the Droidrun Guides! This section provides step-by-step instructions 
 ---
 
 ### Templates
-TODO
+
+Explore real-world examples and starter projects in the [droidrun-examples repository](https://github.com/droidrun/droidrun-examples):
+
+- **[LinkedInJobsScraper](https://github.com/droidrun/droidrun-examples/tree/main/LinkedInJobsScraper)** - Agentic workflow that searches LinkedIn for roles, evaluates matches, and prepares tailored applications
+- **[LinkedInLeads](https://github.com/droidrun/droidrun-examples/tree/main/LinkedInLeads)** - End-to-end lead discovery and enrichment for LinkedIn companies and roles
+- **[TwitterPost](https://github.com/droidrun/droidrun-examples/tree/main/TwitterPost)** - Finds trending topics, drafts posts, and generates images to publish on X/Twitter
+- **[play2048](https://github.com/droidrun/droidrun-examples/tree/main/play2048)** - DroidAgent that plays the 2048 game on play2048.co
+
+Each example includes a self-contained workflow with entrypoint, configuration, and sample data. See the [README](https://github.com/droidrun/droidrun-examples) for setup instructions and contribution guidelines.
+https://github.com/droidrun/droidrun-examples
+
+
+---
 
 Need help? Join our [Discord community](https://discord.gg/ZZbKEZZkwK) for support and discussions.


### PR DESCRIPTION
Added one line descriptions and quick links to droidrun-examples repository in `guides/overview.mdx` under `Templates` header