### PR TITLE
v0.6.0rc5: backfill cloud screen_bounds in CloudDriver

### DIFF
--- a/compat/pyproject.toml
+++ b/compat/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "droidrun"
-version = "0.6.0rc4"
+version = "0.6.0rc5"
 description = "Compatibility shim — droidrun has been renamed to mobilerun"
 requires-python = ">=3.11,<3.14"
-dependencies = ["mobilerun==0.6.0rc4"]
+dependencies = ["mobilerun==0.6.0rc5"]
 
 [project.optional-dependencies]
-anthropic = ["mobilerun[anthropic]==0.6.0rc4"]
-deepseek = ["mobilerun[deepseek]==0.6.0rc4"]
-langfuse = ["mobilerun[langfuse]==0.6.0rc4"]
-dev = ["mobilerun[dev]==0.6.0rc4"]
+anthropic = ["mobilerun[anthropic]==0.6.0rc5"]
+deepseek = ["mobilerun[deepseek]==0.6.0rc5"]
+langfuse = ["mobilerun[langfuse]==0.6.0rc5"]
+dev = ["mobilerun[dev]==0.6.0rc5"]
 
 [project.scripts]
 droidrun = "droidrun.cli_shim:main"

--- a/mobilerun/tools/driver/cloud.py
+++ b/mobilerun/tools/driver/cloud.py
@@ -230,7 +230,28 @@ class CloudDriver(DeviceDriver):
         response = await self._call(
             self._client.devices.state.ui(self.device_id, **self._display_kw)
         )
-        return response.model_dump()
+        data = response.model_dump()
+        self._ensure_screen_bounds(data)
+        return data
+
+    @staticmethod
+    def _ensure_screen_bounds(data: Dict[str, Any]) -> None:
+        """Backfill screen size from the root node when the cloud omits it.
+
+        Cloud state can report ``screen_bounds`` as ``{width: 0, height: 0}``,
+        which makes screen-intersection filtering drop every element. Derive
+        the real size from the root a11y node's bounds instead.
+        """
+        ctx = data.get("device_context") or {}
+        bounds = ctx.get("screen_bounds") or {}
+        if bounds.get("width") and bounds.get("height"):
+            return
+        root_bounds = (data.get("a11y_tree") or {}).get("boundsInScreen") or {}
+        width = root_bounds.get("right", 0) - root_bounds.get("left", 0)
+        height = root_bounds.get("bottom", 0) - root_bounds.get("top", 0)
+        if width > 0 and height > 0:
+            ctx["screen_bounds"] = {"width": width, "height": height}
+            data["device_context"] = ctx
 
     async def get_date(self) -> str:
         return await self._call(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mobilerun"
-version = "0.6.0rc4"
+version = "0.6.0rc5"
 description = "A framework for controlling mobile devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels@droidrun.ai" }]
 dependencies = [


### PR DESCRIPTION
## Summary

- **Hotfix for the dev cloud environment.** `dev-api.mobilerun.ai`
  returns `device_context.screen_bounds = {width:0, height:0}` for at
  least some devices. The shared `ConciseFilter` / `DetailedFilter` then
  treats those zeros as authoritative screen dimensions and discards
  every element in the UI tree (root node fails the
  intersection test), surfacing as *"No UI elements found"* downstream.
- `CloudDriver.get_ui_tree()` now backfills `screen_bounds` from the
  root a11y node's `boundsInScreen` when the API returns missing /
  zero dimensions. Verified against the live dev device.
- **Backwards compatible.** Verified on prod (`api.mobilerun.ai`) too:
  the early-return guard sees real bounds (e.g. 1260×2800) and skips
  the backfill — net zero effect on prod's existing behaviour.
- Bumps `mobilerun` + `droidrun` (compat shim) to `0.6.0rc5`.

## Why this matters

The task-API consuming `mobilerun` against dev is currently broken —
its agent sees an empty UI tree on every step. This release unblocks
it without shipping any of the in-progress CLI / login / stream work.

## Test plan

- [ ] CI green
- [ ] Tag `v0.6.0rc5` after merge → `publish.yml` validates version +
      compat alignment, publishes to PyPI
- [ ] Bump task-api dep to `mobilerun==0.6.0rc5` and re-run on dev