### PR TITLE
fix(anthropic_oauth): always send max_tokens; skip temperature for Opus 4; default to Opus 4.7

### DIFF
--- a/mobilerun/agent/providers/registry.py
+++ b/mobilerun/agent/providers/registry.py
@@ -104,8 +104,9 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 id="anthropic_oauth",
                 runtime_provider_name="anthropic_oauth",
                 auth_mode="oauth",
-                default_model="claude-sonnet-4-6",
+                default_model="claude-opus-4-7",
                 models=(
+                    "claude-opus-4-7",
                     "claude-sonnet-4-6",
                     "claude-opus-4-6",
                     "claude-haiku-4-5",

--- a/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
@@ -32,6 +32,7 @@ from llama_index.core.llms.custom import CustomLLM
 from mobilerun.config_manager.credential_paths import ANTHROPIC_OAUTH_CREDENTIAL_PATH
 
 DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_MAX_TOKENS = 4096
 DEFAULT_API_BASE = "https://api.anthropic.com"
 DEFAULT_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 DEFAULT_AUTHORIZE_URL = "https://platform.claude.com/oauth/authorize"
@@ -114,7 +115,7 @@ class AnthropicOAuthLLM(CustomLLM):
     """Anthropic OAuth-backed LLM using Claude subscription OAuth tokens."""
 
     model: str = Field(default=DEFAULT_MODEL, description="Anthropic model id.")
-    max_tokens: Optional[int] = Field(default=None, gt=0)
+    max_tokens: Optional[int] = Field(default=DEFAULT_MAX_TOKENS, gt=0)
     temperature: float = Field(default=DEFAULT_TEMPERATURE, ge=0.0, le=2.0)
     timeout: float = Field(default=30.0, gt=0)
 
@@ -155,7 +156,7 @@ class AnthropicOAuthLLM(CustomLLM):
         self,
         model: str = DEFAULT_MODEL,
         *,
-        max_tokens: Optional[int] = None,
+        max_tokens: Optional[int] = DEFAULT_MAX_TOKENS,
         temperature: float = DEFAULT_TEMPERATURE,
         timeout: float = 30.0,
         access_token: Optional[str] = None,
@@ -699,6 +700,16 @@ class AnthropicOAuthLLM(CustomLLM):
             return False
         return not model_id.startswith("claude-haiku")
 
+    @staticmethod
+    def _supports_temperature(model_id: str) -> bool:
+        """Anthropic deprecated `temperature` on the Claude 4 Opus family.
+
+        Sending it returns 400 "`temperature` is deprecated for this model."
+        Callers that explicitly want to override this can still pass
+        `temperature` via `additional_kwargs` or per-call kwargs.
+        """
+        return not model_id.startswith("claude-opus-4")
+
     def _system_blocks(
         self, user_system_lines: Sequence[str], model_id: str
     ) -> list[dict[str, str]]:
@@ -729,9 +740,10 @@ class AnthropicOAuthLLM(CustomLLM):
 
         payload: Dict[str, Any] = {
             "model": self.model,
-            "temperature": self.temperature,
             "messages": provider_messages,
         }
+        if self._supports_temperature(self.model):
+            payload["temperature"] = self.temperature
         if self.max_tokens is not None:
             payload["max_tokens"] = self.max_tokens
         system_blocks = self._system_blocks(system_lines, self.model)

--- a/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
@@ -31,7 +31,7 @@ from llama_index.core.llms.custom import CustomLLM
 
 from mobilerun.config_manager.credential_paths import ANTHROPIC_OAUTH_CREDENTIAL_PATH
 
-DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_MODEL = "claude-opus-4-7"
 DEFAULT_MAX_TOKENS = 4096
 DEFAULT_API_BASE = "https://api.anthropic.com"
 DEFAULT_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"


### PR DESCRIPTION
## Problem

`AnthropicOAuthLLM` currently fails against Anthropic's `/v1/messages` endpoint in two situations:

### 1. `max_tokens` always missing

```python
max_tokens: Optional[int] = Field(default=None, gt=0)
...
if self.max_tokens is not None:
    payload[\"max_tokens\"] = self.max_tokens
```

The Anthropic API requires `max_tokens`, but the constructor default is `None` and `chat()` only adds it to the payload when explicitly set, so the default-configured client returns:

```
400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"max_tokens: Field required\"}}
```

This affects every model out of the box (reproduced with `claude-sonnet-4-5`, `claude-sonnet-4-6`, `claude-opus-4-7`).

### 2. `temperature` rejected on Claude 4 Opus

Anthropic deprecated `temperature` for the Opus 4 family. Even after fixing #1, `claude-opus-4-7` returns:

```
400 {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"\\`temperature\\` is deprecated for this model.\"}}
```

`chat()` always inlines `\"temperature\": self.temperature`, so these models can't be used with the OAuth client.

## Fix

- Introduce `DEFAULT_MAX_TOKENS = 4096` and use it as the constructor + Field default. The payload always carries `max_tokens` now; `LLMMetadata.num_output` is also accurate by default. Callers can still override via `max_tokens=`, `additional_kwargs`, or per-call kwargs.
- Add `AnthropicOAuthLLM._supports_temperature(model_id)` (False for `claude-opus-4*`) and only inline `temperature` when supported. Callers who explicitly want to set `temperature` on an unsupported model can still do so via `additional_kwargs` / per-call kwargs — the API's error will then surface as intended.

The scope is intentionally narrow: I confirmed via direct curl that `claude-haiku-4-5` still accepts `temperature`, and `claude-sonnet-4-x` calls returned an unrelated rate-limit error during testing, so I limited the deprecation guard to the model family I could confirm. If Sonnet 4 follows the same path later, the helper is a one-line extension.

## Verification

Before:

```
$ mobilerun run --provider anthropic_oauth --model claude-opus-4-7 --no-stream \"Say only 'pong' then complete\"
... HTTPError('400 Client Error: Bad Request ...')
❌ Goal failed: Error: 400 Client Error: Bad Request for url: https://api.anthropic.com/v1/messages
```

After:

```
$ mobilerun run --provider anthropic_oauth --model claude-opus-4-7 --no-stream \"Say only 'pong' then complete\"
🔄 Step 1/4
FastAgent response:
pong
<function_calls><invoke name=\"complete\"><parameter name=\"success\">true</parameter><parameter name=\"message\">pong</parameter></invoke></function_calls>
🎉 Goal achieved: pong
```

No new tests — this directory has no existing unit tests for `AnthropicOAuthLLM`. Happy to add a small payload-shape unit test if maintainers want one.