### PR TITLE
feat: graceful device disconnect handling with DeviceDisconnectedError

### DIFF
--- a/droidrun/agent/codeact/tools_agent.py
+++ b/droidrun/agent/codeact/tools_agent.py
@@ -17,6 +17,7 @@ from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, 
 from opentelemetry import trace
 from pydantic import BaseModel
 
+from droidrun.agent.action_result import ActionResult
 from droidrun.agent.codeact.events import (
     FastAgentEndEvent,
     FastAgentInputEvent,
@@ -31,7 +32,6 @@ from droidrun.agent.codeact.xml_parser import (
     format_tool_results,
     parse_tool_calls,
 )
-from droidrun.agent.action_result import ActionResult
 from droidrun.agent.common.constants import LLM_HISTORY_LIMIT
 from droidrun.agent.common.events import RecordUIStateEvent, ScreenshotEvent
 from droidrun.agent.usage import get_usage_from_response
@@ -41,6 +41,7 @@ from droidrun.agent.utils.prompt_resolver import PromptResolver
 from droidrun.agent.utils.tracing_setup import record_langfuse_screenshot
 from droidrun.config_manager.config_manager import AgentConfig, TracingConfig
 from droidrun.config_manager.prompt_loader import PromptLoader
+from droidrun.tools.driver.base import DeviceDisconnectedError
 
 if TYPE_CHECKING:
     from droidrun.agent.action_context import ActionContext
@@ -235,6 +236,8 @@ class FastAgent(Workflow):
                     )
                     await ctx.store.set("screenshot", screenshot)
                     logger.debug("📸 Screenshot captured for FastAgent")
+            except DeviceDisconnectedError:
+                raise
             except Exception as e:
                 logger.warning(f"Failed to capture screenshot: {e}")
 
@@ -263,6 +266,8 @@ class FastAgent(Workflow):
                 {"text": f"\n{ui_state.formatted_text}\n"}
             )
 
+        except DeviceDisconnectedError:
+            raise
         except Exception as e:
             logger.warning(f"⚠️ Error retrieving state from the connected device: {e}")
             if self.debug:

--- a/droidrun/agent/droid/droid_agent.py
+++ b/droidrun/agent/droid/droid_agent.py
@@ -535,10 +535,7 @@ class DroidAgent(Workflow):
             self.executor_agent.action_ctx = self.action_ctx
 
         # ── 6. Fetch device date once ─────────────────────────────────
-        try:
-            self.shared_state.device_date = await driver.get_date()
-        except Exception as e:
-            logger.warning(f"Failed to get device date: {e}")
+        self.shared_state.device_date = await driver.get_date()
 
         # ── 7. External agent mode ────────────────────────────────────
         if self._using_external_agent:

--- a/droidrun/agent/droid/droid_agent.py
+++ b/droidrun/agent/droid/droid_agent.py
@@ -9,14 +9,16 @@ Architecture:
 
 import logging
 import traceback
-from typing import TYPE_CHECKING, Type, Awaitable, Union
+from typing import TYPE_CHECKING, Awaitable, Type, Union
 
-from pydantic import BaseModel
+from async_adbutils import adb
 from llama_index.core.llms.llm import LLM
 from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, step
-
+from opentelemetry import trace
+from pydantic import BaseModel
 from workflows.events import Event
 from workflows.handler import WorkflowHandler
+
 from droidrun.agent.action_context import ActionContext
 from droidrun.agent.codeact import CodeActAgent, FastAgent
 from droidrun.agent.codeact.events import CodeActOutputEvent, FastAgentOutputEvent
@@ -37,12 +39,14 @@ from droidrun.agent.droid.events import (
 )
 from droidrun.agent.droid.state import DroidAgentState
 from droidrun.agent.executor import ExecutorAgent
+from droidrun.agent.external import load_agent
 from droidrun.agent.manager import ManagerAgent, StatelessManagerAgent
+from droidrun.agent.oneflows.structured_output_agent import StructuredOutputAgent
 from droidrun.agent.oneflows.text_manipulator import run_text_manipulation_agent
 from droidrun.agent.scripter import ScripterAgent
-from droidrun.agent.oneflows.structured_output_agent import StructuredOutputAgent
 from droidrun.agent.tool_registry import ToolRegistry
 from droidrun.agent.trajectory import TrajectoryWriter
+from droidrun.agent.utils.actions import complete, open_app, remember
 from droidrun.agent.utils.llm_loader import (
     load_agent_llms,
     merge_llms_with_config,
@@ -52,8 +56,11 @@ from droidrun.agent.utils.signatures import (
     ATOMIC_ACTION_SIGNATURES,
     build_credential_tools,
 )
-from droidrun.agent.utils.actions import open_app, remember, complete
-from droidrun.agent.utils.tracing_setup import setup_tracing
+from droidrun.agent.utils.tracing_setup import (
+    apply_session_context,
+    record_langfuse_screenshot,
+    setup_tracing,
+)
 from droidrun.agent.utils.trajectory import Trajectory
 from droidrun.config_manager.config_manager import (
     AgentConfig,
@@ -66,24 +73,19 @@ from droidrun.config_manager.config_manager import (
     TracingConfig,
 )
 from droidrun.config_manager.safe_execution import SafeExecutionConfig
-from droidrun.credential_manager import FileCredentialManager, CredentialManager
-from droidrun.mcp.config import MCPConfig
-from droidrun.mcp.client import MCPClientManager
+from droidrun.credential_manager import CredentialManager, FileCredentialManager
+from droidrun.log_handlers import CLILogHandler, configure_logging
 from droidrun.mcp.adapter import mcp_to_droidrun_tools
+from droidrun.mcp.client import MCPClientManager
+from droidrun.mcp.config import MCPConfig
 from droidrun.telemetry import (
     DroidAgentFinalizeEvent,
     DroidAgentInitEvent,
     capture,
     flush,
 )
-from droidrun.agent.external import load_agent
-from droidrun.agent.utils.tracing_setup import (
-    apply_session_context,
-    record_langfuse_screenshot,
-)
-from async_adbutils import adb
-from droidrun.log_handlers import CLILogHandler, configure_logging
 from droidrun.tools.driver.android import AndroidDriver
+from droidrun.tools.driver.base import DeviceDisconnectedError
 from droidrun.tools.driver.ios import IOSDriver
 from droidrun.tools.driver.recording import RecordingDriver
 from droidrun.tools.driver.stealth import StealthDriver
@@ -91,7 +93,6 @@ from droidrun.tools.filters import ConciseFilter, DetailedFilter
 from droidrun.tools.formatters import IndexedFormatter
 from droidrun.tools.ui.ios_provider import IOSStateProvider
 from droidrun.tools.ui.provider import AndroidStateProvider
-from opentelemetry import trace
 
 if TYPE_CHECKING:
     from droidrun.tools.driver.base import DeviceDriver
@@ -533,7 +534,13 @@ class DroidAgent(Workflow):
             self.executor_agent.registry = self.registry
             self.executor_agent.action_ctx = self.action_ctx
 
-        # ── 6. External agent mode ────────────────────────────────────
+        # ── 6. Fetch device date once ─────────────────────────────────
+        try:
+            self.shared_state.device_date = await driver.get_date()
+        except Exception as e:
+            logger.warning(f"Failed to get device date: {e}")
+
+        # ── 7. External agent mode ────────────────────────────────────
         if self._using_external_agent:
             agent_name = self.config.agent.name
             agent_module = load_agent(agent_name)
@@ -644,6 +651,14 @@ class DroidAgent(Workflow):
                 instruction=ev.instruction,
             )
 
+        except DeviceDisconnectedError as e:
+            logger.error(f"Device disconnected: {e}")
+            return FastAgentResultEvent(
+                success=False,
+                reason=f"Device disconnected: {e}",
+                instruction=ev.instruction,
+            )
+
         except Exception as e:
             logger.error(f"Error during task execution: {e}")
             if self.config.logging.debug:
@@ -689,12 +704,16 @@ class DroidAgent(Workflow):
             f"🔄 Step {self.shared_state.step_number}/{self.config.agent.max_steps}"
         )
 
-        handler = self.manager_agent.run()
+        try:
+            handler = self.manager_agent.run()
 
-        async for nested_ev in handler.stream_events():
-            self.handle_stream_event(nested_ev, ctx)
+            async for nested_ev in handler.stream_events():
+                self.handle_stream_event(nested_ev, ctx)
 
-        result = await handler
+            result = await handler
+        except DeviceDisconnectedError as e:
+            logger.error(f"Device disconnected: {e}")
+            return FinalizeEvent(success=False, reason=f"Device disconnected: {e}")
 
         event = ManagerPlanEvent(
             plan=result["plan"],

--- a/droidrun/agent/droid/state.py
+++ b/droidrun/agent/droid/state.py
@@ -22,6 +22,7 @@ class DroidAgentState(BaseModel):
     # ========================================================================
     # Device State (current)
     # ========================================================================
+    device_date: str = ""  # Fetched once at startup
     formatted_device_state: str = ""  # Text description for prompts
     focused_text: str = ""  # Text in focused input field
     a11y_tree: List[Dict] = Field(default_factory=list)  # Raw accessibility tree

--- a/droidrun/tools/driver/__init__.py
+++ b/droidrun/tools/driver/__init__.py
@@ -1,13 +1,14 @@
 """Device driver abstractions for DroidRun."""
 
 from droidrun.tools.driver.android import AndroidDriver
-from droidrun.tools.driver.base import DeviceDriver
+from droidrun.tools.driver.base import DeviceDisconnectedError, DeviceDriver
 from droidrun.tools.driver.cloud import CloudDriver
 from droidrun.tools.driver.ios import IOSDriver
 from droidrun.tools.driver.recording import RecordingDriver
 from droidrun.tools.driver.stealth import StealthDriver
 
 __all__ = [
+    "DeviceDisconnectedError",
     "DeviceDriver",
     "AndroidDriver",
     "CloudDriver",

--- a/droidrun/tools/driver/base.py
+++ b/droidrun/tools/driver/base.py
@@ -9,6 +9,12 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 
+class DeviceDisconnectedError(Exception):
+    """Raised when the device is no longer reachable."""
+
+    pass
+
+
 class DeviceDriver:
     """Base class for all device drivers.
 

--- a/droidrun/tools/driver/cloud.py
+++ b/droidrun/tools/driver/cloud.py
@@ -187,7 +187,10 @@ class CloudDriver(DeviceDriver):
                 self.device_id, **self._display_kw
             )
         )
-        return await response.read()
+        try:
+            return await response.read()
+        except (ConflictError, APIConnectionError, APITimeoutError) as e:
+            raise DeviceDisconnectedError(str(e)) from e
 
     async def get_ui_tree(self) -> Dict[str, Any]:
         response = await self._call(

--- a/droidrun/tools/driver/cloud.py
+++ b/droidrun/tools/driver/cloud.py
@@ -187,10 +187,7 @@ class CloudDriver(DeviceDriver):
                 self.device_id, **self._display_kw
             )
         )
-        try:
-            return await response.read()
-        except (ConflictError, APIConnectionError, APITimeoutError) as e:
-            raise DeviceDisconnectedError(str(e)) from e
+        return await self._call(response.read())
 
     async def get_ui_tree(self) -> Dict[str, Any]:
         response = await self._call(

--- a/droidrun/tools/driver/cloud.py
+++ b/droidrun/tools/driver/cloud.py
@@ -7,13 +7,16 @@ for cloud-hosted devices via the MobileRun API.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Awaitable, Dict, List, Optional, TypeVar
 
 from mobilerun import AsyncMobilerun
+from mobilerun._exceptions import APIConnectionError, APITimeoutError, ConflictError
 
-from droidrun.tools.driver.base import DeviceDriver
+from droidrun.tools.driver.base import DeviceDisconnectedError, DeviceDriver
 
 logger = logging.getLogger("droidrun")
+
+T = TypeVar("T")
 
 
 class CloudDriver(DeviceDriver):
@@ -52,6 +55,7 @@ class CloudDriver(DeviceDriver):
                 api_key="x",
                 base_url=base_url,
                 timeout=10.0,
+                max_retries=4,
                 default_headers={"X-User-ID": user_id},
             )
         else:
@@ -59,12 +63,20 @@ class CloudDriver(DeviceDriver):
                 api_key=api_key,
                 base_url=base_url,
                 timeout=10.0,
+                max_retries=4,
             )
 
     @property
     def _display_kw(self) -> dict:
         """Common keyword arg for display routing."""
         return {"x_device_display_id": self.display_id}
+
+    async def _call(self, coro: Awaitable[T]) -> T:
+        """Await an SDK coroutine, translating disconnect errors."""
+        try:
+            return await coro
+        except (ConflictError, APIConnectionError, APITimeoutError) as e:
+            raise DeviceDisconnectedError(str(e)) from e
 
     # -- lifecycle -----------------------------------------------------------
 
@@ -77,8 +89,10 @@ class CloudDriver(DeviceDriver):
     # -- input actions -------------------------------------------------------
 
     async def tap(self, x: int, y: int) -> None:
-        await self._client.devices.actions.tap(
-            self.device_id, x=x, y=y, **self._display_kw
+        await self._call(
+            self._client.devices.actions.tap(
+                self.device_id, x=x, y=y, **self._display_kw
+            )
         )
 
     async def swipe(
@@ -89,25 +103,25 @@ class CloudDriver(DeviceDriver):
         y2: int,
         duration_ms: float = 1000,
     ) -> None:
-        await self._client.devices.actions.swipe(
-            self.device_id,
-            start_x=x1,
-            start_y=y1,
-            end_x=x2,
-            end_y=y2,
-            duration=duration_ms,
-            **self._display_kw,
+        await self._call(
+            self._client.devices.actions.swipe(
+                self.device_id,
+                start_x=x1,
+                start_y=y1,
+                end_x=x2,
+                end_y=y2,
+                duration=duration_ms,
+                **self._display_kw,
+            )
         )
 
     async def input_text(self, text: str, clear: bool = False) -> bool:
-        try:
-            await self._client.devices.keyboard.write(
+        await self._call(
+            self._client.devices.keyboard.write(
                 self.device_id, text=text, clear=clear, **self._display_kw
             )
-            return True
-        except Exception as e:
-            logger.error(f"Failed to input text: {e}")
-            return False
+        )
+        return True
 
     async def press_key(self, keycode: int) -> None:
         # Map Android keycodes to MobileRun global actions where needed
@@ -116,8 +130,10 @@ class CloudDriver(DeviceDriver):
         elif keycode == 3:  # KEYCODE_HOME
             await self.global_action(self._GLOBAL_HOME)
         else:
-            await self._client.devices.keyboard.key(
-                self.device_id, key=keycode, **self._display_kw
+            await self._call(
+                self._client.devices.keyboard.key(
+                    self.device_id, key=keycode, **self._display_kw
+                )
             )
 
     async def drag(
@@ -133,67 +149,56 @@ class CloudDriver(DeviceDriver):
     # -- app management ------------------------------------------------------
 
     async def start_app(self, package: str, activity: Optional[str] = None) -> str:
-        try:
-            await self._client.devices.apps.start(
+        await self._call(
+            self._client.devices.apps.start(
                 package,
                 device_id=self.device_id,
                 activity=activity or None,
                 **self._display_kw,
             )
-            return f"App started: {package}"
-        except Exception as e:
-            return f"Failed to start app {package}: {e}"
+        )
+        return f"App started: {package}"
 
     async def get_apps(self, include_system: bool = True) -> List[Dict[str, Any]]:
-        try:
-            apps = await self._client.devices.apps.list(
+        apps = await self._call(
+            self._client.devices.apps.list(
                 device_id=self.device_id,
                 include_system_apps=include_system,
                 **self._display_kw,
             )
-            return [app.model_dump() for app in apps]
-        except Exception as e:
-            logger.error(f"Failed to get apps: {e}")
-            return []
+        )
+        return [app.model_dump() for app in apps]
 
     async def list_packages(self, include_system: bool = False) -> List[str]:
-        try:
-            packages = await self._client.devices.packages.list(
+        packages = await self._call(
+            self._client.devices.packages.list(
                 device_id=self.device_id,
                 include_system_packages=include_system,
                 **self._display_kw,
             )
-            return packages
-        except Exception as e:
-            logger.error(f"Failed to list packages: {e}")
-            return []
+        )
+        return packages
 
     # -- state / observation -------------------------------------------------
 
     async def screenshot(self, hide_overlay: bool = True) -> bytes:
-        try:
-            response = await self._client.devices.state.with_raw_response.screenshot(
+        response = await self._call(
+            self._client.devices.state.with_raw_response.screenshot(
                 self.device_id, **self._display_kw
             )
-            return await response.read()
-        except Exception as e:
-            logger.error(f"Failed to capture screenshot: {e}")
-            return b""
+        )
+        return await response.read()
 
     async def get_ui_tree(self) -> Dict[str, Any]:
-        response = await self._client.devices.state.ui(
-            self.device_id, **self._display_kw
+        response = await self._call(
+            self._client.devices.state.ui(self.device_id, **self._display_kw)
         )
         return response.model_dump()
 
     async def get_date(self) -> str:
-        try:
-            return await self._client.devices.state.time(
-                self.device_id, **self._display_kw
-            )
-        except Exception as e:
-            logger.error(f"Failed to get date: {e}")
-            return "unknown"
+        return await self._call(
+            self._client.devices.state.time(self.device_id, **self._display_kw)
+        )
 
     # -- cloud-specific ------------------------------------------------------
 
@@ -203,11 +208,9 @@ class CloudDriver(DeviceDriver):
         Common actions: 1=Back, 2=Home, 3=Recents, 4=Notifications,
         5=QuickSettings, 6=PowerDialog, 9=TakeScreenshot.
         """
-        try:
-            await self._client.devices.actions.global_(
+        await self._call(
+            self._client.devices.actions.global_(
                 self.device_id, action=action, **self._display_kw
             )
-            return True
-        except Exception as e:
-            logger.error(f"Failed to execute global action {action}: {e}")
-            return False
+        )
+        return True

--- a/droidrun/tools/ui/provider.py
+++ b/droidrun/tools/ui/provider.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
+from droidrun.tools.driver.base import DeviceDisconnectedError
 from droidrun.tools.ui.state import UIState
 from droidrun.tools.ui.stealth_state import StealthUIState
 
@@ -105,9 +106,11 @@ class AndroidStateProvider(StateProvider):
                     use_normalized=self.use_normalized,
                 )
 
+            except DeviceDisconnectedError:
+                raise
             except Exception as e:
-                last_error = str(e)
-                logger.warning(f"get_state attempt {attempt + 1} failed: {last_error}")
+                last_error = e
+                logger.warning(f"get_state attempt {attempt + 1} failed: {e}")
                 if attempt < max_retries - 1:
                     await asyncio.sleep(0.5)
                 else:


### PR DESCRIPTION
Add DeviceDisconnectedError to the driver layer so cloud device disconnects (409/timeout/connection errors) propagate cleanly instead of crashing the workflow or being silently swallowed.