### PR TITLE
Add env and file credential sources

### DIFF
--- a/docs/features/credentials.mdx
+++ b/docs/features/credentials.mdx
@@ -6,7 +6,7 @@ description: 'Extend Mobilerun with secure credential management'
 ## Overview
 
 Secure storage for passwords, API keys, and tokens.
-- Stored in YAML files or in-memory dicts
+- Stored in YAML files, in-memory dicts, environment variables, or local secret files
 - Never logged or exposed
 - Auto-injected as `type_secret` action
 - Simple string or dict format
@@ -55,6 +55,14 @@ secrets:
   GMAIL_PASSWORD:
     value: "gmail_pass_123"
     enabled: true
+
+  # Environment variable source
+  APP_USERNAME:
+    env: MY_APP_USERNAME
+
+  # Local secret file source (the file contents are read and stripped)
+  APP_PASSWORD:
+    file: ~/.config/my-app/password
 
   # Simple string format (auto-enabled)
   API_KEY: "sk-1234567890abcdef"
@@ -125,8 +133,8 @@ from mobilerun import MobileAgent, MobileConfig
 
 async def main():
     credentials = {
-        "EMAIL_USER": "user@example.com",
-        "EMAIL_PASS": "secret_password"
+        "EMAIL_USER": {"env": "EMAIL_USER"},
+        "EMAIL_PASS": {"file": "~/.config/email/password"}
     }
 
     config = MobileConfig()
@@ -156,7 +164,7 @@ asyncio.run(main())
 | Feature | Credentials | Variables |
 |---------|------------|-----------|
 | **Purpose** | Passwords, API keys | Non-sensitive data |
-| **Storage** | YAML or in-memory | In-memory only |
+| **Storage** | YAML, in-memory, env, or file | In-memory only |
 | **Logging** | Never logged | May appear in logs |
 | **Access** | Via `type_secret` tool | In shared state |
 | **Security** | Protected | No protection |

--- a/docs/sdk/droid-agent.mdx
+++ b/docs/sdk/droid-agent.mdx
@@ -49,7 +49,7 @@ Initialize the MobileAgent wrapper.
   - `LLM`: Single LLM instance used for all agents
   - `None`: LLMs will be loaded from config.llm_profiles
 - `custom_tools` _dict_ - Custom tool definitions. Format: `{"tool_name": {"parameters": {...}, "description": "...", "function": callable}}`. These are merged with auto-generated credential tools.
-- `credentials` _Union[dict, CredentialManager, None]_ - Direct credential mapping `{"SECRET_ID": "value"}`, a CredentialManager instance, or None. If None, credentials will be loaded from config.credentials if available.
+- `credentials` _Union[dict, CredentialManager, None]_ - Direct credential mapping `{"SECRET_ID": "value"}`, source mapping such as `{"SECRET_ID": {"env": "ENV_VAR"}}` or `{"SECRET_ID": {"file": "/path/to/secret"}}`, a CredentialManager instance, or None. If None, credentials will be loaded from config.credentials if available.
 - `variables` _dict | None_ - Custom variables accessible throughout execution. Available in shared_state.custom_variables.
 - `output_model` _Type[BaseModel] | None_ - Pydantic model for structured output extraction from final answer. If provided, the final answer will be parsed into this model.
 - `prompts` _dict[str, str] | None_ - Custom Jinja2 prompt templates to override defaults. Keys: "fast_agent_system", "fast_agent_user", "manager_system", "executor_system". Values: Jinja2 template strings (NOT file paths).

--- a/mobilerun/config/credentials_example.yaml
+++ b/mobilerun/config/credentials_example.yaml
@@ -24,6 +24,20 @@ secrets:
     value: "example_password"
     enabled: true
 
+  # === Environment Variable Source ===
+  # Reads from os.environ without storing the value in this YAML file
+
+  APP_USERNAME:
+    env: MY_APP_USERNAME
+    enabled: true
+
+  # === Local Secret File Source ===
+  # Reads and strips the file contents at runtime
+
+  APP_PASSWORD:
+    file: ~/.config/my-app/password
+    enabled: true
+
   # === Simple String Format ===
   # Automatically enabled when loaded
 
@@ -63,10 +77,12 @@ secrets:
 
 # === File Format Notes ===
 #
-# Valid value types:
-# - Strings (required)
-# - Empty strings are filtered out
-# - Whitespace-only values are filtered out
+# Valid source types:
+# - String values (auto-enabled)
+# - Dict with value: "secret"
+# - Dict with env: ENVIRONMENT_VARIABLE_NAME
+# - Dict with file: /path/to/secret/file
+# - Empty values are filtered out
 #
 # Invalid value types (will be skipped with warning):
 # - Integers

--- a/mobilerun/credential_manager/file_credential_manager.py
+++ b/mobilerun/credential_manager/file_credential_manager.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Any, Dict, Optional
 
 import yaml
@@ -15,6 +16,9 @@ logger = logging.getLogger("mobilerun")
 class FileCredentialManager(CredentialManager):
     """
     Credential manager that supports both dict and YAML file sources.
+
+    Secret values can be provided directly, read from environment variables, or
+    read from local secret files.
     """
 
     def __init__(self, credentials: Any):
@@ -59,13 +63,10 @@ class FileCredentialManager(CredentialManager):
     def _load_from_dict(self, credentials_dict: dict) -> Dict[str, str]:
         """Load credentials from in-memory dict."""
         secrets = {}
-        for secret_id, secret_value in credentials_dict.items():
-            if isinstance(secret_value, str) and secret_value:
-                secrets[secret_id] = secret_value
-            else:
-                logger.warning(
-                    f"Skipped invalid secret: {secret_id} (type={type(secret_value)})"
-                )
+        for secret_id, secret_data in credentials_dict.items():
+            value = self._resolve_secret_data(secret_id, secret_data)
+            if value:
+                secrets[secret_id] = value
         return secrets
 
     def _load_from_file(self, file_path: str) -> Dict[str, str]:
@@ -77,6 +78,10 @@ class FileCredentialManager(CredentialManager):
               MY_PASSWORD:
                 value: "secret123"
                 enabled: true
+              USERNAME:
+                env: APP_USERNAME
+              TOKEN:
+                file: ~/.config/my-app/token
               SIMPLE_KEY: "simple_value"  # Auto-enabled
 
         Returns:
@@ -92,22 +97,72 @@ class FileCredentialManager(CredentialManager):
 
         secrets = {}
         for secret_id, secret_data in data["secrets"].items():
-            if isinstance(secret_data, dict):
-                enabled = secret_data.get("enabled", True)
-                value = secret_data.get("value", "")
-            else:
-                enabled = True
-                value = secret_data
-
-            if enabled and value:
+            value = self._resolve_secret_data(secret_id, secret_data)
+            if value:
                 secrets[secret_id] = value
                 logger.debug(f"Loaded secret: {secret_id}")
-            else:
-                logger.debug(
-                    f"Skipped secret: {secret_id} (enabled={enabled}, has_value={bool(value)})"
-                )
 
         return secrets
+
+    def _resolve_secret_data(self, secret_id: str, secret_data: Any) -> Optional[str]:
+        """Resolve a secret entry without logging the resolved value."""
+        if isinstance(secret_data, str):
+            return secret_data or None
+
+        if not isinstance(secret_data, dict):
+            logger.warning(
+                f"Skipped invalid secret: {secret_id} (type={type(secret_data)})"
+            )
+            return None
+
+        enabled = secret_data.get("enabled", True)
+        if not enabled:
+            logger.debug(f"Skipped disabled secret: {secret_id}")
+            return None
+
+        if "value" in secret_data:
+            value = secret_data.get("value", "")
+            if isinstance(value, str) and value:
+                return value
+            logger.warning(f"Skipped secret '{secret_id}': empty or invalid value")
+            return None
+
+        if "env" in secret_data:
+            env_name = secret_data.get("env")
+            if not isinstance(env_name, str) or not env_name:
+                logger.warning(f"Skipped secret '{secret_id}': invalid env source")
+                return None
+            value = os.environ.get(env_name, "")
+            if value:
+                return value
+            logger.warning(
+                f"Skipped secret '{secret_id}': environment variable '{env_name}' is not set"
+            )
+            return None
+
+        if "file" in secret_data:
+            source_path = secret_data.get("file")
+            if not isinstance(source_path, str) or not source_path:
+                logger.warning(f"Skipped secret '{secret_id}': invalid file source")
+                return None
+            try:
+                resolved_path = PathResolver.resolve(source_path, must_exist=True)
+                with open(resolved_path, "r") as f:
+                    value = f.read().strip()
+            except Exception as exc:
+                logger.warning(
+                    f"Skipped secret '{secret_id}': could not read file source ({exc})"
+                )
+                return None
+            if value:
+                return value
+            logger.warning(f"Skipped secret '{secret_id}': file source is empty")
+            return None
+
+        logger.warning(
+            f"Skipped secret '{secret_id}': expected one of value, env, or file"
+        )
+        return None
 
     async def resolve_key(self, key: str) -> str:
         """Get secret value by key."""

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,129 @@
+import asyncio
+import os
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from mobilerun.agent.utils.actions import type_secret
+from mobilerun.agent.utils.signatures import build_tool_registry
+from mobilerun.credential_manager import FileCredentialManager
+
+
+class DummyDriver:
+    def __init__(self):
+        self.taps = []
+        self.inputs = []
+
+    async def tap(self, x, y):
+        self.taps.append((x, y))
+
+    async def input_text(self, text):
+        self.inputs.append(text)
+        return True
+
+
+class DummyUI:
+    def get_element_coords(self, index):
+        return (index * 10, index * 20)
+
+
+class FileCredentialManagerTest(unittest.TestCase):
+    def test_loads_direct_env_and_file_sources_from_dict(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            token_path = Path(tmpdir) / "token.txt"
+            token_path.write_text("file-token\n")
+
+            with patch.dict(os.environ, {"APP_USERNAME": "env-user"}, clear=False):
+                manager = FileCredentialManager(
+                    {
+                        "DIRECT": "plain-secret",
+                        "ENV_USER": {"env": "APP_USERNAME"},
+                        "FILE_TOKEN": {"file": str(token_path)},
+                        "DISABLED": {"value": "ignored", "enabled": False},
+                    }
+                )
+
+            self.assertEqual(
+                asyncio.run(manager.get_keys()),
+                ["DIRECT", "ENV_USER", "FILE_TOKEN"],
+            )
+            self.assertEqual(asyncio.run(manager.resolve_key("DIRECT")), "plain-secret")
+            self.assertEqual(asyncio.run(manager.resolve_key("ENV_USER")), "env-user")
+            self.assertEqual(
+                asyncio.run(manager.resolve_key("FILE_TOKEN")), "file-token"
+            )
+
+    def test_loads_env_and_file_sources_from_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            secret_path = tmp_path / "password.txt"
+            secret_path.write_text("file-password\n")
+            credentials_path = tmp_path / "credentials.yaml"
+            credentials_path.write_text(
+                textwrap.dedent(
+                    f"""
+                    secrets:
+                      APP_USER:
+                        env: LOGIN_USER
+                      APP_PASSWORD:
+                        file: {secret_path}
+                      INLINE:
+                        value: inline-secret
+                      SKIPPED:
+                        env: MISSING_LOGIN_USER
+                    """
+                ).strip()
+            )
+
+            with (
+                patch.dict(os.environ, {"LOGIN_USER": "yaml-user"}, clear=False),
+                self.assertLogs("mobilerun", level="WARNING") as captured,
+            ):
+                manager = FileCredentialManager(str(credentials_path))
+
+            self.assertEqual(
+                asyncio.run(manager.get_keys()),
+                ["APP_USER", "APP_PASSWORD", "INLINE"],
+            )
+            self.assertIn("MISSING_LOGIN_USER", "\n".join(captured.output))
+            self.assertEqual(asyncio.run(manager.resolve_key("APP_USER")), "yaml-user")
+            self.assertEqual(
+                asyncio.run(manager.resolve_key("APP_PASSWORD")), "file-password"
+            )
+
+    def test_type_secret_uses_value_without_exposing_it_in_result(self):
+        manager = FileCredentialManager({"PASSWORD": "super-secret"})
+        driver = DummyDriver()
+        ctx = SimpleNamespace(
+            credential_manager=manager,
+            ui=DummyUI(),
+            driver=driver,
+        )
+
+        result = asyncio.run(type_secret("PASSWORD", 3, ctx=ctx))
+
+        self.assertTrue(result.success)
+        self.assertEqual(driver.taps, [(30, 60)])
+        self.assertEqual(driver.inputs, ["super-secret"])
+        self.assertIn("PASSWORD", result.summary)
+        self.assertNotIn("super-secret", result.summary)
+
+    def test_tool_registry_description_does_not_include_secret_values(self):
+        manager = FileCredentialManager({"PASSWORD": "super-secret"})
+
+        registry, standard_tool_names = asyncio.run(
+            build_tool_registry(credential_manager=manager)
+        )
+
+        self.assertIn("type_secret", registry.tools)
+        self.assertIn("type_secret", standard_tool_names)
+        descriptions = registry.get_tool_descriptions_text()
+        self.assertIn("type_secret", descriptions)
+        self.assertNotIn("super-secret", descriptions)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #127

## Summary
- extend `FileCredentialManager` so secrets can be sourced from direct values, environment variables, or local secret files
- support the same source mapping in SDK-provided credential dictionaries and YAML credential files
- document the new formats and add regression coverage for secret loading plus `type_secret` redaction behavior

## Validation
- `/Users/manuelsampedro/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m unittest tests.test_credentials`
- `/Users/manuelsampedro/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m compileall -q mobilerun tests`
- `git diff --check`
- `/Users/manuelsampedro/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m unittest discover -s tests`