### PR TITLE
fix: support renamed portal APK asset in latest release

### DIFF
--- a/droidrun/portal.py
+++ b/droidrun/portal.py
@@ -167,7 +167,7 @@ def download_portal_apk(debug: bool = False):
         if (
             "browser_download_url" in asset
             and "name" in asset
-            and asset["name"].startswith(ASSET_NAME)
+        and (asset["name"].startswith(ASSET_NAME) or asset["name"].startswith(PORTAL_PACKAGE_NAME))
         ):
             asset_url = asset["browser_download_url"]
             asset_version = asset["name"].split("-")[-1]


### PR DESCRIPTION
The portal APK asset name changed from `droidrun-portal...` to `com.droidrun.portal...`.

This patch updates the asset matching logic so portal APK download still works with the new release naming.
