### PR TITLE
Check the device before setting up the keyboard in adb.py

### DIFF
--- a/droidrun/tools/adb.py
+++ b/droidrun/tools/adb.py
@@ -106,7 +106,10 @@ class AdbTools(Tools):
 
         # Connect to device
         self.device = await adb.device(serial=self._serial)
-
+        # Check if device is online
+        state = await self.device.get_state()
+        if state != "device":
+            raise ConnectionError(f"Device is not online. State: {state}")
         # Initialize portal client
         self.portal = PortalClient(self.device, prefer_tcp=self._use_tcp)
         await self.portal.connect()


### PR DESCRIPTION
The `adb.py` file doesn’t check whether the device is connected and online, so it tries to set up the keyboard, which results in **"Error setting up keyboard"**. This can be misleading. I’ve added a simple check before the portal connection in adb.py:

```
 # Check if device is online
        state = await self.device.get_state()
        if state != "device":
            raise ConnectionError(f"Device is not online. State: {state}")
```
Related to issue #241 
P.s: _This is my first PR ever, so appologies in advance if I got anything wrong._