### PR TITLE
fix: prevent executor agent from getting stuck in action loop

### DIFF
--- a/droidrun/agent/droid/droid_agent.py
+++ b/droidrun/agent/droid/droid_agent.py
@@ -7,6 +7,7 @@ Architecture:
 - When reasoning=True: Uses Manager (planning) + Executor (action) workflows
 """
 
+import json
 import logging
 from typing import TYPE_CHECKING, Type, Awaitable, Union
 
@@ -762,9 +763,23 @@ class DroidAgent(Workflow):
         """
         Process Executor result and continue.
 
-        Checks for error escalation and loops back to Manager.
+        Checks for error escalation, repeated action loops, and loops back to Manager.
         Note: Max steps check is now done in run_manager pre-flight.
         """
+        # Check for repeated action loop (same action N times in a row)
+        repeat_thresh = 3
+        if len(self.shared_state.action_pool) >= repeat_thresh:
+            recent_actions = self.shared_state.action_pool[-repeat_thresh:]
+            try:
+                normalized = [json.dumps(a, sort_keys=True) for a in recent_actions]
+                if len(set(normalized)) == 1:
+                    logger.warning(
+                        f"⚠️ Executor stuck: same action repeated {repeat_thresh} times in a row: {normalized[0]}"
+                    )
+                    self.shared_state.error_flag_plan = True
+            except (TypeError, ValueError):
+                pass  # Non-serializable actions, skip detection
+
         # Check error escalation and reset flag when errors are resolved
         err_thresh = self.shared_state.err_to_manager_thresh
 

--- a/droidrun/config/prompts/executor/system.jinja2
+++ b/droidrun/config/prompts/executor/system.jinja2
@@ -93,8 +93,10 @@ No actions have been taken yet.
 Whatever the current subgoal says to do, do that EXACTLY. Do not substitute with what you think is better. Do not optimize. Do not consider screen state. Parse the subgoal text literally and execute the matching atomic action.
 
 IMPORTANT:
-1. Do NOT repeat previously failed actions multiple times. Try changing to another action.
+1. Do NOT repeat previously failed actions multiple times. If an action failed, try a DIFFERENT action or approach.
 2. Must do the current subgoal.
+3. If you have tried the same action 2+ times and it keeps failing, try a completely different approach. If truly stuck with no viable action, use `{"action": "wait", "duration": 1.0}` as a fallback and explain why in the Description (e.g., "No actionable element found for subgoal").
+4. ALWAYS output a valid action. There is no "skip" or "do nothing" option — use `wait` with duration 1.0 if uncertain.
 
 Provide your output in the following format, which contains three parts:
 


### PR DESCRIPTION
Fixes #251

## Problem
The executor agent gets stuck in an infinite loop when no action is possible, especially with lighter LLMs (e.g., gemini-2.5-flash-lite). The executor has no fallback behavior when it cannot determine a viable action.

## Changes

### 1. Executor system prompt improvements (`system.jinja2`)
- Added explicit rules for stuck/uncertain scenarios: use `wait` with duration 1.0 as a fallback action
- Reinforced that every response MUST include a valid action (no skip/do-nothing)
- Strengthened guidance to try different approaches after repeated failures

### 2. Repeated-action loop detection (`droid_agent.py`)
- Added detection in `handle_executor_result`: when the same action is repeated 3+ times consecutively, sets `error_flag_plan = True` to force the manager to re-plan
- Uses JSON-normalized comparison of action dictionaries for reliable detection
- Gracefully handles non-serializable actions

## How it works
1. **Prompt-level prevention**: The LLM is now explicitly told to use `wait` as a no-op fallback, preventing invalid/empty responses that cause parsing loops
2. **Code-level detection**: Even if the LLM repeats the same action, the loop detector catches it after 3 repetitions and forces a re-plan via the manager

Based on the approach suggested in the issue by the reporter.