### PR TITLE
Fix: "failed to install portal: Failed to download and install portal APK: 'name'"

### DIFF
--- a/droidrun/portal.py
+++ b/droidrun/portal.py
@@ -95,7 +95,7 @@ def download_portal_apk(debug: bool = False):
             asset["downloadUrl"]
         ).startswith(ASSET_NAME):
             asset_url = asset["downloadUrl"]
-            asset_version: str = asset_version: str = asset.get("name", os.path.basename(asset_url)).split(
+            asset_version: str = asset.get("name", os.path.basename(asset_url)).split(
                 "-"
             )[-1]
             asset_version = asset_version.removesuffix(".apk")


### PR DESCRIPTION
Handle the ungh.cc API response (with downloadUrl only) by extracting the filename directly from the URL using `os.path.basename()`