### PR TITLE
fix: properly detect and report input_text failures in StealthAdbTools

### DIFF
--- a/droidrun/tools/stealth_adb.py
+++ b/droidrun/tools/stealth_adb.py
@@ -286,13 +286,20 @@ class StealthAdbTools(AdbTools):
             )
             results.append(result)
 
+            # Check if the word input failed
+            if "Error" in result or "failed" in result:
+                return f"Stealth typing failed at word {i + 1}/{len(words)}: {result}"
+
             # Add space after word (except for last word)
             if i < len(words) - 1:
-                await super().input_text(" ", index=-1, clear=False)
+                space_result = await super().input_text(" ", index=-1, clear=False)
+                # Check if space input failed
+                if "Error" in space_result or "failed" in space_result:
+                    return f"Stealth typing failed adding space after word {i + 1}: {space_result}"
                 # Random delay between words (100-300ms)
                 await asyncio.sleep(random.uniform(0.1, 0.3))
 
-        return f"Stealth typing completed: {len(words)} words typed"
+        return f"Stealth typing completed: {len(words)} words typed successfully"
 
     async def swipe(
         self,


### PR DESCRIPTION
The input_text method in StealthAdbTools was always returning success even when the actual text input failed. This PR adds proper error checking to detect failures and return descriptive error messages.

## Changes
- Check result after each word is typed
- Check result after each space is added
- Return early with error message on failure
- Only return success when all words are typed successfully

Fixes #235