### PR TITLE
Pin langfuse to version 3.9.0 from uv.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ openrouter = [
     "llama-index-llms-openrouter>=0.4.2",
 ]
 langfuse = [
-    "langfuse>=2.0.0",
+    "langfuse==3.9.0",
     "openinference-instrumentation-llama-index>=3.0.0",
     "llama-index-instrumentation"
 ]


### PR DESCRIPTION
Pin langfuse dependency to version 3.9.0 to match the version specified in uv.lock.

**Changes:**
- Updated `pyproject.toml:79` from `langfuse>=2.0.0` to `langfuse==3.9.0`

Closes #252

---
Generated with [Claude Code](https://claude.ai/code)