### PR TITLE
chore(release): bump mobilerun to 0.6.0rc2

### DIFF
--- a/compat/pyproject.toml
+++ b/compat/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "droidrun"
-version = "0.6.0rc1"
+version = "0.6.0rc2"
 description = "Compatibility shim — droidrun has been renamed to mobilerun"
 requires-python = ">=3.11,<3.14"
-dependencies = ["mobilerun==0.6.0rc1"]
+dependencies = ["mobilerun==0.6.0rc2"]
 
 [project.optional-dependencies]
-anthropic = ["mobilerun[anthropic]==0.6.0rc1"]
-deepseek = ["mobilerun[deepseek]==0.6.0rc1"]
-langfuse = ["mobilerun[langfuse]==0.6.0rc1"]
-dev = ["mobilerun[dev]==0.6.0rc1"]
+anthropic = ["mobilerun[anthropic]==0.6.0rc2"]
+deepseek = ["mobilerun[deepseek]==0.6.0rc2"]
+langfuse = ["mobilerun[langfuse]==0.6.0rc2"]
+dev = ["mobilerun[dev]==0.6.0rc2"]
 
 [project.scripts]
 droidrun = "droidrun.cli_shim:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mobilerun"
-version = "0.6.0rc1"
+version = "0.6.0rc2"
 description = "A framework for controlling mobile devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels@droidrun.ai" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1881,7 +1881,7 @@ wheels = [
 
 [[package]]
 name = "mobilerun"
-version = "0.6.0rc1"
+version = "0.6.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Bump the root `mobilerun` package version to `0.6.0rc2`.
- Bump the `droidrun` compatibility shim version and all `mobilerun==...` pins to `0.6.0rc2`.
- Refresh `uv.lock`.

## Why
This publishes the merged portal runtime/download fix under a new release candidate. The existing `v0.6.0rc1` tag already points before that fix and should not be reused.

## Validation
- `rg -n "0\\.6\\.0rc1|mobilerun==0\\.6\\.0rc1" pyproject.toml compat/pyproject.toml uv.lock` returned no matches.
- `uv lock --check` passed.
- Root and compat versions match `0.6.0rc2`; compat pins `mobilerun==0.6.0rc2`.
- `python3 -m unittest discover -s tests` passed.
- `python3 -m py_compile ...` passed for portal/CLI paths and asset-selection tests.
- `uv run mobilerun --version` prints `v0.6.0rc2`.
- Built root package with `uv run --with build python -m build --outdir /tmp/mobilerun-0.6.0rc2-dist`.
- Built compat shim with `uv run --with build python -m build compat/ --outdir /tmp/droidrun-0.6.0rc2-dist`.