### PR TITLE
refactor(ios): unify iOS driver/provider with state_full endpoint

### DIFF
--- a/docs/guides/device-setup.mdx
+++ b/docs/guides/device-setup.mdx
@@ -327,38 +327,135 @@ iOS support is currently **experimental**. Functionality is limited compared to 
 
 ## Prerequisites
 
-- **macOS** with Xcode installed
-- **iOS device** with Developer mode enabled
-- **iOS Portal app** (separate from Android Portal)
+- **macOS** with **Xcode 15+** installed (iOS Portal must be built from source)
+- **Apple Developer account** (free or paid — needed for code signing)
+- **iOS device** (iPhone or iPad) with **Developer Mode** enabled
+- **USB cable** to connect the device to your Mac (for initial build and deployment)
+- **`iproxy`** from `libimobiledevice` (for USB port forwarding)
+
+### Install `iproxy`
+
+```bash
+brew install libimobiledevice
+```
+
+### Enable Developer Mode on your device
+
+1. Go to **Settings** > **Privacy & Security** > **Developer Mode**
+2. Toggle **Developer Mode** on
+3. Restart the device when prompted
+4. After restart, confirm the prompt to enable Developer Mode
 
 ---
 
-## Setup
+## Build and Install the iOS Portal
+
+The iOS Portal is an Xcode project that runs as a UI test — it launches an HTTP server on port **6643** that Droidrun communicates with.
 
 <Steps>
-  <Step title="Install iOS Portal">
-    The iOS Portal app must be manually installed on your device.
+  <Step title="Clone the iOS Portal repository">
+    ```bash
+    git clone https://github.com/droidrun/ios-portal.git
+    cd ios-portal
+    ```
+  </Step>
+
+  <Step title="Open the project in Xcode">
+    ```bash
+    open droidrun-ios-portal.xcodeproj
+    ```
+  </Step>
+
+  <Step title="Configure code signing">
+    You must change the signing team and bundle identifier to your own:
+
+    1. In Xcode, select the **droidrun-ios-portal** project in the navigator
+    2. For **each target** (`droidrun-ios-portal`, `droidrun-ios-portalUITests`):
+       - Select the target
+       - Go to the **Signing & Capabilities** tab
+       - Set **Team** to your Apple Developer account
+       - Change the **Bundle Identifier** to something unique, e.g.:
+         - `com.yourname.droidrun-ios-portal`
+         - `com.yourname.droidrun-ios-portalUITests`
+    3. Let Xcode automatically manage provisioning profiles
+
+    <Warning>
+    You **must** change the bundle identifiers — the default ones are tied to the Droidrun team's signing certificate and will fail to build on your machine.
+    </Warning>
+  </Step>
+
+  <Step title="Select your device and run the test">
+    1. Connect your iOS device via USB
+    2. In Xcode, select your device from the device dropdown (top bar)
+    3. If this is your first time deploying to the device, trust the developer certificate:
+       - On the device: **Settings** > **General** > **VPN & Device Management** > tap your developer profile > **Trust**
+    4. Run the portal using either method:
+
+    **Option A — Xcode UI:**
+    - Go to **Product** > **Test** (or press `Cmd + U`)
+    - This builds the app, installs it, and starts the "Droidrun Server" UI test
+
+    **Option B — Command line:**
+    ```bash
+    # Find your device ID
+    xcrun xctrace list devices
+
+    # Run the portal server
+    ./device.sh YOUR_DEVICE_UDID
+    ```
+
+    The HTTP server starts on port **6643** and keeps running until the test session ends.
+  </Step>
+
+  <Step title="Set up port forwarding with iproxy">
+    The portal server runs on the device's localhost. To reach it from your Mac, forward the port over USB:
+
+    ```bash
+    iproxy 6643 6643
+    ```
+
+    Keep this running in a separate terminal. The portal is now accessible at `http://127.0.0.1:6643`.
 
     <Note>
-    Installation instructions and download link coming soon.
+    `iproxy` forwards over USB, so you don't need WiFi connectivity between your Mac and the device.
     </Note>
   </Step>
 
-  <Step title="Get Device IP">
-    Find your iOS device's IP address in Settings > WiFi > (i) icon
-  </Step>
+  <Step title="Verify the connection">
+    ```bash
+    # Quick health check
+    curl http://127.0.0.1:6643/device/date
 
-  <Step title="Test Connection">
-    Run a simple task to verify connectivity:
+    # Should return something like: {"date": "2026-03-31 10:30:00"}
+    ```
+
+    Then test with Droidrun:
     ```bash
     droidrun run "take a screenshot" --ios
     ```
 
-    <Note>
-    The `droidrun ping` command is Android-only (uses ADB). For iOS, run a simple task with `--ios` to verify the connection.
-    </Note>
+    Droidrun will auto-discover the portal on port 6643. If it's on a different port, pass the URL explicitly:
+    ```bash
+    droidrun run "take a screenshot" --ios --device http://127.0.0.1:6643
+    ```
   </Step>
 </Steps>
+
+---
+
+## Running on the Simulator
+
+You can also run the portal on the iOS Simulator (no code signing or physical device needed):
+
+```bash
+# List available simulators
+xcrun simctl list devices available
+
+# Run the portal on a simulator by name
+./simulator.sh "iPhone 16 Pro"
+```
+
+The simulator portal is accessible at `http://127.0.0.1:6643` directly (no `iproxy` needed).
 
 ---
 
@@ -368,26 +465,41 @@ iOS Portal uses a different architecture than Android:
 
 | Feature | Android | iOS |
 |---------|---------|-----|
-| Communication | ADB + TCP/Content Provider | HTTP server only |
-| Setup Tool | `droidrun setup` | Manual installation |
-| Accessibility | Android Accessibility API | iOS Accessibility API |
-| Text Input | Custom keyboard IME | Direct text input |
+| Communication | ADB + TCP/Content Provider | HTTP server (port 6643) |
+| Portal type | APK (auto-installed) | Xcode UI test (built from source) |
+| Setup tool | `droidrun setup` | Xcode build + `iproxy` |
+| Accessibility | Android Accessibility API | iOS XCUITest framework |
+| Text Input | Custom keyboard IME | Direct XCUITest text input |
+| Connection | ADB over USB/TCP | USB via `iproxy` or WiFi |
+
+The iOS Portal leverages XCUITest to extract accessibility trees, perform gestures, and capture screenshots — all exposed through a REST API.
 
 ---
 
 ## Usage
+
+### CLI
+
+```bash
+# Auto-discovers portal on port 6643
+droidrun run "your command" --ios
+
+# Explicit portal URL
+droidrun run "your command" --ios --device http://127.0.0.1:6643
+```
 
 ### Python API
 
 ```python
 from droidrun import DroidAgent, DroidConfig, DeviceConfig
 
-# Configure for iOS
 config = DroidConfig(
-    device=DeviceConfig(platform="ios")
+    device=DeviceConfig(
+        platform="ios",
+        serial="http://127.0.0.1:6643",  # optional, auto-discovered if omitted
+    )
 )
 
-# Create agent
 agent = DroidAgent(
     goal="Open Settings and check WiFi",
     config=config
@@ -396,33 +508,62 @@ agent = DroidAgent(
 result = await agent.run()
 ```
 
-### CLI
-
-```bash
-# Use --ios flag
-droidrun run "your command" --ios
-
-# Or set platform in config.yaml:
-# device:
-#   platform: ios
-```
-
 ---
 
-## Limitations
-
-Current iOS support has these limitations:
+## Supported Features
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| `get_date()` | ❌ | Not available on iOS |
-| `press_button("back")` | ❌ | No iOS equivalent, raises ValueError |
-| `drag()` | ❌ | Not supported, auto-disabled |
-| `get_apps()` | ⚠️ | Use `list_packages()` instead |
-| `input_text()` | ⚠️ | No `index` or `clear` parameters |
-| `tap()`, `swipe()` | ✅ | Fully supported |
-| `get_state()` | ✅ | Returns accessibility tree |
-| `take_screenshot()` | ✅ | Fully supported |
+| `tap()` | ✅ | |
+| `swipe()` | ✅ | |
+| `input_text()` | ✅ | |
+| `screenshot()` | ✅ | |
+| `get_state()` | ✅ | Accessibility tree extraction |
+| `start_app()` | ✅ | By bundle identifier |
+| `get_date()` | ✅ | |
+| `press_button()` | ✅ | `home` only |
+| `drag()` | ❌ | |
+| `install_app()` | ❌ | |
+
+---
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Build fails with signing error">
+    **Symptoms:** Xcode shows "Signing for target requires a development team"
+
+    **Solutions:**
+    1. Make sure you changed the **Team** and **Bundle Identifier** for both targets
+    2. If using a free Apple Developer account, you may need to re-trust the certificate on the device every 7 days (**Settings** > **General** > **VPN & Device Management**)
+  </Accordion>
+
+  <Accordion title="Portal not reachable">
+    **Symptoms:** `curl http://127.0.0.1:6643/device/date` times out or connection refused
+
+    **Solutions:**
+    1. Verify `iproxy 6643 6643` is running
+    2. Check the Xcode test is still running (the portal stops when the test ends)
+    3. Re-run the test with `Cmd + U` in Xcode or `./device.sh UDID`
+  </Accordion>
+
+  <Accordion title="Auto-discovery fails">
+    **Symptoms:** `droidrun run ... --ios` says "Could not find iOS portal"
+
+    **Solutions:**
+    1. Auto-discovery scans ports 6643-6652. Make sure `iproxy` is forwarding to one of these.
+    2. Pass the URL explicitly: `--device http://127.0.0.1:6643`
+  </Accordion>
+
+  <Accordion title="Test session keeps stopping">
+    **Symptoms:** The portal server stops after a few minutes
+
+    **Solutions:**
+    1. Keep Xcode open and the test running — closing Xcode ends the test session
+    2. Disable auto-lock on the device (**Settings** > **Display & Brightness** > **Auto-Lock** > **Never**)
+    3. Keep the device plugged in to prevent sleep
+  </Accordion>
+</AccordionGroup>
 
   </Tab>
 </Tabs>

--- a/docs/sdk/ios-tools.mdx
+++ b/docs/sdk/ios-tools.mdx
@@ -14,13 +14,10 @@ class IOSDriver(DeviceDriver)
 
 iOS device driver communicating via HTTP REST to the iOS Portal app.
 
-**Status**: iOS support is in beta with limited functionality compared to AndroidDriver.
-
-**Key Limitations**:
-- `get_date()` - Not available (returns empty string)
-- `drag()` - Not supported (not in `supported` set)
-- `press_button()` - Only `home` is supported; `back` and `enter` raise `ValueError`
-- `input_text()` - `clear` parameter is ignored
+**Unsupported methods**:
+- `drag()` — not in `supported` set
+- `install_app()` — not in `supported` set
+- `press_button()` — `home` only
 
 <a id="droidrun.tools.driver.ios.IOSDriver.__init__"></a>
 
@@ -37,7 +34,7 @@ Initialize the IOSDriver instance.
 
 **Arguments**:
 
-- `url` _str_ - iOS Portal app URL (e.g., "http://192.168.1.100:8080")
+- `url` _str_ - iOS Portal URL (e.g., "http://127.0.0.1:6643")
 - `bundle_identifiers` _List[str] | None_ - Optional list of custom app bundle identifiers
 
 **Usage:**
@@ -45,12 +42,12 @@ Initialize the IOSDriver instance.
 ```python
 from droidrun.tools.driver import IOSDriver
 
-# Connect to iOS device
-driver = IOSDriver(url="http://192.168.1.100:8080")
+# Connect via iproxy
+driver = IOSDriver(url="http://127.0.0.1:6643")
 
 # With specific bundle identifiers
 driver = IOSDriver(
-    url="http://192.168.1.100:8080",
+    url="http://127.0.0.1:6643",
     bundle_identifiers=["com.example.app1", "com.example.app2"]
 )
 ```
@@ -61,7 +58,7 @@ driver = IOSDriver(
 IOSDriver.supported = {
     "tap", "swipe", "input_text", "press_button",
     "start_app", "screenshot", "get_ui_tree",
-    "list_packages", "get_apps",
+    "list_packages", "get_apps", "get_date",
 }
 
 IOSDriver.supported_buttons = {"home"}
@@ -69,10 +66,11 @@ IOSDriver.supported_buttons = {"home"}
 
 **Setup Requirements:**
 
-1. Install Droidrun iOS Portal app on device
-2. Launch Portal app (starts HTTP server)
-3. Connect device and computer to same network
-4. Use displayed URL to initialize IOSDriver
+1. Build and run the iOS Portal via Xcode (runs as a UI test)
+2. Forward port with `iproxy 6643 6643`
+3. Use `http://127.0.0.1:6643` as the URL
+
+See [Device Setup — iOS](/guides/device-setup) for full instructions.
 
 ---
 
@@ -86,7 +84,7 @@ IOSDriver.supported_buttons = {"home"}
 async def connect() -> None
 ```
 
-Create an HTTP client connection to the iOS Portal app.
+Create an HTTP client and verify connectivity by calling `/device/date`.
 
 <a id="droidrun.tools.driver.ios.IOSDriver.ensure_connected"></a>
 
@@ -110,7 +108,7 @@ Connect if not already connected. Safe to call multiple times.
 async def tap(x: int, y: int) -> None
 ```
 
-Tap at absolute pixel coordinates.
+Tap at coordinates.
 
 **Arguments**:
 
@@ -122,9 +120,6 @@ Tap at absolute pixel coordinates.
 ```python
 await driver.tap(200, 400)
 ```
-
-**Notes:**
-- Stores tap coordinates internally for `input_text()` targeting
 
 <a id="droidrun.tools.driver.ios.IOSDriver.swipe"></a>
 
@@ -140,7 +135,7 @@ async def swipe(
 ) -> None
 ```
 
-Perform directional swipe gesture (up, down, left, right).
+Swipe from one point to another.
 
 **Arguments**:
 
@@ -148,7 +143,7 @@ Perform directional swipe gesture (up, down, left, right).
 - `y1` _int_ - Starting Y coordinate
 - `x2` _int_ - Ending X coordinate
 - `y2` _int_ - Ending Y coordinate
-- `duration_ms` _float_ - Duration in milliseconds (ignored on iOS)
+- `duration_ms` _float_ - Duration in milliseconds
 
 **Usage:**
 
@@ -159,11 +154,6 @@ await driver.swipe(200, 800, 200, 200)
 # Swipe left
 await driver.swipe(600, 400, 100, 400)
 ```
-
-**Notes:**
-- iOS uses directional swipes, not precise coordinates
-- Direction calculated from coordinate delta (largest axis wins)
-- `duration_ms` parameter is ignored by iOS API
 
 <a id="droidrun.tools.driver.ios.IOSDriver.input_text"></a>
 
@@ -178,7 +168,7 @@ Input text into the currently focused element.
 **Arguments**:
 
 - `text` _str_ - Text to input (supports Unicode)
-- `clear` _bool_ - Not supported on iOS (ignored)
+- `clear` _bool_ - Clear existing text before input
 
 **Returns**:
 
@@ -192,12 +182,10 @@ await driver.tap(200, 400)
 
 # Input text
 success = await driver.input_text("Hello World")
-```
 
-**Notes:**
-- Must tap text field before calling this method
-- Uses last tapped coordinates for targeting
-- `clear` parameter is ignored on iOS
+# Clear field and type new text
+success = await driver.input_text("new text", clear=True)
+```
 
 <a id="droidrun.tools.driver.ios.IOSDriver.press_button"></a>
 
@@ -211,7 +199,7 @@ Press a named system button.
 
 **Supported buttons:** `home`
 
-Raises `ValueError` if the button name is not in `supported_buttons` (e.g. `back`, `enter`).
+Raises `ValueError` for unsupported button names.
 
 **Arguments**:
 
@@ -250,7 +238,6 @@ Launch an app by bundle identifier.
 - Messages: `com.apple.MobileSMS`
 - Safari: `com.apple.mobilesafari`
 - Settings: `com.apple.Preferences`
-- Mail: `com.apple.mobilemail`
 - Calendar: `com.apple.mobilecal`
 - Photos: `com.apple.mobileslideshow`
 - Maps: `com.apple.Maps`
@@ -293,7 +280,9 @@ List known bundle identifiers.
 async def get_apps(include_system: bool = True) -> List[Dict[str, str]]
 ```
 
-Return known apps as list of dicts. Since iOS has no app listing endpoint, this returns bundle identifiers as both 'package' and 'label'.
+Return known apps as list of dicts with `package` (bundle identifier) and `label` (human-readable name).
+
+System apps are mapped to friendly names (e.g., `com.apple.mobilesafari` → `Safari`). Third-party bundle identifiers are humanized from the last segment.
 
 **Arguments**:
 
@@ -301,7 +290,7 @@ Return known apps as list of dicts. Since iOS has no app listing endpoint, this 
 
 **Returns**:
 
-- `List[Dict[str, str]]` - List of dicts with 'package' and 'label' keys (both set to bundle identifier)
+- `List[Dict[str, str]]` - List of dicts with 'package' and 'label' keys
 
 ---
 
@@ -341,13 +330,14 @@ with open("screenshot.png", "wb") as f:
 async def get_ui_tree() -> Dict[str, Any]
 ```
 
-Return raw iOS accessibility data and phone state.
+Return unified state from the iOS portal.
 
 **Returns**:
 
 Dictionary with:
-- `a11y_raw` - The raw accessibility tree text from the portal
+- `a11y_tree` - The accessibility tree elements
 - `phone_state` - Dict with `currentApp` and `keyboardVisible`
+- `device_context` - Additional device context
 
 **Usage:**
 
@@ -364,7 +354,11 @@ print(tree["phone_state"]["currentApp"])
 async def get_date() -> str
 ```
 
-Not available on iOS. Returns an empty string.
+Get the current date and time from the device.
+
+**Returns**:
+
+- `str` - Date string, or empty string on failure
 
 ---
 
@@ -373,10 +367,10 @@ Not available on iOS. Returns an empty string.
 The following DeviceDriver methods are **not in `supported`** and will raise `NotImplementedError`:
 
 #### drag()
-Not supported on iOS. Not declared in `supported` set.
+Not supported on iOS.
 
 #### install\_app()
-Not supported on iOS. Not declared in `supported` set.
+Not supported on iOS.
 
 ---
 
@@ -386,26 +380,8 @@ Not supported on iOS. Not declared in `supported` set.
 driver.url                    # iOS Portal URL
 driver.bundle_identifiers     # Custom bundle IDs
 driver.supported              # Set of supported method names
+driver.supported_buttons      # Set of supported button names
 ```
-
----
-
-## iOS vs Android Differences
-
-| Feature | IOSDriver | AndroidDriver |
-|---------|-----------|---------------|
-| press_button | home only | back, home, enter |
-| Swipe | Direction-based | Coordinate-based |
-| Drag | Not supported | Declared (not yet implemented) |
-| App IDs | Bundle identifiers | Package names |
-| Connection | HTTP (Portal app) | ADB over USB/TCP |
-| get_date() | Returns empty | Via ADB shell |
-| input_text() clear | Ignored | Supported |
-
-**Setup differences:**
-
-**Android**: USB or `adb connect` + Portal APK
-**iOS**: Portal app + same network + HTTP connection
 
 ---
 
@@ -417,7 +393,7 @@ from droidrun.tools.driver import IOSDriver
 
 async def main():
     # Initialize and connect
-    driver = IOSDriver(url="http://192.168.1.100:8080")
+    driver = IOSDriver(url="http://127.0.0.1:6643")
     await driver.connect()
 
     # Launch Messages
@@ -448,5 +424,6 @@ asyncio.run(main())
 
 ## See Also
 
-- [AndroidDriver](/sdk/adb-tools) - Android device driver with full functionality
+- [AndroidDriver](/sdk/adb-tools) - Android device driver
 - [DeviceDriver Base Class](/sdk/base-tools) - Base class and architecture reference
+- [Device Setup — iOS](/guides/device-setup) - Full setup instructions

--- a/droidrun/agent/droid/droid_agent.py
+++ b/droidrun/agent/droid/droid_agent.py
@@ -77,7 +77,7 @@ from droidrun.telemetry import (
 )
 from droidrun.tools.driver.android import AndroidDriver
 from droidrun.tools.driver.base import DeviceDisconnectedError
-from droidrun.tools.driver.ios import IOSDriver
+from droidrun.tools.driver.ios import IOSDriver, discover_ios_portal
 from droidrun.tools.driver.recording import RecordingDriver
 from droidrun.tools.driver.stealth import StealthDriver
 from droidrun.tools.filters import ConciseFilter, DetailedFilter
@@ -392,8 +392,7 @@ class DroidAgent(Workflow):
         elif is_ios:
             ios_url = self.resolved_device_config.serial
             if not ios_url:
-                raise ValueError("iOS device URL required in config.device.serial")
-            # TODO: bundle_identifiers not configurable yet
+                ios_url = await discover_ios_portal()
             driver = IOSDriver(url=ios_url)
             await driver.connect()
         else:
@@ -451,6 +450,7 @@ class DroidAgent(Workflow):
         registry, standard_tool_names = await build_tool_registry(
             supported_buttons=driver.supported_buttons,
             credential_manager=self.credential_manager,
+            platform="ios" if is_ios else "android",
         )
 
         # User custom tools

--- a/droidrun/agent/droid/droid_agent.py
+++ b/droidrun/agent/droid/droid_agent.py
@@ -40,18 +40,13 @@ from droidrun.agent.executor import ExecutorAgent
 from droidrun.agent.external import load_agent
 from droidrun.agent.manager import ManagerAgent, StatelessManagerAgent
 from droidrun.agent.oneflows.structured_output_agent import StructuredOutputAgent
-from droidrun.agent.tool_registry import ToolRegistry
 from droidrun.agent.trajectory import TrajectoryWriter
-from droidrun.agent.utils.actions import complete, open_app, remember
 from droidrun.agent.utils.llm_loader import (
     load_agent_llms,
     merge_llms_with_config,
 )
 from droidrun.agent.utils.prompt_resolver import PromptResolver
-from droidrun.agent.utils.signatures import (
-    ATOMIC_ACTION_SIGNATURES,
-    build_credential_tools,
-)
+from droidrun.agent.utils.signatures import build_tool_registry
 from droidrun.agent.utils.tracing_setup import (
     apply_session_context,
     record_langfuse_screenshot,
@@ -310,46 +305,9 @@ class DroidAgent(Workflow):
             self.manager_agent = None
             self.executor_agent = None
 
-        atomic_tools = list(ATOMIC_ACTION_SIGNATURES.keys())
-
-        capture(
-            DroidAgentInitEvent(
-                goal=self.shared_state.instruction,
-                llms={
-                    "manager": (
-                        self.manager_llm.class_name() if self.manager_llm else "None"
-                    ),
-                    "executor": (
-                        self.executor_llm.class_name() if self.executor_llm else "None"
-                    ),
-                    "fast_agent": (
-                        self.fast_agent_llm.class_name()
-                        if self.fast_agent_llm
-                        else "None"
-                    ),
-                    "app_opener": (
-                        self.app_opener_llm.class_name()
-                        if self.app_opener_llm
-                        else "None"
-                    ),
-                },
-                tools=",".join(atomic_tools + ["remember", "complete"]),
-                max_steps=self.config.agent.max_steps,
-                timeout=timeout,
-                vision={
-                    "manager": self.config.agent.manager.vision,
-                    "executor": self.config.agent.executor.vision,
-                    "fast_agent": self.config.agent.fast_agent.vision,
-                },
-                reasoning=self.config.agent.reasoning,
-                enable_tracing=self.config.tracing.enabled,
-                debug=self.config.logging.debug,
-                save_trajectories=self.config.logging.save_trajectory,
-                runtype=self.runtype,
-                custom_prompts=prompts,
-            ),
-            self.user_id,
-        )
+        # Telemetry init event is fired in start_handler after registry is built.
+        self._init_prompts = prompts  # stash for telemetry
+        self._init_timeout = timeout
 
         logger.debug("✅ DroidAgent initialized successfully.")
 
@@ -468,6 +426,7 @@ class DroidAgent(Workflow):
                 driver = RecordingDriver(driver)
 
         self.driver = driver
+        self.shared_state.platform = driver.platform
 
         # ── 2. Create state provider ──────────────────────────────────
         if self._injected_state_provider is not None:
@@ -489,52 +448,16 @@ class DroidAgent(Workflow):
             )
 
         # ── 3. Build tool registry ────────────────────────────────────
-        registry = ToolRegistry()
-
-        # 3a. Atomic tools (click, long_press, type, system_button, swipe, etc.)
-        registry.register_from_dict(ATOMIC_ACTION_SIGNATURES)
-
-        # 3b. open_app (always registered)
-        registry.register(
-            "open_app",
-            fn=open_app,
-            params={"text": {"type": "string", "required": True}},
-            description='Open an app by name or description. Usage: {"action": "open_app", "text": "Gmail"}',
-            deps={"start_app", "get_apps"},
+        registry, standard_tool_names = await build_tool_registry(
+            supported_buttons=driver.supported_buttons,
+            credential_manager=self.credential_manager,
         )
 
-        # 3c. remember + complete (always registered, from DroidAgentState methods)
-        registry.register(
-            "remember",
-            fn=remember,
-            params={"information": {"type": "string", "required": True}},
-            description="Remember information for later use",
-        )
-        registry.register(
-            "complete",
-            fn=complete,
-            params={
-                "success": {"type": "boolean", "required": True},
-                "message": {"type": "string", "required": True},
-            },
-            description=(
-                "Mark task as complete. "
-                "success=true if task succeeded, false if failed. "
-                "message contains the result, answer, or explanation."
-            ),
-        )
-
-        # 3d. type_secret (conditional)
-        if self.credential_manager:
-            credential_tools = await build_credential_tools(self.credential_manager)
-            if credential_tools:
-                registry.register_from_dict(credential_tools)
-
-        # 3e. User custom tools
+        # User custom tools
         if self.user_custom_tools:
             registry.register_from_dict(self.user_custom_tools)
 
-        # 3f. MCP tools
+        # MCP tools
         if self.config.mcp and self.config.mcp.enabled:
             self.mcp_manager = MCPClientManager(self.config.mcp)
             await self.mcp_manager.discover_tools()
@@ -542,11 +465,11 @@ class DroidAgent(Workflow):
             if mcp_tools:
                 registry.register_from_dict(mcp_tools)
 
-        # 3g. Disable unsupported tools based on driver + state provider capabilities
+        # Capability-based filtering (deps vs driver+provider supported)
         capabilities = driver.supported | self.state_provider.supported
         registry.disable_unsupported(capabilities)
 
-        # 3h. Disable tools from config
+        # Config-level filtering
         disabled_tools = (
             self.config.tools.disabled_tools
             if self.config.tools and self.config.tools.disabled_tools
@@ -556,6 +479,7 @@ class DroidAgent(Workflow):
             registry.disable(disabled_tools)
 
         self.registry = registry
+        self.standard_tool_names = standard_tool_names
 
         # ── 4. Create ActionContext ────────────────────────────────────
         self.action_ctx = ActionContext(
@@ -574,11 +498,52 @@ class DroidAgent(Workflow):
             self.manager_agent.state_provider = self.state_provider
             self.manager_agent.registry = self.registry
             self.manager_agent.save_trajectory = self.config.logging.save_trajectory
+            self.manager_agent.standard_tool_names = self.standard_tool_names
             self.executor_agent.registry = self.registry
             self.executor_agent.action_ctx = self.action_ctx
 
         # ── 6. Fetch device date once ─────────────────────────────────
         self.shared_state.device_date = await driver.get_date()
+
+        # ── 7. Telemetry init event ───────────────────────────────────
+        capture(
+            DroidAgentInitEvent(
+                goal=self.shared_state.instruction,
+                llms={
+                    "manager": (
+                        self.manager_llm.class_name() if self.manager_llm else "None"
+                    ),
+                    "executor": (
+                        self.executor_llm.class_name() if self.executor_llm else "None"
+                    ),
+                    "fast_agent": (
+                        self.fast_agent_llm.class_name()
+                        if self.fast_agent_llm
+                        else "None"
+                    ),
+                    "app_opener": (
+                        self.app_opener_llm.class_name()
+                        if self.app_opener_llm
+                        else "None"
+                    ),
+                },
+                tools=",".join(sorted(standard_tool_names)),
+                max_steps=self.config.agent.max_steps,
+                timeout=self._init_timeout,
+                vision={
+                    "manager": self.config.agent.manager.vision,
+                    "executor": self.config.agent.executor.vision,
+                    "fast_agent": self.config.agent.fast_agent.vision,
+                },
+                reasoning=self.config.agent.reasoning,
+                enable_tracing=self.config.tracing.enabled,
+                debug=self.config.logging.debug,
+                save_trajectories=self.config.logging.save_trajectory,
+                runtype=self.runtype,
+                custom_prompts=self._init_prompts,
+            ),
+            self.user_id,
+        )
 
         if self.config.logging.save_trajectory != "none":
             self.trajectory_writer.write(self.trajectory, stage="init")

--- a/droidrun/agent/droid/state.py
+++ b/droidrun/agent/droid/state.py
@@ -26,6 +26,7 @@ class DroidAgentState(BaseModel):
     step_number: int = 0
     runtype: str = "developer"
     user_id: str | None = None
+    platform: str = "Android"
 
     # ========================================================================
     # Device State (current)

--- a/droidrun/agent/droid/state.py
+++ b/droidrun/agent/droid/state.py
@@ -166,20 +166,28 @@ class DroidAgentState(BaseModel):
     def update_current_app(self, package_name: str, activity_name: str):
         """
         Update package and activity together, capturing telemetry event only once.
+        Skips empty values — won't overwrite a known package/activity with "".
         """
-        package_changed = package_name != self.current_package_name
-        activity_changed = activity_name != self.current_activity_name
+        package_name = package_name.strip() if package_name else ""
+        activity_name = activity_name.strip() if activity_name else ""
+
+        # Don't overwrite known values with empty strings
+        effective_package = package_name or self.current_package_name
+        effective_activity = activity_name or self.current_activity_name
+
+        package_changed = effective_package != self.current_package_name
+        activity_changed = effective_activity != self.current_activity_name
 
         if not (package_changed or activity_changed):
             return
 
-        if package_changed and package_name:
-            self.visited_packages.add(package_name)
-        if activity_changed and activity_name:
-            self.visited_activities.add(activity_name)
+        if package_changed and effective_package:
+            self.visited_packages.add(effective_package)
+        if activity_changed and effective_activity:
+            self.visited_activities.add(effective_activity)
 
-        self.current_package_name = package_name
-        self.current_activity_name = activity_name
+        self.current_package_name = effective_package
+        self.current_activity_name = effective_activity
 
         capture(
             PackageVisitEvent(

--- a/droidrun/agent/droid/state.py
+++ b/droidrun/agent/droid/state.py
@@ -191,8 +191,8 @@ class DroidAgentState(BaseModel):
 
         capture(
             PackageVisitEvent(
-                package_name=package_name or "Unknown",
-                activity_name=activity_name or "Unknown",
+                package_name=effective_package or "Unknown",
+                activity_name=effective_activity or "Unknown",
                 step_number=self.step_number,
             ),
             user_id=self.user_id,

--- a/droidrun/agent/executor/executor_agent.py
+++ b/droidrun/agent/executor/executor_agent.py
@@ -95,9 +95,14 @@ class ExecutorAgent(Workflow):
                 )
             ]
 
-        # Get available secrets
+        # Get available secrets (only if type_secret is actually in the registry)
         available_secrets = []
-        if self.action_ctx and self.action_ctx.credential_manager:
+        if (
+            self.registry
+            and "type_secret" in self.registry.tools
+            and self.action_ctx
+            and self.action_ctx.credential_manager
+        ):
             available_secrets = await self.action_ctx.credential_manager.get_keys()
 
         # Build prompt variables
@@ -112,6 +117,7 @@ class ExecutorAgent(Workflow):
             "action_history": action_history,
             "available_secrets": available_secrets,
             "variables": self.shared_state.custom_variables,
+            "platform": self.shared_state.platform,
         }
 
         custom_prompt = self.prompt_resolver.get_prompt("executor_system")

--- a/droidrun/agent/fast_agent/fast_agent.py
+++ b/droidrun/agent/fast_agent/fast_agent.py
@@ -127,6 +127,7 @@ class FastAgent(Workflow):
             "output_schema": self._output_schema,
             "parallel_tools": self.config.parallel_tools,
             "vision": self.vision,
+            "platform": self.shared_state.platform,
         }
 
         custom_system_prompt = self.prompt_resolver.get_prompt("fast_agent_system")
@@ -172,8 +173,13 @@ class FastAgent(Workflow):
         """Initialize message history with goal."""
         logger.debug("Preparing chat for task execution...")
 
-        # Get available secrets
-        if self.action_ctx and self.action_ctx.credential_manager:
+        # Get available secrets (only if type_secret is actually in the registry)
+        if (
+            self.registry
+            and "type_secret" in self.registry.tools
+            and self.action_ctx
+            and self.action_ctx.credential_manager
+        ):
             self._available_secrets = (
                 await self.action_ctx.credential_manager.get_keys()
             )

--- a/droidrun/agent/fast_agent/fast_agent.py
+++ b/droidrun/agent/fast_agent/fast_agent.py
@@ -292,7 +292,10 @@ class FastAgent(Workflow):
         except DeviceDisconnectedError:
             raise
         except Exception as e:
-            logger.warning(f"⚠️ Error retrieving state from the connected device: {e}")
+            err_desc = str(e) or type(e).__name__
+            logger.warning(
+                f"⚠️ Error retrieving state from the connected device: {err_desc}"
+            )
             if self.debug:
                 logger.error("State retrieval error details:", exc_info=True)
 

--- a/droidrun/agent/manager/manager_agent.py
+++ b/droidrun/agent/manager/manager_agent.py
@@ -39,7 +39,6 @@ from droidrun.agent.usage import get_usage_from_response
 from droidrun.agent.utils.chat_utils import filter_empty_messages
 from droidrun.agent.utils.inference import acall_with_retries
 from droidrun.agent.utils.prompt_resolver import PromptResolver
-from droidrun.agent.utils.signatures import ATOMIC_ACTION_SIGNATURES
 from droidrun.agent.utils.tracing_setup import record_langfuse_screenshot
 from droidrun.app_cards.app_card_provider import AppCardProvider
 from droidrun.app_cards.providers import (
@@ -103,6 +102,7 @@ class ManagerAgent(Workflow):
         self.app_card_config = self.agent_config.app_cards
         self.prompt_resolver = prompt_resolver or PromptResolver()
         self.tracing_config = tracing_config
+        self.standard_tool_names: set[str] | None = None
 
         # Initialize app card provider
         self.app_card_provider: AppCardProvider = self._initialize_app_card_provider()
@@ -174,9 +174,14 @@ class ManagerAgent(Workflow):
                 )
             ]
 
-        # Get available secrets
+        # Get available secrets (only if type_secret is actually in the registry)
         available_secrets = []
-        if self.action_ctx and self.action_ctx.credential_manager:
+        if (
+            self.registry
+            and "type_secret" in self.registry.tools
+            and self.action_ctx
+            and self.action_ctx.credential_manager
+        ):
             available_secrets = await self.action_ctx.credential_manager.get_keys()
 
         # Output schema if provided
@@ -185,11 +190,10 @@ class ManagerAgent(Workflow):
             output_schema = self.output_model.model_json_schema()
 
         # Build custom tools descriptions from registry.
-        # Exclude standard atomic actions (Manager prompt already describes them)
-        # and flow-control tools (remember, complete) which Manager doesn't use.
+        # Exclude standard tools (already described in the prompt template).
         custom_tools_descriptions = ""
         if self.registry:
-            _standard = set(ATOMIC_ACTION_SIGNATURES.keys()) | {"remember", "complete"}
+            _standard = self.standard_tool_names or set()
             custom_tools_descriptions = self.registry.get_tool_descriptions_text(
                 exclude=_standard
             )
@@ -204,6 +208,7 @@ class ManagerAgent(Workflow):
             "available_secrets": available_secrets,
             "variables": self.shared_state.custom_variables,
             "output_schema": output_schema,
+            "platform": self.shared_state.platform,
         }
 
         custom_prompt = self.prompt_resolver.get_prompt("manager_system")

--- a/droidrun/agent/oneflows/app_starter_workflow.py
+++ b/droidrun/agent/oneflows/app_starter_workflow.py
@@ -21,19 +21,19 @@ class AppStarter(Workflow):
     to an installed app's package name, then opens it.
     """
 
-    def __init__(self, tools, llm, timeout: int = 60, stream: bool = False, **kwargs):
+    def __init__(self, driver, llm, timeout: int = 60, stream: bool = False, **kwargs):
         """
         Initialize the OpenAppWorkflow.
 
         Args:
-            tools: A Tools instance or DeviceDriver with get_apps()/start_app()
+            driver: DeviceDriver with get_apps()/start_app() methods
             llm: An LLM instance (e.g., OpenAI) to determine which app to open
             timeout: Workflow timeout in seconds (default: 60)
             stream: If True, stream LLM response to console in real-time
             **kwargs: Additional arguments passed to Workflow
         """
         super().__init__(timeout=timeout, **kwargs)
-        self.tools = tools
+        self.driver = driver
         self.llm = llm
         self.stream = stream
 
@@ -51,7 +51,7 @@ class AppStarter(Workflow):
         app_description = ev.app_description
 
         # Get list of installed apps
-        apps = await self.tools.get_apps(include_system=True)
+        apps = await self.driver.get_apps(include_system=True)
 
         # Format apps list for LLM
         apps_list = "\n".join(
@@ -105,7 +105,7 @@ Choose the most appropriate app based on the description. Return the package nam
             )
 
         logger.info(f"Starting app {package_name}")
-        result = await self.tools.start_app(package_name)
+        result = await self.driver.start_app(package_name)
 
         return StopEvent(result=result)
 
@@ -120,14 +120,14 @@ async def main():
     from droidrun.tools.driver.android import AndroidDriver
 
     # Initialize driver with device serial (None for default device)
-    tools = AndroidDriver(serial=None)
-    await tools.connect()
+    driver = AndroidDriver(serial=None)
+    await driver.connect()
 
     # Initialize LLM
     llm = OpenAI(model="gpt-4o-mini")
 
     # Create workflow instance
-    workflow = AppStarter(tools=tools, llm=llm, timeout=60, verbose=True)
+    workflow = AppStarter(driver=driver, llm=llm, timeout=60, verbose=True)
 
     # Run workflow to open an app
     result = await workflow.run(app_description="Settings")

--- a/droidrun/agent/utils/__init__.py
+++ b/droidrun/agent/utils/__init__.py
@@ -10,10 +10,7 @@ from .chat_utils import (
 )
 
 from .prompt_resolver import PromptResolver
-from .signatures import (
-    ATOMIC_ACTION_SIGNATURES,
-    build_credential_tools,
-)
+from .signatures import build_tool_registry
 
 from .trajectory import Trajectory
 
@@ -26,8 +23,7 @@ __all__ = [
     # Prompt utilities
     "PromptResolver",
     # Tool utilities
-    "ATOMIC_ACTION_SIGNATURES",
-    "build_credential_tools",
+    "build_tool_registry",
     # Trajectory
     "Trajectory",
 ]

--- a/droidrun/agent/utils/actions.py
+++ b/droidrun/agent/utils/actions.py
@@ -176,7 +176,7 @@ async def open_app(text: str, *, ctx: "ActionContext") -> ActionResult:
         )
 
     workflow = AppStarter(
-        tools=ctx.driver,
+        driver=ctx.driver,
         llm=ctx.app_opener_llm,
         timeout=60,
         stream=ctx.streaming,

--- a/droidrun/agent/utils/actions.py
+++ b/droidrun/agent/utils/actions.py
@@ -99,7 +99,7 @@ async def click_area(
         return ActionResult(success=False, summary=f"Failed to tap area center: {e}")
 
 
-async def type(
+async def type_text(
     text: str, index: int, clear: bool = False, *, ctx: "ActionContext"
 ) -> ActionResult:
     """Type text into the element with the given index."""
@@ -131,7 +131,7 @@ async def system_button(button: str, *, ctx: "ActionContext") -> ActionResult:
         return ActionResult(success=False, summary=str(e))
     except Exception as e:
         return ActionResult(
-            success=False, summary=f"Failed to press {button} button: {e}"
+            success=False, summary=f"Failed to press {button} button: {e.__class__.__name__}: {e}"
         )
 
 
@@ -189,6 +189,28 @@ async def open_app(text: str, *, ctx: "ActionContext") -> ActionResult:
     if isinstance(result, str) and "could not open app" in result.lower():
         return ActionResult(success=False, summary=result)
     return ActionResult(success=True, summary=str(result))
+
+
+async def open_bundle_id(bundle_id: str, *, ctx: "ActionContext") -> ActionResult:
+    """Open an app by exact package name or iOS bundle identifier."""
+    hint = (
+        "Maybe you got the wrong bundle ID. You could try using swipes and search "
+        "to find the app."
+    )
+    try:
+        result = await ctx.driver.start_app(bundle_id)
+        await asyncio.sleep(1)
+        if isinstance(result, str) and result.lower().startswith("failed"):
+            return ActionResult(
+                success=False,
+                summary=f"Failed to open app '{bundle_id}': {result}\n{hint}",
+            )
+        return ActionResult(success=True, summary=str(result))
+    except Exception as e:
+        return ActionResult(
+            success=False,
+            summary=f"Failed to open app '{bundle_id}': {e.__class__.__name__}: {e}\n{hint}",
+        )
 
 
 async def wait(duration: float = 1.0, *, ctx: "ActionContext") -> ActionResult:

--- a/droidrun/agent/utils/actions.py
+++ b/droidrun/agent/utils/actions.py
@@ -131,7 +131,8 @@ async def system_button(button: str, *, ctx: "ActionContext") -> ActionResult:
         return ActionResult(success=False, summary=str(e))
     except Exception as e:
         return ActionResult(
-            success=False, summary=f"Failed to press {button} button: {e.__class__.__name__}: {e}"
+            success=False,
+            summary=f"Failed to press {button} button: {e.__class__.__name__}: {e}",
         )
 
 

--- a/droidrun/agent/utils/signatures.py
+++ b/droidrun/agent/utils/signatures.py
@@ -11,10 +11,11 @@ from droidrun.agent.utils.actions import (
     long_press,
     long_press_at,
     open_app,
+    open_bundle_id,
     remember,
     swipe,
     system_button,
-    type,
+    type_text,
     type_secret,
     wait,
 )
@@ -25,6 +26,7 @@ logger = logging.getLogger("droidrun")
 async def build_tool_registry(
     supported_buttons: set[str] | None = None,
     credential_manager=None,
+    platform: str = "android",
 ) -> tuple[ToolRegistry, set[str]]:
     """Build a ToolRegistry with all standard droidrun tools.
 
@@ -32,6 +34,8 @@ async def build_tool_registry(
         supported_buttons: Buttons available for system_button description.
             Defaults to ``{"back", "home", "enter"}`` if *None*.
         credential_manager: If provided and has keys, ``type_secret`` is registered.
+        platform: ``"android"`` or ``"ios"``. Controls which ``open_app``
+            implementation is registered.
 
     Returns:
         ``(registry, standard_tool_names)`` where *standard_tool_names* is the
@@ -112,7 +116,7 @@ async def build_tool_registry(
 
     registry.register(
         "type",
-        fn=type,
+        fn=type_text,
         params={
             "text": {"type": "string", "required": True},
             "index": {"type": "number", "required": True},
@@ -175,16 +179,28 @@ async def build_tool_registry(
 
     # -- App / state / flow control ------------------------------------------
 
-    registry.register(
-        "open_app",
-        fn=open_app,
-        params={"text": {"type": "string", "required": True}},
-        description=(
-            "Open an app by name or description. "
-            'Usage: {"action": "open_app", "text": "Gmail"}'
-        ),
-        deps={"start_app", "get_apps"},
-    )
+    if platform.lower() == "ios":
+        registry.register(
+            "open_app",
+            fn=open_bundle_id,
+            params={"bundle_id": {"type": "string", "required": True}},
+            description=(
+                "Open an app by its exact bundle identifier. "
+                'Usage: {"action": "open_app", "bundle_id": "com.apple.Preferences"}'
+            ),
+            deps={"start_app"},
+        )
+    else:
+        registry.register(
+            "open_app",
+            fn=open_app,
+            params={"text": {"type": "string", "required": True}},
+            description=(
+                "Open an app by name or description. "
+                'Usage: {"action": "open_app", "text": "Gmail"}'
+            ),
+            deps={"start_app", "get_apps"},
+        )
 
     registry.register(
         "remember",

--- a/droidrun/agent/utils/signatures.py
+++ b/droidrun/agent/utils/signatures.py
@@ -135,12 +135,13 @@ async def build_tool_registry(
     # -- system_button (dynamic description) ---------------------------------
 
     buttons = ", ".join(sorted(supported_buttons or set()))
+    buttons_desc = f"Available buttons: {buttons}. " if buttons else ""
     registry.register(
         "system_button",
         fn=system_button,
         params={"button": {"type": "string", "required": True}},
         description=(
-            f"Press a system button. Available buttons: {buttons}. "
+            f"Press a system button. {buttons_desc}"
             'Usage example: {"action": "system_button", "button": "home"}'
         ),
         deps={"press_button"},

--- a/droidrun/agent/utils/signatures.py
+++ b/droidrun/agent/utils/signatures.py
@@ -1,13 +1,17 @@
-"""Action signatures and credential tool builder."""
+"""Tool registry builder — single place for all standard droidrun tools."""
 
 import logging
 
+from droidrun.agent.tool_registry import ToolRegistry
 from droidrun.agent.utils.actions import (
     click,
-    click_at,
     click_area,
+    click_at,
+    complete,
     long_press,
     long_press_at,
+    open_app,
+    remember,
     swipe,
     system_button,
     type,
@@ -15,113 +19,219 @@ from droidrun.agent.utils.actions import (
     wait,
 )
 
+logger = logging.getLogger("droidrun")
 
-ATOMIC_ACTION_SIGNATURES = {
-    "click": {
-        "parameters": {
-            "index": {"type": "number", "required": True},
-        },
-        "description": 'Click the point on the screen with specified index. Usage Example: {"action": "click", "index": element_index}',
-        "function": click,
-        "deps": {"tap", "element_index"},
-    },
-    "long_press": {
-        "parameters": {
-            "index": {"type": "number", "required": True},
-        },
-        "description": 'Long press on the position with specified index. Usage Example: {"action": "long_press", "index": element_index}',
-        "function": long_press,
-        "deps": {"swipe", "element_index"},
-    },
-    "click_at": {
-        "parameters": {
+
+async def build_tool_registry(
+    supported_buttons: set[str] | None = None,
+    credential_manager=None,
+) -> tuple[ToolRegistry, set[str]]:
+    """Build a ToolRegistry with all standard droidrun tools.
+
+    Args:
+        supported_buttons: Buttons available for system_button description.
+            Defaults to ``{"back", "home", "enter"}`` if *None*.
+        credential_manager: If provided and has keys, ``type_secret`` is registered.
+
+    Returns:
+        ``(registry, standard_tool_names)`` where *standard_tool_names* is the
+        set of tool names registered here.  The ManagerAgent uses this to
+        exclude already-described tools from its ``<custom_actions>`` prompt
+        section.  User/MCP tools added later by DroidAgent will NOT be in
+        this set, so they correctly appear in ``<custom_actions>``.
+    """
+    registry = ToolRegistry()
+
+    # -- Core UI actions -----------------------------------------------------
+
+    registry.register(
+        "click",
+        fn=click,
+        params={"index": {"type": "number", "required": True}},
+        description=(
+            "Click the point on the screen with specified index. "
+            'Usage Example: {"action": "click", "index": element_index}'
+        ),
+        deps={"tap", "element_index"},
+    )
+
+    registry.register(
+        "long_press",
+        fn=long_press,
+        params={"index": {"type": "number", "required": True}},
+        description=(
+            "Long press on the position with specified index. "
+            'Usage Example: {"action": "long_press", "index": element_index}'
+        ),
+        deps={"swipe", "element_index"},
+    )
+
+    registry.register(
+        "click_at",
+        fn=click_at,
+        params={
             "x": {"type": "number", "required": True},
             "y": {"type": "number", "required": True},
         },
-        "description": 'Click at screen position (x, y). Use element bounds as reference to determine where to click. Usage: {"action": "click_at", "x": 500, "y": 300}',
-        "function": click_at,
-        "deps": {"tap", "convert_point"},
-    },
-    "click_area": {
-        "parameters": {
+        description=(
+            "Click at screen position (x, y). Use element bounds as reference "
+            'to determine where to click. Usage: {"action": "click_at", "x": 500, "y": 300}'
+        ),
+        deps={"tap", "convert_point"},
+    )
+
+    registry.register(
+        "click_area",
+        fn=click_area,
+        params={
             "x1": {"type": "number", "required": True},
             "y1": {"type": "number", "required": True},
             "x2": {"type": "number", "required": True},
             "y2": {"type": "number", "required": True},
         },
-        "description": 'Click center of area (x1, y1, x2, y2). Useful when you want to click a specific region. Usage: {"action": "click_area", "x1": 100, "y1": 200, "x2": 300, "y2": 400}',
-        "function": click_area,
-        "deps": {"tap", "convert_point"},
-    },
-    "long_press_at": {
-        "parameters": {
+        description=(
+            "Click center of area (x1, y1, x2, y2). Useful when you want to click "
+            'a specific region. Usage: {"action": "click_area", "x1": 100, "y1": 200, "x2": 300, "y2": 400}'
+        ),
+        deps={"tap", "convert_point"},
+    )
+
+    registry.register(
+        "long_press_at",
+        fn=long_press_at,
+        params={
             "x": {"type": "number", "required": True},
             "y": {"type": "number", "required": True},
         },
-        "description": 'Long press at screen position (x, y). Use element bounds as reference. Usage: {"action": "long_press_at", "x": 500, "y": 300}',
-        "function": long_press_at,
-        "deps": {"swipe", "convert_point"},
-    },
-    "type": {
-        "parameters": {
+        description=(
+            "Long press at screen position (x, y). Use element bounds as reference. "
+            'Usage: {"action": "long_press_at", "x": 500, "y": 300}'
+        ),
+        deps={"swipe", "convert_point"},
+    )
+
+    registry.register(
+        "type",
+        fn=type,
+        params={
             "text": {"type": "string", "required": True},
             "index": {"type": "number", "required": True},
             "clear": {"type": "boolean", "required": False, "default": False},
         },
-        "description": 'Type text into an input box or text field. Specify the element with index to focus the input field before typing. By default, text is APPENDED to existing content. Set clear=True to clear the field first (recommended for URL bars, search fields, or when replacing text). Usage Example: {"action": "type", "text": "example.com", "index": element_index, "clear": true}',
-        "function": type,
-        "deps": {"tap", "input_text", "element_index"},
-    },
-    "system_button": {
-        "parameters": {
-            "button": {"type": "string", "required": True},
-        },
-        "description": 'Press a system button, including back, home, and enter. Usage example: {"action": "system_button", "button": "Home"}',
-        "function": system_button,
-        "deps": {"press_button"},
-    },
-    "swipe": {
-        "parameters": {
+        description=(
+            "Type text into an input box or text field. Specify the element with "
+            "index to focus the input field before typing. By default, text is "
+            "APPENDED to existing content. Set clear=True to clear the field first "
+            "(recommended for URL bars, search fields, or when replacing text). "
+            'Usage Example: {"action": "type", "text": "example.com", "index": element_index, "clear": true}'
+        ),
+        deps={"tap", "input_text", "element_index"},
+    )
+
+    # -- system_button (dynamic description) ---------------------------------
+
+    buttons = ", ".join(sorted(supported_buttons or set()))
+    registry.register(
+        "system_button",
+        fn=system_button,
+        params={"button": {"type": "string", "required": True}},
+        description=(
+            f"Press a system button. Available buttons: {buttons}. "
+            'Usage example: {"action": "system_button", "button": "home"}'
+        ),
+        deps={"press_button"},
+    )
+
+    # -- Navigation / timing -------------------------------------------------
+
+    registry.register(
+        "swipe",
+        fn=swipe,
+        params={
             "coordinate": {"type": "list", "required": True},
             "coordinate2": {"type": "list", "required": True},
             "duration": {"type": "number", "required": False, "default": 1.0},
         },
-        "description": 'Scroll from the position with coordinate to the position with coordinate2. Duration is in seconds (default: 1.0). Usage Example: {"action": "swipe", "coordinate": [x1, y1], "coordinate2": [x2, y2], "duration": 1.5}',
-        "function": swipe,
-        "deps": {"swipe", "convert_point"},
-    },
-    "wait": {
-        "parameters": {
+        description=(
+            "Scroll from the position with coordinate to the position with "
+            "coordinate2. Duration is in seconds (default: 1.0). "
+            'Usage Example: {"action": "swipe", "coordinate": [x1, y1], "coordinate2": [x2, y2], "duration": 1.5}'
+        ),
+        deps={"swipe", "convert_point"},
+    )
+
+    registry.register(
+        "wait",
+        fn=wait,
+        params={
             "duration": {"type": "number", "required": False, "default": 1.0},
         },
-        "description": 'Wait for a specified duration in seconds. Useful for waiting for animations, page loads, or other time-based operations. Usage Example: {"action": "wait", "duration": 2.0}',
-        "function": wait,
-    },
-}
+        description=(
+            "Wait for a specified duration in seconds. Useful for waiting for "
+            "animations, page loads, or other time-based operations. "
+            'Usage Example: {"action": "wait", "duration": 2.0}'
+        ),
+    )
 
+    # -- App / state / flow control ------------------------------------------
 
-async def build_credential_tools(credential_manager) -> dict:
-    """Build credential-related custom tools if credential manager is available."""
-    logger = logging.getLogger("droidrun")
+    registry.register(
+        "open_app",
+        fn=open_app,
+        params={"text": {"type": "string", "required": True}},
+        description=(
+            "Open an app by name or description. "
+            'Usage: {"action": "open_app", "text": "Gmail"}'
+        ),
+        deps={"start_app", "get_apps"},
+    )
 
-    if credential_manager is None:
-        return {}
+    registry.register(
+        "remember",
+        fn=remember,
+        params={"information": {"type": "string", "required": True}},
+        description="Remember information for later use",
+    )
 
-    available_secrets = await credential_manager.get_keys()
-    if not available_secrets:
-        logger.debug("No enabled secrets found, credential tools disabled")
-        return {}
-
-    logger.debug(f"Building credential tools with {len(available_secrets)} secrets")
-
-    return {
-        "type_secret": {
-            "parameters": {
-                "secret_id": {"type": "string", "required": True},
-                "index": {"type": "number", "required": True},
-            },
-            "description": 'Type a secret credential from the credential store into an input field. The agent never sees the actual secret value, only the secret_id. Usage: {"action": "type_secret", "secret_id": "MY_PASSWORD", "index": 5}',
-            "function": type_secret,
-            "deps": {"tap", "input_text", "element_index"},
+    registry.register(
+        "complete",
+        fn=complete,
+        params={
+            "success": {"type": "boolean", "required": True},
+            "message": {"type": "string", "required": True},
         },
-    }
+        description=(
+            "Mark task as complete. "
+            "success=true if task succeeded, false if failed. "
+            "message contains the result, answer, or explanation."
+        ),
+    )
+
+    standard_tool_names = set(registry.tools.keys())
+
+    # -- Credential tools (conditional) --------------------------------------
+
+    if credential_manager is not None:
+        available_secrets = await credential_manager.get_keys()
+        if available_secrets:
+            logger.debug(
+                f"Building credential tools with {len(available_secrets)} secrets"
+            )
+            registry.register(
+                "type_secret",
+                fn=type_secret,
+                params={
+                    "secret_id": {"type": "string", "required": True},
+                    "index": {"type": "number", "required": True},
+                },
+                description=(
+                    "Type a secret credential from the credential store into an "
+                    "input field. The agent never sees the actual secret value, "
+                    "only the secret_id. "
+                    'Usage: {"action": "type_secret", "secret_id": "MY_PASSWORD", "index": 5}'
+                ),
+                deps={"tap", "input_text", "element_index"},
+            )
+            standard_tool_names.add("type_secret")
+
+    return registry, standard_tool_names

--- a/droidrun/cli/device_commands.py
+++ b/droidrun/cli/device_commands.py
@@ -17,7 +17,7 @@ from rich.console import Console
 from droidrun.config_manager import ConfigLoader
 from droidrun.portal import ensure_portal_ready
 from droidrun.tools.driver.android import AndroidDriver
-from droidrun.tools.driver.ios import IOSDriver
+from droidrun.tools.driver.ios import IOSDriver, discover_ios_portal, validate_ios_portal_url
 from droidrun.tools.filters import ConciseFilter
 from droidrun.tools.formatters import IndexedFormatter
 from droidrun.tools.ui.ios_provider import IOSStateProvider
@@ -66,9 +66,11 @@ async def _create_driver(
     is_ios = config.device.platform.lower() == "ios"
 
     if is_ios:
-        if not config.device.serial:
-            raise click.ClickException("iOS device URL required (--device)")
-        driver = IOSDriver(url=config.device.serial)
+        if config.device.serial:
+            url = validate_ios_portal_url(config.device.serial)
+        else:
+            url = await discover_ios_portal()
+        driver = IOSDriver(url=url)
         await driver.connect()
         return driver, True
 

--- a/droidrun/cli/device_commands.py
+++ b/droidrun/cli/device_commands.py
@@ -17,7 +17,11 @@ from rich.console import Console
 from droidrun.config_manager import ConfigLoader
 from droidrun.portal import ensure_portal_ready
 from droidrun.tools.driver.android import AndroidDriver
-from droidrun.tools.driver.ios import IOSDriver, discover_ios_portal, validate_ios_portal_url
+from droidrun.tools.driver.ios import (
+    IOSDriver,
+    discover_ios_portal,
+    validate_ios_portal_url,
+)
 from droidrun.tools.filters import ConciseFilter
 from droidrun.tools.formatters import IndexedFormatter
 from droidrun.tools.ui.ios_provider import IOSStateProvider

--- a/droidrun/cli/main.py
+++ b/droidrun/cli/main.py
@@ -38,6 +38,7 @@ from droidrun.portal import (
 from droidrun.agent.external import list_agents
 from droidrun.agent.utils.llm_picker import load_llm
 from droidrun.telemetry import print_telemetry_message
+from droidrun.tools.driver.ios import discover_ios_portal, validate_ios_portal_url
 
 # Suppress all warnings
 warnings.filterwarnings("ignore")
@@ -171,6 +172,11 @@ async def run_command(
         # Platform overrides
         if ios:
             config.device.platform = "ios"
+            if config.device.serial:
+                config.device.serial = validate_ios_portal_url(config.device.serial)
+            else:
+                logger.info("🔍 Searching for iOS portal...")
+                config.device.serial = await discover_ios_portal()
 
         # ================================================================
         # STEP 2: Initialize DroidAgent with config
@@ -242,7 +248,8 @@ async def run_command(
             return False
 
         except Exception as e:
-            logger.error(f"💥 Error: {e}")
+            err_desc = str(e) or type(e).__name__
+            logger.error(f"💥 Error: {err_desc}")
             if config.logging.debug:
                 import traceback
 
@@ -250,7 +257,8 @@ async def run_command(
             return False
 
     except Exception as e:
-        logger.error(f"💥 Setup error: {e}")
+        err_desc = str(e) or type(e).__name__
+        logger.error(f"💥 Setup error: {err_desc}")
         if debug_mode:
             import traceback
 
@@ -385,7 +393,7 @@ except Exception:
     help="Trajectory saving level: none (no saving), step (save per step), action (save per action)",
     default=None,
 )
-@click.option("--ios", type=bool, default=None, help="Run on iOS device")
+@click.option("--ios", is_flag=True, default=False, help="Run on iOS device")
 @coro
 async def run(
     command: str,
@@ -405,7 +413,7 @@ async def run(
     debug: bool | None,
     tcp: bool | None,
     save_trajectory: str | None,
-    ios: bool | None,
+    ios: bool,
 ):
     """Run a command on your Android device using natural language."""
 
@@ -428,13 +436,13 @@ async def run(
             tcp=tcp,
             temperature=temperature,
             save_trajectory=save_trajectory,
-            ios=ios if ios is not None else False,
+            ios=ios,
         )
     finally:
         # Disable Droidrun keyboard after execution
         # Note: Port forwards are managed automatically and persist until device disconnect
         try:
-            if not (ios if ios is not None else False):
+            if not ios:
                 device_obj = await adb.device(device)
                 if device_obj:
                     await device_obj.shell(

--- a/droidrun/config/prompts/executor/rev1.jinja2
+++ b/droidrun/config/prompts/executor/rev1.jinja2
@@ -1,4 +1,4 @@
-# Android Action Executor
+# {{ platform }} Action Executor
 
 You are an action executor. Your only job: execute the current subgoal exactly as written.
 

--- a/droidrun/config/prompts/executor/system.jinja2
+++ b/droidrun/config/prompts/executor/system.jinja2
@@ -1,4 +1,4 @@
-You are a LOW-LEVEL ACTION EXECUTOR for an Android phone. You do NOT answer questions or provide results. You ONLY perform individual atomic actions as specified in the current subgoal. You are part of a larger system - your job is to execute actions, not to think about or answer the user's original question.
+You are a LOW-LEVEL ACTION EXECUTOR for a {{ platform }} device. You do NOT answer questions or provide results. You ONLY perform individual atomic actions as specified in the current subgoal. You are part of a larger system - your job is to execute actions, not to think about or answer the user's original question.
 
 ### User Request ###
 {{ instruction }}

--- a/droidrun/config/prompts/fast_agent/system.jinja2
+++ b/droidrun/config/prompts/fast_agent/system.jinja2
@@ -1,4 +1,4 @@
-You are Droidrun — a sharp, clever agent that controls Android devices through tools. You've got a dry sense of humor and you read screens like a pro. Be concise.
+You are Droidrun — a sharp, clever agent that controls {{ platform }} devices through tools. You've got a dry sense of humor and you read screens like a pro. Be concise.
 
 You will be given a task to perform. You should:
 1. Analyze the current device state and screenshot

--- a/droidrun/config/prompts/manager/rev1.jinja2
+++ b/droidrun/config/prompts/manager/rev1.jinja2
@@ -1,6 +1,6 @@
-# Android Planning Agent
+# {{ platform }} Planning Agent
 
-You operate an Android phone by creating high-level plans to fulfill user requests.
+You operate a {{ platform }} device by creating high-level plans to fulfill user requests.
 
 ## User Request
 {{ instruction }}

--- a/droidrun/config/prompts/manager/system.jinja2
+++ b/droidrun/config/prompts/manager/system.jinja2
@@ -1,4 +1,4 @@
-You are an agent who can operate an Android phone on behalf of a user. Your goal is to track progress and devise high-level plans to achieve the user's requests.
+You are an agent who can operate a {{ platform }} device on behalf of a user. Your goal is to track progress and devise high-level plans to achieve the user's requests.
 
 <user_request>
 {{ instruction }}

--- a/droidrun/tools/android/portal_client.py
+++ b/droidrun/tools/android/portal_client.py
@@ -355,7 +355,7 @@ class PortalClient:
         try:
             async with httpx.AsyncClient() as client:
                 response = await self._tcp_request(
-                    client, "GET", f"{self.tcp_base_url}/state_full", timeout=10
+                    client, "GET", f"{self.tcp_base_url}/state", timeout=10
                 )
                 if response.status_code == 200:
                     data = response.json()
@@ -391,7 +391,7 @@ class PortalClient:
         """Get state via content provider (fallback)."""
         try:
             output = await self.device.shell(
-                "content query --uri content://com.droidrun.portal/state_full"
+                "content query --uri content://com.droidrun.portal/state"
             )
             state_data = self._parse_content_provider_output(output)
 

--- a/droidrun/tools/driver/android.py
+++ b/droidrun/tools/driver/android.py
@@ -24,6 +24,8 @@ PORTAL_DEFAULT_TCP_PORT = 8080
 class AndroidDriver(DeviceDriver):
     """Raw Android device I/O via ADB + Portal."""
 
+    platform = "Android"
+
     supported = {
         "tap",
         "swipe",

--- a/droidrun/tools/driver/base.py
+++ b/droidrun/tools/driver/base.py
@@ -21,8 +21,11 @@ class DeviceDriver:
     Every method raises ``NotImplementedError`` by default.
     Concrete drivers override the methods they support and declare them
     in the ``supported`` class-level set.
+
+    ``platform`` identifies the device type (e.g. "Android", "iOS").
     """
 
+    platform: str = "Android"
     supported: set[str] = set()
     supported_buttons: set[str] = set()
 

--- a/droidrun/tools/driver/cloud.py
+++ b/droidrun/tools/driver/cloud.py
@@ -22,6 +22,8 @@ T = TypeVar("T")
 class CloudDriver(DeviceDriver):
     """Cloud device I/O via the MobileRun SDK."""
 
+    platform = "Android"
+
     supported = {
         "tap",
         "swipe",

--- a/droidrun/tools/driver/ios.py
+++ b/droidrun/tools/driver/ios.py
@@ -168,7 +168,7 @@ class IOSDriver(DeviceDriver):
         ``device_context`` keys — matching the format expected by
         ``fetch_state_with_retry()``.
         """
-        resp = await self._client.get("/state_full")
+        resp = await self._client.get("/state")
         resp.raise_for_status()
         return resp.json()
 

--- a/droidrun/tools/driver/ios.py
+++ b/droidrun/tools/driver/ios.py
@@ -214,10 +214,6 @@ class IOSDriver(DeviceDriver):
                 f"Button '{button}' not supported on iOS. "
                 f"Supported: {', '.join(sorted(self.supported_buttons))}"
             )
-        if button_lower == "back":
-            resp = await self._client.post("/gestures/back")
-            resp.raise_for_status()
-            return
         if button_lower == "home":
             resp = await self._client.post("/inputs/key", json={"key": 1})
             resp.raise_for_status()

--- a/droidrun/tools/driver/ios.py
+++ b/droidrun/tools/driver/ios.py
@@ -3,13 +3,9 @@
 Wraps the iOS portal HTTP API (running on the device) to provide device I/O
 through the same ``DeviceDriver`` interface used by Android.
 
-Known limitations (pre-existing, documented as TODOs):
-- ``clear`` parameter in ``input_text`` is ignored
-- ``press_button`` only supports HOME; BACK and ENTER have no iOS equivalent
-- ``get_date`` not available (no iOS portal endpoint)
-- ``drag`` not implemented
-- ``get_apps`` returns bundle identifiers, not real app metadata
-- Screen dimensions inferred from element bounds (no portal endpoint)
+Known limitations:
+- ``get_apps`` returns a hardcoded list of system bundle identifiers
+- ``packageName`` is not tracked (iOS has no API to detect the foreground app)
 """
 
 from __future__ import annotations
@@ -61,12 +57,13 @@ class IOSDriver(DeviceDriver):
         "get_ui_tree",
         "list_packages",
         "get_apps",
+        "get_date",
     }
 
-    supported_buttons = {"home"}
+    supported_buttons = {"home", "back"}
 
     _BUTTON_IOS_KEYCODES = {
-        "home": 0,
+        "home": 1,  # XCUIDeviceButtonHome = 1
     }
 
     def __init__(
@@ -77,14 +74,12 @@ class IOSDriver(DeviceDriver):
         self.url = url.rstrip("/")
         self.bundle_identifiers = bundle_identifiers or []
         self._client: Optional[httpx.AsyncClient] = None
-        self._last_tapped_rect: Optional[str] = None
         self._connected = False
 
     # -- lifecycle -----------------------------------------------------------
 
     async def connect(self) -> None:
         self._client = httpx.AsyncClient(base_url=self.url, timeout=30.0)
-        # TODO: verify URL is reachable (ping /vision/state or similar)
         self._connected = True
         logger.info(f"Connected to iOS device at {self.url}")
 
@@ -96,9 +91,6 @@ class IOSDriver(DeviceDriver):
 
     async def tap(self, x: int, y: int) -> None:
         ios_rect = f"{{{{{x},{y}}},{{{1},{1}}}}}"
-        # Store for input_text (iOS API requires a rect for typing)
-        # TODO: stores center point as 1x1 rect, not full element bounds
-        self._last_tapped_rect = f"{x},{y},1,1"
         resp = await self._client.post(
             "/gestures/tap",
             json={"rect": ios_rect, "count": 1, "longPress": False},
@@ -108,23 +100,21 @@ class IOSDriver(DeviceDriver):
     async def swipe(
         self, x1: int, y1: int, x2: int, y2: int, duration_ms: float = 1000
     ) -> None:
-        # iOS API is direction-based, not coordinate-based
-        dx, dy = x2 - x1, y2 - y1
-        if abs(dx) > abs(dy):
-            direction = "right" if dx > 0 else "left"
-        else:
-            direction = "down" if dy > 0 else "up"
         resp = await self._client.post(
             "/gestures/swipe",
-            json={"x": float(x1), "y": float(y1), "dir": direction},
+            json={
+                "x1": float(x1),
+                "y1": float(y1),
+                "x2": float(x2),
+                "y2": float(y2),
+                "durationMs": float(duration_ms),
+            },
         )
         resp.raise_for_status()
 
     async def input_text(self, text: str, clear: bool = False) -> bool:
-        # TODO: clear not supported on iOS portal
-        rect = self._last_tapped_rect or "0,0,100,100"
         resp = await self._client.post(
-            "/inputs/type", json={"rect": rect, "text": text}
+            "/inputs/type", json={"text": text, "clear": clear}
         )
         return resp.status_code == 200
 
@@ -136,6 +126,10 @@ class IOSDriver(DeviceDriver):
                 f"Button '{button}' not supported on iOS. "
                 f"Supported: {', '.join(sorted(self.supported_buttons))}"
             )
+        if button_lower == "back":
+            resp = await self._client.post("/gestures/back")
+            resp.raise_for_status()
+            return
         keycode = self._BUTTON_IOS_KEYCODES[button_lower]
         resp = await self._client.post("/inputs/key", json={"key": keycode})
         resp.raise_for_status()
@@ -151,8 +145,6 @@ class IOSDriver(DeviceDriver):
         return f"Failed to launch {package}: HTTP {resp.status_code}"
 
     async def get_apps(self, include_system: bool = True) -> List[Dict[str, str]]:
-        # TODO: iOS portal has no app listing endpoint.
-        # Returns bundle identifiers as both package and label.
         all_ids: set[str] = set(self.bundle_identifiers)
         if include_system:
             all_ids.update(SYSTEM_BUNDLE_IDENTIFIERS)
@@ -170,34 +162,18 @@ class IOSDriver(DeviceDriver):
         return resp.content
 
     async def get_ui_tree(self) -> Dict[str, Any]:
-        """Return raw iOS accessibility data and phone state.
+        """Return unified state from the iOS portal.
 
-        Returns a dict with:
-        - ``a11y_raw``: the raw accessibility tree text from the portal
-        - ``phone_state``: dict with ``current_activity`` and ``keyboard_shown``
+        Returns a dict with ``a11y_tree``, ``phone_state``, and
+        ``device_context`` keys — matching the format expected by
+        ``fetch_state_with_retry()``.
         """
-        a11y_resp = await self._client.get("/vision/a11y")
-        a11y_resp.raise_for_status()
-        a11y_data = a11y_resp.json()
-
-        state_resp = await self._client.get("/vision/state")
-        if state_resp.status_code == 200:
-            state_data = state_resp.json()
-            phone_state = {
-                "currentApp": state_data.get("activity", "Unknown"),
-                "keyboardVisible": state_data.get("keyboardShown", False),
-            }
-        else:
-            phone_state = {
-                "currentApp": "Unknown",
-                "keyboardVisible": False,
-            }
-
-        return {
-            "a11y_raw": a11y_data["accessibilityTree"],
-            "phone_state": phone_state,
-        }
+        resp = await self._client.get("/state_full")
+        resp.raise_for_status()
+        return resp.json()
 
     async def get_date(self) -> str:
-        # TODO: not available on iOS portal
+        resp = await self._client.get("/device/date")
+        if resp.status_code == 200:
+            return resp.json().get("date", "")
         return ""

--- a/droidrun/tools/driver/ios.py
+++ b/droidrun/tools/driver/ios.py
@@ -10,8 +10,11 @@ Known limitations:
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import re
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 import httpx
 
@@ -19,27 +22,105 @@ from droidrun.tools.driver.base import DeviceDriver
 
 logger = logging.getLogger("droidrun")
 
-SYSTEM_BUNDLE_IDENTIFIERS = [
-    "ai.droidrun.droidrun-ios-portal",
-    "com.apple.Bridge",
-    "com.apple.DocumentsApp",
-    "com.apple.Fitness",
-    "com.apple.Health",
-    "com.apple.Maps",
-    "com.apple.MobileAddressBook",
-    "com.apple.MobileSMS",
-    "com.apple.Passbook",
-    "com.apple.Passwords",
-    "com.apple.Preferences",
-    "com.apple.PreviewShell",
-    "com.apple.mobilecal",
-    "com.apple.mobilesafari",
-    "com.apple.mobileslideshow",
-    "com.apple.news",
-    "com.apple.reminders",
-    "com.apple.shortcuts",
-    "com.apple.webapp",
-]
+SYSTEM_APP_LABELS = {
+    "ai.droidrun.droidrun-ios-portal": "Droidrun Portal",
+    "com.apple.Bridge": "Watch",
+    "com.apple.DocumentsApp": "Files",
+    "com.apple.Fitness": "Fitness",
+    "com.apple.Health": "Health",
+    "com.apple.Maps": "Maps",
+    "com.apple.MobileAddressBook": "Contacts",
+    "com.apple.MobileSMS": "Messages",
+    "com.apple.Passbook": "Wallet",
+    "com.apple.Passwords": "Passwords",
+    "com.apple.Preferences": "Settings",
+    "com.apple.PreviewShell": "Freeform",
+    "com.apple.mobilecal": "Calendar",
+    "com.apple.mobilesafari": "Safari",
+    "com.apple.mobileslideshow": "Photos",
+    "com.apple.news": "News",
+    "com.apple.reminders": "Reminders",
+    "com.apple.shortcuts": "Shortcuts",
+    "com.apple.webapp": "Web App",
+}
+
+
+IOS_PORTAL_DEFAULT_PORT = 6643
+IOS_PORTAL_SCAN_RANGE = 10
+
+
+def validate_ios_portal_url(url: str) -> str:
+    """Validate and normalize an iOS portal base URL."""
+    normalized = url.rstrip("/")
+    parsed = urlparse(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(
+            "iOS device must be the portal base URL, e.g. http://127.0.0.1:6643"
+        )
+    return normalized
+
+
+async def discover_ios_portal(
+    host: str = "127.0.0.1",
+    start_port: int = IOS_PORTAL_DEFAULT_PORT,
+    scan_range: int = IOS_PORTAL_SCAN_RANGE,
+    timeout: float = 1.0,
+) -> str:
+    """Auto-discover the iOS portal by scanning a small port range.
+
+    Tries ``start_port`` first (fast path), then scans the remaining ports
+    in ``[start_port, start_port + scan_range)`` concurrently.
+
+    Returns:
+        The portal base URL, e.g. ``http://127.0.0.1:6643``.
+
+    Raises:
+        ConnectionError: If no portal is found in the scan range.
+    """
+
+    async def _probe(client: httpx.AsyncClient, port: int) -> Optional[str]:
+        url = f"http://{host}:{port}"
+        try:
+            resp = await client.get(f"{url}/device/date")
+            if resp.status_code == 200 and "date" in resp.json():
+                return url
+        except Exception:
+            pass
+        return None
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        # Fast path: try the default port first
+        result = await _probe(client, start_port)
+        if result:
+            logger.info(f"iOS portal found at {result}")
+            return result
+
+        # Scan remaining ports concurrently
+        results = await asyncio.gather(
+            *[_probe(client, p) for p in range(start_port + 1, start_port + scan_range)]
+        )
+        for r in results:
+            if r is not None:
+                logger.info(f"iOS portal found at {r}")
+                return r
+
+    raise ConnectionError(
+        f"Could not find iOS portal on {host} "
+        f"(scanned ports {start_port}-{start_port + scan_range - 1}). "
+        "Make sure the Droidrun Portal app is running and iproxy is forwarding the port."
+    )
+
+
+def _humanize_bundle_identifier(bundle_id: str) -> str:
+    mapped = SYSTEM_APP_LABELS.get(bundle_id)
+    if mapped:
+        return mapped
+
+    last_segment = bundle_id.rsplit(".", 1)[-1]
+    words = re.findall(r"[A-Z]?[a-z]+|[A-Z]+(?=[A-Z][a-z]|\b)|\d+", last_segment)
+    if words:
+        return " ".join(words)
+    return last_segment or bundle_id
 
 
 class IOSDriver(DeviceDriver):
@@ -60,18 +141,14 @@ class IOSDriver(DeviceDriver):
         "get_date",
     }
 
-    supported_buttons = {"home", "back"}
-
-    _BUTTON_IOS_KEYCODES = {
-        "home": 1,  # XCUIDeviceButtonHome = 1
-    }
+    supported_buttons = {"home"}
 
     def __init__(
         self,
         url: str,
         bundle_identifiers: Optional[List[str]] = None,
     ) -> None:
-        self.url = url.rstrip("/")
+        self.url = validate_ios_portal_url(url)
         self.bundle_identifiers = bundle_identifiers or []
         self._client: Optional[httpx.AsyncClient] = None
         self._connected = False
@@ -80,6 +157,17 @@ class IOSDriver(DeviceDriver):
 
     async def connect(self) -> None:
         self._client = httpx.AsyncClient(base_url=self.url, timeout=30.0)
+        try:
+            resp = await self._client.get("/device/date")
+            resp.raise_for_status()
+        except Exception as exc:
+            await self._client.aclose()
+            self._client = None
+            raise ConnectionError(
+                f"Could not connect to iOS portal at {self.url}. "
+                "Make sure the Droidrun Portal app is running on the device "
+                "and the URL/port is correct."
+            ) from exc
         self._connected = True
         logger.info(f"Connected to iOS device at {self.url}")
 
@@ -130,9 +218,10 @@ class IOSDriver(DeviceDriver):
             resp = await self._client.post("/gestures/back")
             resp.raise_for_status()
             return
-        keycode = self._BUTTON_IOS_KEYCODES[button_lower]
-        resp = await self._client.post("/inputs/key", json={"key": keycode})
-        resp.raise_for_status()
+        if button_lower == "home":
+            resp = await self._client.post("/inputs/key", json={"key": 1})
+            resp.raise_for_status()
+            return
 
     # -- app management ------------------------------------------------------
 
@@ -147,8 +236,11 @@ class IOSDriver(DeviceDriver):
     async def get_apps(self, include_system: bool = True) -> List[Dict[str, str]]:
         all_ids: set[str] = set(self.bundle_identifiers)
         if include_system:
-            all_ids.update(SYSTEM_BUNDLE_IDENTIFIERS)
-        return [{"package": bid, "label": bid} for bid in sorted(all_ids)]
+            all_ids.update(SYSTEM_APP_LABELS)
+        return [
+            {"package": bid, "label": _humanize_bundle_identifier(bid)}
+            for bid in sorted(all_ids)
+        ]
 
     async def list_packages(self, include_system: bool = False) -> List[str]:
         apps = await self.get_apps(include_system)
@@ -168,9 +260,12 @@ class IOSDriver(DeviceDriver):
         ``device_context`` keys — matching the format expected by
         ``fetch_state_with_retry()``.
         """
-        resp = await self._client.get("/state")
+        resp = await self._client.get("/state", timeout=15.0)
         resp.raise_for_status()
-        return resp.json()
+        try:
+            return resp.json()
+        except Exception as e:
+            raise ValueError(f"Invalid response from /state: {e}") from e
 
     async def get_date(self) -> str:
         resp = await self._client.get("/device/date")

--- a/droidrun/tools/driver/ios.py
+++ b/droidrun/tools/driver/ios.py
@@ -49,6 +49,8 @@ SYSTEM_BUNDLE_IDENTIFIERS = [
 class IOSDriver(DeviceDriver):
     """iOS device driver communicating via HTTP REST to the iOS portal app."""
 
+    platform = "iOS"
+
     supported = {
         "tap",
         "swipe",

--- a/droidrun/tools/driver/recording.py
+++ b/droidrun/tools/driver/recording.py
@@ -24,6 +24,10 @@ class RecordingDriver:
         self.log: List[Dict[str, Any]] = []
 
     @property
+    def platform(self) -> str:
+        return self.inner.platform
+
+    @property
     def supported(self) -> set[str]:
         return self.inner.supported
 

--- a/droidrun/tools/driver/stealth.py
+++ b/droidrun/tools/driver/stealth.py
@@ -123,6 +123,10 @@ class StealthDriver:
         self.inner = inner
 
     @property
+    def platform(self) -> str:
+        return self.inner.platform
+
+    @property
     def supported(self) -> set[str]:
         return self.inner.supported
 

--- a/droidrun/tools/formatters/indexed_formatter.py
+++ b/droidrun/tools/formatters/indexed_formatter.py
@@ -44,7 +44,7 @@ class IndexedFormatter(TreeFormatter):
         """Format phone state."""
         if isinstance(phone_state, dict) and "error" not in phone_state:
             current_app = phone_state.get("currentApp", "")
-            package_name = phone_state.get("packageName", "Unknown")
+            package_name = phone_state.get("packageName", "")
             focused_element = phone_state.get("focusedElement")
             is_editable = phone_state.get("isEditable", False)
 
@@ -53,10 +53,23 @@ class IndexedFormatter(TreeFormatter):
             else:
                 focused_desc = "''"
 
-            phone_state_text = f"""**Current Phone State:**
-• **App:** {current_app} ({package_name})
-• **Keyboard:** {'Visible' if is_editable else 'Hidden'}
-• **Focused Element:** {focused_desc}"""
+            # Build app line — skip package if empty, skip whole line if both empty
+            if current_app and package_name:
+                app_line = f"• **App:** {current_app} ({package_name})"
+            elif current_app:
+                app_line = f"• **App:** {current_app}"
+            elif package_name:
+                app_line = f"• **App:** {package_name}"
+            else:
+                app_line = ""
+
+            lines = ["**Current Phone State:**"]
+            if app_line:
+                lines.append(app_line)
+            lines.append(f"• **Keyboard:** {'Visible' if is_editable else 'Hidden'}")
+            lines.append(f"• **Focused Element:** {focused_desc}")
+
+            phone_state_text = "\n".join(lines)
         else:
             if isinstance(phone_state, dict) and "error" in phone_state:
                 phone_state_text = f"📱 **Phone State Error:** {phone_state.get('message', 'Unknown error')}"

--- a/droidrun/tools/ui/ios_provider.py
+++ b/droidrun/tools/ui/ios_provider.py
@@ -14,7 +14,7 @@ import logging
 import re
 from typing import Any, Dict, List
 
-from droidrun.tools.driver.base import DeviceDriver
+from droidrun.tools.driver.base import DeviceDisconnectedError, DeviceDriver
 from droidrun.tools.ui.provider import StateProvider, fetch_state_with_retry
 from droidrun.tools.ui.state import UIState
 
@@ -40,6 +40,7 @@ _LABEL_RE = re.compile(r"label:\s*'([^']*)'")
 _IDENTIFIER_RE = re.compile(r"identifier:\s*'([^']*)'")
 _PLACEHOLDER_RE = re.compile(r"placeholderValue:\s*'([^']*)'")
 _VALUE_RE = re.compile(r"value:\s*([^,}]+)")
+_CLOCK_RE = re.compile(r"^\d{1,2}:\d{2}$")
 
 
 class IOSStateProvider(StateProvider):
@@ -52,18 +53,33 @@ class IOSStateProvider(StateProvider):
         self.use_normalized = use_normalized
 
     async def get_state(self) -> UIState:
-        raw = await fetch_state_with_retry(
-            fetch=self.driver.get_ui_tree,
-            recovery=None,
-            max_retries=3,
-            retry_delays=[1.0, 2.0],
-        )
+        try:
+            raw = await fetch_state_with_retry(
+                fetch=self.driver.get_ui_tree,
+                recovery=None,
+                max_retries=2,
+                retry_delays=[1.0],
+            )
+        except DeviceDisconnectedError:
+            raise
+        except Exception as e:
+            logger.warning(f"iOS state retrieval failed, returning empty state: {e}")
+            return UIState(
+                elements=[],
+                formatted_text="No UI elements available — device may be loading.",
+                focused_text="",
+                phone_state={},
+                screen_width=390,
+                screen_height=844,
+                use_normalized=self.use_normalized,
+            )
 
         a11y_text = raw.get("a11y_tree", "")
-        phone_state = raw.get("phone_state", {})
+        phone_state = dict(raw.get("phone_state", {}) or {})
         device_context = raw.get("device_context", {})
 
         elements = _parse_a11y_tree(a11y_text)
+        phone_state = _normalize_phone_state(phone_state, a11y_text)
 
         # Screen size from device_context
         screen_bounds = device_context.get("screen_bounds", {})
@@ -101,6 +117,8 @@ def _parse_a11y_tree(a11y_text: str) -> List[Dict[str, Any]]:
     """
     elements: List[Dict[str, Any]] = []
     element_index = 0
+
+    seen_signatures: set[tuple[str, str, str]] = set()
 
     for line in a11y_text.strip().split("\n"):
         stripped = line.strip()
@@ -147,6 +165,14 @@ def _parse_a11y_tree(a11y_text: str) -> List[Dict[str, Any]]:
         # Bounds in "left,top,right,bottom" format — compatible with UIState
         bounds_str = f"{int(x)},{int(y)},{int(x + width)},{int(y + height)}"
 
+        # Filter noisy wrapper nodes that duplicate a more useful action target.
+        signature = (element_type, text, bounds_str)
+        if element_type == "Other" and not (label or identifier or placeholder or value):
+            continue
+        if signature in seen_signatures:
+            continue
+        seen_signatures.add(signature)
+
         elements.append(
             {
                 "index": element_index,
@@ -164,7 +190,41 @@ def _parse_a11y_tree(a11y_text: str) -> List[Dict[str, Any]]:
         )
         element_index += 1
 
-    return elements
+    return _prioritize_actionable_elements(elements)
+
+
+def _normalize_phone_state(
+    phone_state: Dict[str, Any], a11y_text: str
+) -> Dict[str, Any]:
+    package_name = phone_state.get("packageName", "") or ""
+    current_app = phone_state.get("currentApp", "") or ""
+
+    is_home = package_name == "com.apple.springboard" or "Home screen icons" in a11y_text
+    if is_home:
+        phone_state["packageName"] = "com.apple.springboard"
+        if not current_app or _CLOCK_RE.match(current_app):
+            phone_state["currentApp"] = "Home Screen"
+    elif current_app and _CLOCK_RE.match(current_app):
+        phone_state["currentApp"] = ""
+
+    return phone_state
+
+
+def _prioritize_actionable_elements(
+    elements: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    actionable_types = {"Icon", "Button", "SearchField", "TextField", "SecureTextField", "TextView", "Cell", "StaticText", "Image", "Switch"}
+
+    def sort_key(el: Dict[str, Any]) -> tuple[int, int]:
+        class_name = el.get("className", "")
+        text = el.get("text", "")
+        actionable_rank = 0 if class_name in actionable_types and text else 1
+        return (actionable_rank, el.get("index", 0))
+
+    ordered = sorted(elements, key=sort_key)
+    for i, el in enumerate(ordered):
+        el["index"] = i
+    return ordered
 
 
 # ---------------------------------------------------------------------------

--- a/droidrun/tools/ui/ios_provider.py
+++ b/droidrun/tools/ui/ios_provider.py
@@ -20,17 +20,18 @@ from droidrun.tools.ui.state import UIState
 
 logger = logging.getLogger("droidrun")
 
-# Element types considered interactive on iOS.
-_INTERACTIVE_TYPES = {
-    "Button",
-    "SearchField",
-    "TextField",
-    "Cell",
-    "Switch",
-    "Slider",
-    "Stepper",
-    "Picker",
-    "Link",
+# Element types to skip — layout containers that add noise without useful info.
+# Everything else is kept (buttons, cells, text, icons, images, etc.)
+_SKIP_TYPES = {
+    "Window",
+    "Window (Main)",
+    "ScrollView",
+    "CollectionView",
+    "Table",
+    "Toolbar",
+    "TabBar",
+    "StatusBar",
+    "PageIndicator",
 }
 
 _COORD_RE = re.compile(r"\{\{([0-9.]+),\s*([0-9.]+)\},\s*\{([0-9.]+),\s*([0-9.]+)\}\}")
@@ -53,7 +54,9 @@ class IOSStateProvider(StateProvider):
     async def get_state(self) -> UIState:
         raw = await fetch_state_with_retry(
             fetch=self.driver.get_ui_tree,
-            recovery=None,  # no iOS equivalent of a11y service restart
+            recovery=None,
+            max_retries=3,
+            retry_delays=[1.0, 2.0],
         )
 
         a11y_text = raw.get("a11y_tree", "")
@@ -116,13 +119,17 @@ def _parse_a11y_tree(a11y_text: str) -> List[Dict[str, Any]]:
 
         x, y, width, height = map(float, coord_match.groups())
 
+        # Skip elements with no tappable area
+        if width == 0 or height == 0:
+            continue
+
         # Element type
         type_match = _ELEMENT_TYPE_RE.match(line)
         element_type = type_match.group(1).strip() if type_match else "Unknown"
         element_type = re.sub(r"^[→\s]+", "", element_type)
 
-        # Only keep interactive elements
-        if not any(it in element_type for it in _INTERACTIVE_TYPES):
+        # Skip layout containers that add noise without useful info
+        if element_type in _SKIP_TYPES:
             continue
 
         # Extract properties
@@ -173,9 +180,9 @@ def _format_elements(
     """Build the text representation shown to the agent."""
     schema = "'index. className: text - bounds(x1,y1,x2,y2)'"
     if not elements:
-        return f"Current Clickable UI elements:\n{schema}:\nNo UI elements found"
+        return f"Current UI elements:\n{schema}:\nNo UI elements found"
 
-    lines = [f"Current Clickable UI elements:\n{schema}:"]
+    lines = [f"Current UI elements:\n{schema}:"]
     for el in elements:
         idx = el.get("index", 0)
         cls = el.get("className", "Unknown")

--- a/droidrun/tools/ui/ios_provider.py
+++ b/droidrun/tools/ui/ios_provider.py
@@ -167,7 +167,9 @@ def _parse_a11y_tree(a11y_text: str) -> List[Dict[str, Any]]:
 
         # Filter noisy wrapper nodes that duplicate a more useful action target.
         signature = (element_type, text, bounds_str)
-        if element_type == "Other" and not (label or identifier or placeholder or value):
+        if element_type == "Other" and not (
+            label or identifier or placeholder or value
+        ):
             continue
         if signature in seen_signatures:
             continue
@@ -199,7 +201,9 @@ def _normalize_phone_state(
     package_name = phone_state.get("packageName", "") or ""
     current_app = phone_state.get("currentApp", "") or ""
 
-    is_home = package_name == "com.apple.springboard" or "Home screen icons" in a11y_text
+    is_home = (
+        package_name == "com.apple.springboard" or "Home screen icons" in a11y_text
+    )
     if is_home:
         phone_state["packageName"] = "com.apple.springboard"
         if not current_app or _CLOCK_RE.match(current_app):
@@ -211,9 +215,20 @@ def _normalize_phone_state(
 
 
 def _prioritize_actionable_elements(
-    elements: List[Dict[str, Any]]
+    elements: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
-    actionable_types = {"Icon", "Button", "SearchField", "TextField", "SecureTextField", "TextView", "Cell", "StaticText", "Image", "Switch"}
+    actionable_types = {
+        "Icon",
+        "Button",
+        "SearchField",
+        "TextField",
+        "SecureTextField",
+        "TextView",
+        "Cell",
+        "StaticText",
+        "Image",
+        "Switch",
+    }
 
     def sort_key(el: Dict[str, Any]) -> tuple[int, int]:
         class_name = el.get("className", "")

--- a/droidrun/tools/ui/ios_provider.py
+++ b/droidrun/tools/ui/ios_provider.py
@@ -3,9 +3,7 @@
 Parses the raw text-based accessibility tree returned by the iOS portal
 into structured elements compatible with UIState.
 
-Known limitations (pre-existing, documented as TODOs):
-- Screen dimensions inferred from element bounds with hardcoded fallback
-- ``focused_text`` always empty (iOS portal doesn't expose it)
+Known limitations:
 - Normalized coordinates untested on iOS
 - No filter/formatter pipeline (iOS a11y tree is raw text, not structured JSON)
 """
@@ -14,10 +12,10 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 from droidrun.tools.driver.base import DeviceDriver
-from droidrun.tools.ui.provider import StateProvider
+from droidrun.tools.ui.provider import StateProvider, fetch_state_with_retry
 from droidrun.tools.ui.state import UIState
 
 logger = logging.getLogger("droidrun")
@@ -50,22 +48,37 @@ class IOSStateProvider(StateProvider):
 
     def __init__(self, driver: DeviceDriver, use_normalized: bool = False) -> None:
         super().__init__(driver)
-        # TODO: normalized coordinates untested on iOS
         self.use_normalized = use_normalized
 
     async def get_state(self) -> UIState:
-        raw = await self.driver.get_ui_tree()
-        a11y_text = raw.get("a11y_raw", "")
+        raw = await fetch_state_with_retry(
+            fetch=self.driver.get_ui_tree,
+            recovery=None,  # no iOS equivalent of a11y service restart
+        )
+
+        a11y_text = raw.get("a11y_tree", "")
         phone_state = raw.get("phone_state", {})
+        device_context = raw.get("device_context", {})
 
         elements = _parse_a11y_tree(a11y_text)
-        screen_width, screen_height = _infer_screen_size(elements)
+
+        # Screen size from device_context
+        screen_bounds = device_context.get("screen_bounds", {})
+        screen_width = int(screen_bounds.get("width", 390))
+        screen_height = int(screen_bounds.get("height", 844))
+
         formatted_text = _format_elements(elements, screen_width, screen_height)
+
+        # Extract focused text from phone_state
+        focused_element = phone_state.get("focusedElement")
+        focused_text = ""
+        if focused_element and isinstance(focused_element, dict):
+            focused_text = focused_element.get("text", "")
 
         return UIState(
             elements=elements,
             formatted_text=formatted_text,
-            focused_text="",  # TODO: iOS doesn't expose focused element text
+            focused_text=focused_text,
             phone_state=phone_state,
             screen_width=screen_width,
             screen_height=screen_height,
@@ -145,34 +158,6 @@ def _parse_a11y_tree(a11y_text: str) -> List[Dict[str, Any]]:
         element_index += 1
 
     return elements
-
-
-# ---------------------------------------------------------------------------
-# Screen size inference
-# ---------------------------------------------------------------------------
-
-
-def _infer_screen_size(
-    elements: List[Dict[str, Any]],
-) -> Tuple[int, int]:
-    """Best-effort screen dimensions from element bounds.
-
-    Falls back to iPhone 14 dimensions if no elements are available.
-    """
-    max_right = 0
-    max_bottom = 0
-    for el in elements:
-        bounds = el.get("bounds", "")
-        if not bounds:
-            continue
-        parts = bounds.split(",")
-        if len(parts) == 4:
-            max_right = max(max_right, int(float(parts[2])))
-            max_bottom = max(max_bottom, int(float(parts[3])))
-    if max_right > 0 and max_bottom > 0:
-        return max_right, max_bottom
-    # TODO: hardcoded iPhone 14 fallback — no portal endpoint for screen size
-    return 390, 844
 
 
 # ---------------------------------------------------------------------------

--- a/droidrun/tools/ui/provider.py
+++ b/droidrun/tools/ui/provider.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
 
 from droidrun.tools.driver.base import DeviceDisconnectedError
@@ -61,11 +62,18 @@ async def fetch_state_with_retry(
     last_error: Optional[Exception] = None
     recovery_attempted = False
 
+    is_debug = logger.isEnabledFor(logging.DEBUG)
+
     for attempt in range(max_retries):
         try:
             logger.debug(f"Getting state (attempt {attempt + 1}/{max_retries})")
 
+            t0 = time.monotonic() if is_debug else 0
             combined_data = await fetch()
+
+            if is_debug:
+                elapsed = (time.monotonic() - t0) * 1000
+                logger.debug(f"State fetched in {elapsed:.0f}ms")
 
             if "error" in combined_data:
                 raise Exception(f"Portal returned error: {combined_data}")
@@ -84,8 +92,11 @@ async def fetch_state_with_retry(
             is_last = attempt >= max_retries - 1
             delay = delays[attempt] if attempt < len(delays) else delays[-1]
 
+            err_desc = str(e) or type(e).__name__
             suffix = f" (retrying in {delay:.0f}s)" if not is_last else ""
-            logger.warning(f"get_state attempt {attempt + 1} failed: {e}{suffix}")
+            logger.warning(
+                f"get_state attempt {attempt + 1} failed: {err_desc}{suffix}"
+            )
 
             # Mid-retry recovery: restart the a11y service once
             if (
@@ -105,7 +116,8 @@ async def fetch_state_with_retry(
             if not is_last:
                 await asyncio.sleep(delay)
 
-    error_msg = f"Failed to get state after {max_retries} attempts: {last_error}"
+    last_desc = str(last_error) or type(last_error).__name__
+    error_msg = f"Failed to get state after {max_retries} attempts: {last_desc}"
     logger.error(error_msg)
     raise Exception(error_msg) from last_error
 

--- a/uv.lock
+++ b/uv.lock
@@ -760,7 +760,7 @@ wheels = [
 
 [[package]]
 name = "droidrun"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- **Unified iOS state endpoint**: Replaced separate `/vision/a11y` + `/vision/state` calls with a single `/state_full` endpoint, updated provider to use `fetch_state_with_retry()`
- **iOS driver improvements**: Coordinate-based swipe, `clear` support in `input_text`, `back` button, `get_date` endpoint, removed `_last_tapped_rect` workaround
- **Robust phone state display**: `update_current_app()` won't overwrite known values with empty strings; formatter gracefully handles missing package/activity