### PR TITLE
chore: bump version to 0.4.14

### DIFF
--- a/droidrun/__init__.py
+++ b/droidrun/__init__.py
@@ -2,7 +2,7 @@
 Droidrun - A framework for controlling Android devices through LLM agents.
 """
 
-__version__ = "0.4.13"
+__version__ = "0.4.14"
 
 # Import main classes for easier access
 from droidrun.agent.droid import DroidAgent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "droidrun"
-version = "0.4.13"
+version = "0.4.14"
 description = "A framework for controlling Android devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels.schmidt@droidrun.ai" }]
 dependencies = [


### PR DESCRIPTION
To release droidrun-mcp new version is needed. 

tag as v0.4.14 please 