### PR TITLE
Add direct structured output schema API

### DIFF
--- a/docs/features/structured-output.mdx
+++ b/docs/features/structured-output.mdx
@@ -84,6 +84,28 @@ print(f"Invoice {invoice.invoice_number}: ${invoice.total_due}")
 
 ## Working with Results
 
+### Direct Model Return
+
+If you prefer `await agent.run()` to return your Pydantic model directly, configure
+the schema with `set_output_schema()`:
+
+```python
+from pydantic import BaseModel
+
+class AgentResponse(BaseModel):
+    success: bool
+    output: str | None = None
+
+agent = MobileAgent(
+    goal="Check whether the current screen shows a successful login",
+    config=MobileConfig(),
+)
+agent.set_output_schema(AgentResponse)
+
+response = await agent.run()
+print(response.success)
+```
+
 ### Accessing Data
 
 ```python

--- a/docs/sdk/droid-agent.mdx
+++ b/docs/sdk/droid-agent.mdx
@@ -220,12 +220,26 @@ if result.success and result.structured_output:
     print(f"Condition: {weather.condition}")
 ```
 
+You can also use `set_output_schema()` when you want `await agent.run()` to
+return the Pydantic model directly:
+
+```python
+agent = MobileAgent(
+    goal="Open weather app and get current weather",
+    config=config,
+)
+agent.set_output_schema(WeatherInfo)
+
+weather: WeatherInfo = await agent.run()
+print(weather.temperature)
+```
+
 <a id="mobilerun.agent.droid.droid_agent.MobileAgent.run"></a>
 
 #### MobileAgent.run
 
 ```python
-async def run(*args, **kwargs) -> ResultEvent
+async def run(*args, **kwargs) -> ResultEvent | BaseModel
 ```
 
 Run the MobileAgent workflow.
@@ -237,6 +251,7 @@ Run the MobileAgent workflow.
   - `reason` (str): Success message or failure reason
   - `steps` (int): Number of steps executed
   - `structured_output` (Any): Parsed Pydantic model (if output_model provided, otherwise None)
+- The configured Pydantic model directly when `set_output_schema()` was used
 
 **Usage:**
 

--- a/mobilerun/agent/droid/droid_agent.py
+++ b/mobilerun/agent/droid/droid_agent.py
@@ -10,7 +10,7 @@ Architecture:
 import logging
 import os
 import traceback
-from typing import TYPE_CHECKING, Awaitable, Type, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Type, Union
 
 from async_adbutils import adb
 from llama_index.core.llms.llm import LLM
@@ -100,6 +100,38 @@ logger = logging.getLogger("mobilerun")
 _COORDINATE_TOOL_NAMES = {"click_at", "click_area", "long_press_at"}
 
 
+class _StructuredOutputHandler:
+    """Awaitable wrapper that returns the parsed Pydantic output directly."""
+
+    def __init__(self, handler: WorkflowHandler, output_model: Type[BaseModel]):
+        self._handler = handler
+        self._output_model = output_model
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._handler, name)
+
+    def __await__(self):
+        return self._await_structured_output().__await__()
+
+    async def _await_structured_output(self) -> BaseModel:
+        result = await self._handler
+        structured_output = getattr(result, "structured_output", None)
+
+        if isinstance(structured_output, self._output_model):
+            return structured_output
+
+        if structured_output is None:
+            raise ValueError(
+                "Structured output was requested, but no structured output was "
+                f"produced. Final result: {getattr(result, 'reason', result)!r}"
+            )
+
+        raise TypeError(
+            "Structured output was produced, but it does not match "
+            f"{self._output_model.__name__}: {type(structured_output).__name__}"
+        )
+
+
 def _normalize_control_backend(control_backend: str | None) -> str | None:
     if control_backend is None:
         return None
@@ -171,6 +203,7 @@ class MobileAgent(Workflow):
             runtype=self.runtype,
         )
         self.output_model = output_model
+        self._return_structured_output_directly = False
 
         # Initialize prompt resolver for custom prompts
         self.prompt_resolver = PromptResolver(custom_prompts=prompts)
@@ -351,9 +384,32 @@ class MobileAgent(Workflow):
 
         logger.debug("✅ MobileAgent initialized successfully.")
 
-    def run(self, *args, **kwargs) -> Awaitable[ResultEvent] | WorkflowHandler:
+    def set_output_schema(self, output_model: Type[BaseModel]) -> "MobileAgent":
+        """
+        Configure a Pydantic schema and make await agent.run() return that model.
+
+        The constructor-level output_model keeps the existing ResultEvent return
+        shape. This setter enables the concise API requested by users:
+        agent.set_output_schema(MyModel); response = await agent.run().
+        """
+        if not isinstance(output_model, type) or not issubclass(output_model, BaseModel):
+            raise TypeError("output_model must be a Pydantic BaseModel subclass")
+
+        self.output_model = output_model
+        self._return_structured_output_directly = True
+
+        if self.manager_agent is not None:
+            self.manager_agent.output_model = output_model
+
+        return self
+
+    def run(
+        self, *args, **kwargs
+    ) -> Awaitable[ResultEvent | BaseModel] | WorkflowHandler | _StructuredOutputHandler:
         apply_session_context()
         handler = super().run(*args, **kwargs)  # type: ignore[assignment]
+        if self._return_structured_output_directly and self.output_model is not None:
+            return _StructuredOutputHandler(handler, self.output_model)
         return handler
 
     # ========================================================================

--- a/tests/test_structured_output_api.py
+++ b/tests/test_structured_output_api.py
@@ -1,0 +1,87 @@
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from pydantic import BaseModel
+
+from mobilerun.agent.droid.droid_agent import MobileAgent, _StructuredOutputHandler
+
+
+class AgentResponse(BaseModel):
+    success: bool
+    output: str | None = None
+
+
+class FakeHandler:
+    def __init__(self, result):
+        self.result = result
+        self.delegated_attribute = "delegated"
+
+    async def stream_events(self):
+        yield "event"
+
+    def __await__(self):
+        async def done():
+            return self.result
+
+        return done().__await__()
+
+
+async def _await(awaitable):
+    return await awaitable
+
+
+class StructuredOutputApiTest(unittest.TestCase):
+    def test_wrapper_returns_model_directly_and_delegates_handler_api(self):
+        model = AgentResponse(success=True, output="done")
+        result = SimpleNamespace(structured_output=model, reason="done")
+        handler = _StructuredOutputHandler(FakeHandler(result), AgentResponse)
+
+        async def collect_events():
+            return [event async for event in handler.stream_events()]
+
+        self.assertEqual(handler.delegated_attribute, "delegated")
+        self.assertEqual(asyncio.run(collect_events()), ["event"])
+        self.assertIs(asyncio.run(_await(handler)), model)
+
+    def test_wrapper_raises_when_structured_output_is_missing(self):
+        result = SimpleNamespace(structured_output=None, reason="not enough data")
+        handler = _StructuredOutputHandler(FakeHandler(result), AgentResponse)
+
+        with self.assertRaisesRegex(ValueError, "no structured output was produced"):
+            asyncio.run(_await(handler))
+
+    def test_wrapper_raises_when_structured_output_has_wrong_type(self):
+        result = SimpleNamespace(
+            structured_output=SimpleNamespace(success=True),
+            reason="done",
+        )
+        handler = _StructuredOutputHandler(FakeHandler(result), AgentResponse)
+
+        with self.assertRaisesRegex(TypeError, "does not match AgentResponse"):
+            asyncio.run(_await(handler))
+
+    def test_set_output_schema_enables_direct_model_return_and_updates_manager(self):
+        manager_agent = SimpleNamespace(output_model=None)
+        agent = object.__new__(MobileAgent)
+        agent.manager_agent = manager_agent
+        agent.output_model = None
+        agent._return_structured_output_directly = False
+
+        returned = MobileAgent.set_output_schema(agent, AgentResponse)
+
+        self.assertIs(returned, agent)
+        self.assertIs(agent.output_model, AgentResponse)
+        self.assertIs(manager_agent.output_model, AgentResponse)
+        self.assertTrue(agent._return_structured_output_directly)
+
+    def test_set_output_schema_rejects_non_pydantic_models(self):
+        agent = object.__new__(MobileAgent)
+        agent.manager_agent = None
+
+        with self.assertRaisesRegex(TypeError, "BaseModel subclass"):
+            MobileAgent.set_output_schema(agent, dict)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #125.

## Summary
- adds `MobileAgent.set_output_schema()` for the issue's direct Pydantic schema API
- preserves the existing `output_model=...` behavior that returns `ResultEvent`
- wraps the workflow handler only for `set_output_schema()` so `await agent.run()` returns the parsed Pydantic model directly
- documents the direct-return API and adds unit coverage

## Validation
- `/Users/manuelsampedro/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m unittest tests.test_structured_output_api`
- `/Users/manuelsampedro/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m unittest discover -s tests`
- `/Users/manuelsampedro/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m compileall -q mobilerun tests`
- `git diff --check`