### PR TITLE
Bugfix for adding checked stated to Formatted a11y tree

### DIFF
--- a/droidrun/tools/formatters/indexed_formatter.py
+++ b/droidrun/tools/formatters/indexed_formatter.py
@@ -68,7 +68,7 @@ class IndexedFormatter(TreeFormatter):
     def _format_ui_elements_text(self, a11y_tree: List[Dict[str, Any]]) -> str:
         """Format UI elements text."""
         coord_note = " (normalized [0-1000])" if self.use_normalized else ""
-        schema = "'index. className: resourceId, text - bounds(x1,y1,x2,y2)'"
+        schema = "'index. className: resourceId; checkedState, text - bounds(x1,y1,x2,y2)'"
         if a11y_tree:
             formatted_ui = IndexedFormatter._format_ui_elements(a11y_tree)
             ui_elements_text = (
@@ -98,6 +98,7 @@ class IndexedFormatter(TreeFormatter):
             resource_id = element.get("resourceId", "")
             text = element.get("text", "")
             bounds = element.get("bounds", "")
+            checkedState = element.get("checkedState", "")
             children = element.get("children", [])
 
             line_parts = []
@@ -114,6 +115,9 @@ class IndexedFormatter(TreeFormatter):
 
             if details:
                 line_parts.append(", ".join(details))
+
+            if checkedState:
+                line_parts.append(f'; {checkedState}')
 
             if bounds:
                 line_parts.append(f"- ({bounds})")
@@ -165,10 +169,15 @@ class IndexedFormatter(TreeFormatter):
         class_name = node.get("className", "")
         short_class = class_name.split(".")[-1] if class_name else ""
 
+        checked_state = ""
+        if node.get("isCheckable"):
+            checked_state = "isChecked=True" if node.get("isChecked") else "isChecked=False"
+
         return {
             "index": index,
             "resourceId": node.get("resourceId", ""),
             "className": short_class,
+            "checkedState" : checked_state,
             "text": text,
             "bounds": bounds_str,
             "children": [],


### PR DESCRIPTION
Currently the formatted tree removed all information about the checked/enabled state of switches/buttons/toggles. This causes droidrun (without vision) to incorrectly toggle switches as it cannot know if they are already checked.

This PR adds an isChecked=True/False field for checkable nodes.