### PR TITLE
fix: resolve circular import conflict with external mcp package

### DIFF
--- a/droidrun/mcp/client.py
+++ b/droidrun/mcp/client.py
@@ -7,9 +7,6 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
-
 if TYPE_CHECKING:
     from droidrun.mcp.config import MCPConfig, MCPServerConfig
 
@@ -33,7 +30,7 @@ class MCPClientManager:
         self.config = config
         self._tools: dict[str, MCPToolInfo] = {}
         self._server_tools: dict[str, list[str]] = {}
-        self._sessions: dict[str, ClientSession] = {}
+        self._sessions: dict = {}  # type: ignore
         self._exit_stacks: dict[str, AsyncExitStack] = {}
 
     async def discover_tools(self) -> dict[str, MCPToolInfo]:
@@ -59,6 +56,10 @@ class MCPClientManager:
         self, server_name: str, config: "MCPServerConfig"
     ) -> None:
         """Connect temporarily to fetch tool schemas."""
+        # Lazy import to avoid circular dependency with droidrun.mcp package
+        from mcp.client.session import ClientSession
+        from mcp.client.stdio import StdioServerParameters, stdio_client
+
         server_params = StdioServerParameters(
             command=config.command,
             args=config.args,
@@ -116,6 +117,10 @@ class MCPClientManager:
 
     async def _connect_server(self, server_name: str) -> None:
         """Establish persistent connection to a server."""
+        # Lazy import to avoid circular dependency with droidrun.mcp package
+        from mcp.client.session import ClientSession
+        from mcp.client.stdio import StdioServerParameters, stdio_client
+
         config = self.config.servers[server_name]
         server_params = StdioServerParameters(
             command=config.command,


### PR DESCRIPTION
```txt
.venv ❯ uv run droidrun/__main__.py --help
Traceback (most recent call last):
  File "/Users/hanxi/toy/droidrun/droidrun/__main__.py", line 5, in <module>
    from droidrun.cli.main import cli
  File "/Users/hanxi/toy/droidrun/droidrun/__init__.py", line 21, in <module>
    from droidrun.agent import ResultEvent
  File "/Users/hanxi/toy/droidrun/droidrun/agent/__init__.py", line 1, in <module>
    from droidrun.agent.droid.events import ResultEvent
  File "/Users/hanxi/toy/droidrun/droidrun/agent/droid/__init__.py", line 7, in <module>
    from droidrun.agent.droid.droid_agent import DroidAgent
  File "/Users/hanxi/toy/droidrun/droidrun/agent/droid/droid_agent.py", line 24, in <module>
    from droidrun.agent.codeact import CodeActAgent, FastAgent
  File "/Users/hanxi/toy/droidrun/droidrun/agent/codeact/__init__.py", line 1, in <module>
    from droidrun.agent.codeact.codeact_agent import CodeActAgent
  File "/Users/hanxi/toy/droidrun/droidrun/agent/codeact/codeact_agent.py", line 23, in <module>
    from droidrun.agent.utils.chat_utils import (
    ...<2 lines>...
    )
  File "/Users/hanxi/toy/droidrun/droidrun/agent/utils/__init__.py", line 21, in <module>
    from .executer import ExecuterState, SimpleCodeExecutor
  File "/Users/hanxi/toy/droidrun/droidrun/agent/utils/executer.py", line 13, in <module>
    from droidrun.config_manager.safe_execution import (
    ...<2 lines>...
    )
  File "/Users/hanxi/toy/droidrun/droidrun/config_manager/__init__.py", line 1, in <module>
    from droidrun.config_manager.config_manager import (
    ...<14 lines>...
    )
  File "/Users/hanxi/toy/droidrun/droidrun/config_manager/config_manager.py", line 10, in <module>
    from droidrun.mcp.config import MCPConfig, MCPServerConfig
  File "/Users/hanxi/toy/droidrun/droidrun/mcp/__init__.py", line 4, in <module>
    from droidrun.mcp.client import MCPClientManager, MCPToolInfo
  File "/Users/hanxi/toy/droidrun/droidrun/mcp/client.py", line 10, in <module>
    from mcp import ClientSession, StdioServerParameters
  File "/Users/hanxi/toy/droidrun/droidrun/mcp/__init__.py", line 4, in <module>
    from droidrun.mcp.client import MCPClientManager, MCPToolInfo
ImportError: cannot import name 'MCPClientManager' from partially initialized module 'droidrun.mcp.client' (most likely due to a circular import) (droidrun/droidrun/mcp/client.py)
```