### PR TITLE
fix(android): restore full portal state and bump version to 0.5.7

### DIFF
--- a/droidrun/tools/android/portal_client.py
+++ b/droidrun/tools/android/portal_client.py
@@ -355,7 +355,7 @@ class PortalClient:
         try:
             async with httpx.AsyncClient() as client:
                 response = await self._tcp_request(
-                    client, "GET", f"{self.tcp_base_url}/state", timeout=10
+                    client, "GET", f"{self.tcp_base_url}/state_full", timeout=10
                 )
                 if response.status_code == 200:
                     data = response.json()
@@ -391,7 +391,7 @@ class PortalClient:
         """Get state via content provider (fallback)."""
         try:
             output = await self.device.shell(
-                "content query --uri content://com.droidrun.portal/state"
+                "content query --uri content://com.droidrun.portal/state_full"
             )
             state_data = self._parse_content_provider_output(output)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "droidrun"
-version = "0.5.6"
+version = "0.5.7"
 description = "A framework for controlling Android devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels.schmidt@droidrun.ai" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -760,7 +760,7 @@ wheels = [
 
 [[package]]
 name = "droidrun"
-version = "0.5.6"
+version = "0.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- restore Android portal state fetches to `state_full` for both TCP and content-provider paths
- fix the regression where `device_context` went missing in `droidrun doctor` and state loading
- bump the package version to `0.5.7`

## Verification
- ran `uv sync`
- verified the environment updated from `droidrun==0.5.6` to `droidrun==0.5.7`

## Context
The Android client was switched from `state_full` to `state`, but the rest of the SDK still requires `device_context` in the returned payload. This restores the previous Android behavior.
