### PR TITLE
fix(deps): bump llama-index-workflows to >=2.16.0 for Langfuse support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "arize-phoenix>=12.3.0",
     "httpx>=0.27.0",
     "llama-index-callbacks-arize-phoenix>=0.6.1",
-    "llama-index-workflows==2.8.3",
+    "llama-index-workflows>=2.16.0",
     "aiofiles>=25.1.0",
     "textual>=6.11.0",
     "mcp>=1.26.0",


### PR DESCRIPTION
## Problem

`mobilerun[langfuse]` fails with an `ImportError` for all users because `llama-index-workflows` is pinned to `==2.8.3`, which is missing modules required by the Langfuse integration:

1. `workflows.runtime` — added in **2.10.0**
2. `workflows.runtime.types.step_function.SpanCancelledEvent` — required by `openinference-instrumentation-llama-index`, added in **2.16.0**

Error seen:
```
⚠️  Langfuse dependencies are not installed.
    Missing: workflows.runtime
```

## Fix

Relax the pin from `==2.8.3` to `>=2.16.0`.

## Tested

- Verified `workflows.runtime` and `openinference.instrumentation.llama_index._handler` import cleanly with `llama-index-workflows==2.16.0`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)