### PR TITLE
llm parameter resulting in the following exception

### DIFF
--- a/docs/v3/guides/gemini.mdx
+++ b/docs/v3/guides/gemini.mdx
@@ -51,23 +51,23 @@ async def main():
     # Set up the Gemini LLM
     llm = GoogleGenAI(
         api_key="YOUR_GEMINI_API_KEY",  # Replace with your Gemini API key
-        model="gemini-2.5-flash",  # or "gemini-2.5-pro" for enhanced reasoning
+        model="gemini-2.5-flash",       # or "gemini-2.5-pro" for enhanced reasoning
     )
 
     # Create the DroidAgent
     agent = DroidAgent(
         goal="Open Settings and check battery level",
-        llm=llm,
+        llms=llm,             # ✅ corrected: 'llms' instead of 'llm'
         tools=tools,
-        vision=True,         # Set to True for vision models, False for text-only
-        reasoning=False,      # Optional: enable planning/reasoning
+        # vision=True,        # Optional: enable if using multimodal models
+        # reasoning=False,    # Optional: enable planning/reasoning
     )
 
     # Run the agent
     result = await agent.run()
-    print(f"Success: {result['success']}")
-    if result.get('output'):
-        print(f"Output: {result['output']}")
+    print(f"Success: {getattr(result, 'success', None)}")
+    if getattr(result, 'reason', None):
+        print(f"Output: {result.reason}")
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
TypeError: Workflow.__init__() got an unexpected keyword argument 'llm'


The issue was caused by an API change in the droidrun framework the DroidAgent constructor now expects the parameter llms (plural) instead of llm.


🔧 Changes Made

Replaced llm= with llms= in the example code block.

Updated how the result object is accessed, changing result['success'] to attribute-style access (result.success, result.reason).

Adjusted comments to reflect the updated constructor signature.