### PR TITLE
fix: add Ollama_llm alias to resolve Ollama provider name mismatch

### DIFF
--- a/mobilerun/agent/usage.py
+++ b/mobilerun/agent/usage.py
@@ -28,6 +28,7 @@ PROVIDER_ALIASES = {
     "MobilerunAnthropic": "Anthropic",
     "MobilerunOpenAIResponses": "OpenAIResponses",
     "openai_responses_llm": "OpenAIResponses",
+    "Ollama_llm": "Ollama",
 }
 
 


### PR DESCRIPTION
﻿## Summary

Fixes #332 — when using Ollama as the LLM provider, `get_usage_from_response()` raised `ValueError: Unsupported provider: Ollama_llm` because llama-index's Ollama class returns `"Ollama_llm"` from `class_name()`, while the function expected `"Ollama"`.

## Root cause

`_normalize_provider_name()` is the existing mechanism for canonicalizing provider names before any checks. `PROVIDER_ALIASES` already maps `"MobilerunAnthropic"` → `"Anthropic"` and `"openai_responses_llm"` → `"OpenAIResponses"` for the same reason.

## Fix

Add `"Ollama_llm": "Ollama"` to `PROVIDER_ALIASES` — one line, consistent with the existing pattern. After normalization, both `get_usage_from_response()` and `create_tracker()` / `track_usage()` correctly route to the Ollama branch and `SUPPORTED_PROVIDERS` check respectively.
