### PR TITLE
fix: clearing test fields reliably and fast

### DIFF
--- a/droidrun/agent/executor/executor_agent.py
+++ b/droidrun/agent/executor/executor_agent.py
@@ -30,6 +30,7 @@ from droidrun.agent.utils.inference import acall_with_retries
 from droidrun.agent.utils.prompt_resolver import PromptResolver
 from droidrun.agent.utils.tools import (
     ATOMIC_ACTION_SIGNATURES,
+    clear_text,
     click,
     long_press,
     open_app,
@@ -365,6 +366,19 @@ class ExecutorAgent(Workflow):
 
                 result = await type(text, index, tools=self.tools_instance)
                 return True, "None", f"Typed '{text}' into element at index {index}"
+
+            elif action_type == "clear_text":
+                index = action_dict.get("index", -1)
+
+                if index == -1:
+                    return (
+                        False,
+                        "Missing 'index' parameter",
+                        "Failed: clear_text requires index",
+                    )
+
+                result = await clear_text(index, tools=self.tools_instance)
+                return True, "None", f"Cleared text at index {index}" 
 
             elif action_type == "system_button":
                 button = action_dict.get("button")

--- a/droidrun/agent/manager/manager_agent.py
+++ b/droidrun/agent/manager/manager_agent.py
@@ -479,6 +479,8 @@ class ManagerAgent(Workflow):
         # ====================================================================
         # Step 3: Detect text manipulation mode
         # ====================================================================
+        # Show text manipulation section when there's focused text with content
+        # (TEXT_TASK is now only for complex text editing, not simple clearing)
         focused_text_clean = focused_text.replace("'", "").strip()
         has_text_to_modify = focused_text_clean != ""
 

--- a/droidrun/agent/utils/tools.py
+++ b/droidrun/agent/utils/tools.py
@@ -154,6 +154,22 @@ async def type(text: str, index: int, *, tools: "Tools" = None, **kwargs) -> str
     return await tools.input_text(text, index)
 
 
+async def clear_text(index: int, *, tools: "Tools" = None, **kwargs) -> str:
+    """
+    Clear all text from the element at the given index using robust key events.
+
+    This is much faster and more reliable than using the text manipulator.
+    Use this action when you need to delete/remove/clear text from an input field.
+    Args:
+        index: The index of the element to clear
+        tools: The Tools instance (injected automatically)
+    Returns:
+        Result message from the clear operation
+    """
+    if tools is None:
+        raise ValueError("tools parameter is required")
+    return await tools.clear_text(index)
+
 async def system_button(button: str, *, tools: "Tools" = None, **kwargs) -> str:
     """
     Press a system button (back, home, or enter).

--- a/droidrun/config/prompts/executor/system.jinja2
+++ b/droidrun/config/prompts/executor/system.jinja2
@@ -49,7 +49,8 @@ Action Related:
 Text Related Operations:
 - Activated input box: If an input box is activated, it may have a cursor inside it and the keyboard is visible. If there is no cursor on the screen but the keyboard is visible, it may be because the cursor is blinking. The color of the activated input box will be highlighted. If you are not sure whether the input box is activated, click it before typing.
 - To input some text: first click the input box that you want to input, make sure the correct input box is activated and the keyboard is visible, then use `type` action to enter the specified text.
-- To clear the text: long press the backspace button in the keyboard.
+- **To clear/delete text from a field: Use the clear_text action!** Example: {"action": "clear_text", "index": 9}. This is fast and reliable.
+- Do NOT use type action with empty string ("") to clear text - it will not work!
 - To copy some text: first long press the text you want to copy, then click the `copy` button in bar.
 - To paste text into a text box: first long press the text box, then click the `paste` button in bar.
 

--- a/droidrun/config/prompts/manager/system.jinja2
+++ b/droidrun/config/prompts/manager/system.jinja2
@@ -46,13 +46,16 @@ General:
 {% if text_manipulation_enabled %}
 
 <text_manipulation>
-1. Use **TEXT_TASK:** prefix in your plan when you need to modify text in the currently focused text input field
-2. TEXT_TASK is for editing, formatting, or transforming existing text content in text boxes using Python code
-3. Do not use TEXT_TASK for extracting text from messages, typing new text, or composing messages
-4. The focused text field contains editable text that you can modify
-5. Example plan item: 'TEXT_TASK: Add "Hello World" at the beginning of the text'
-6. Always use TEXT_TASK for modifying text, do not try to select the text to copy/cut/paste or adjust the text
-</text_manipulation>
+1. The Executor has a clear_text action that can quickly clear text fields - use it for simple deletions
+2. For simple clearing: "Clear the phone number field (index 9)" - Executor will use clear_text action
+3. Use TEXT_TASK: prefix ONLY for complex text editing (formatting, string manipulation, conditional logic)
+4. Do not use TEXT_TASK for extracting text from messages or composing brand new messages from scratch
+5. Example plan items:
+    - Simple: "Clear the phone number field (index 9)" → Executor uses clear_text
+    - Simple: "Type '555' into field 9" → Executor uses type
+    - Complex: "TEXT_TASK: Capitalize all words in the current text"
+    - Complex: "TEXT_TASK: Add @example.com domain to the username"
+6. Do not tell executor to use empty type commands - it won't work
 {% endif %}
 
 Memory Usage:

--- a/droidrun/tools/ios.py
+++ b/droidrun/tools/ios.py
@@ -425,6 +425,22 @@ class IOSTools(Tools):
         except Exception as e:
             return f"Error sending text input: {str(e)}"
 
+    def clear_text(self, index: int = -1) -> str:
+        """
+        Clear all text from a text field on iOS device.
+
+        Args:
+            index: Index of the element to clear (iOS doesn't use index-based tapping in the same way)
+
+        Returns:
+            Result message
+        """
+        # iOS doesn't have a direct clear method in the current implementation
+        # We can simulate clearing by selecting all and deleting
+        # For now, we'll use a workaround of typing empty string
+        logger.info("clear_text called for iOS - using input_text with empty string")
+        return self.input_text("")
+
     def back(self) -> str:
         raise NotImplementedError("Back is not yet implemented for iOS")
 

--- a/droidrun/tools/tools.py
+++ b/droidrun/tools/tools.py
@@ -100,6 +100,13 @@ class Tools(ABC):
         pass
 
     @abstractmethod
+    async def clear_text(self, index: int = -1) -> str:
+        """
+        Clear all text from a text field.
+        """
+        pass
+
+    @abstractmethod
     async def back(self) -> str:
         """
         Press the back button.


### PR DESCRIPTION
I noticed clearing text is very janky in droidrun. Often times it just enters a empty string to the text box and fails completely. 

I added this new function which in my testing works way better and faster than any current method. It tried to do 50 backspace keys instead of one by one, completely clearing text fields. This is very useful for when the agent enters the wrong text in login forms. 

Overall from a lot of testing this works much better in my opinion. This is the solution I'm using to get droidrun to work reliably, hopefully this helps others as well!