### PR TITLE
fix(provider): apply coordinate scale in AndroidStateProvider when vision enabled

### DIFF
--- a/mobilerun/agent/droid/droid_agent.py
+++ b/mobilerun/agent/droid/droid_agent.py
@@ -554,6 +554,7 @@ class MobileAgent(Workflow):
                 tree_formatter=tree_formatter,
                 use_normalized=self.config.agent.use_normalized_coordinates,
                 stealth=stealth_enabled,
+                vision_enabled=vision_enabled,
             )
 
         # ── 3. Build tool registry ────────────────────────────────────

--- a/mobilerun/tools/ui/provider.py
+++ b/mobilerun/tools/ui/provider.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
 
 from mobilerun_core_cli.driver.base import DeviceDisconnectedError
 
+from mobilerun.tools.helpers.images import fit_dimensions_to_max_side
 from mobilerun.tools.ui.state import UIState
 from mobilerun.tools.ui.stealth_state import StealthUIState
 
@@ -161,12 +162,14 @@ class AndroidStateProvider(StateProvider):
         use_normalized: bool = False,
         stealth: bool = False,
         ui_cls: "type[UIState] | None" = None,
+        vision_enabled: bool = False,
     ) -> None:
         super().__init__(driver)
         self.tree_filter = tree_filter
         self.tree_formatter = tree_formatter
         self.use_normalized = use_normalized
         self._ui_cls = ui_cls or (StealthUIState if stealth else UIState)
+        self.vision_enabled = vision_enabled
         # Android screenshots and input taps share device-pixel coordinates,
         # but only when not in normalized mode. ``use_normalized=True`` makes
         # ``UIState.convert_point`` treat inputs as [0-1000] normalized
@@ -243,6 +246,19 @@ class AndroidStateProvider(StateProvider):
             self.tree_formatter.format(filtered, combined_data["phone_state"])
         )
 
+        coordinate_scale_x = 1.0
+        coordinate_scale_y = 1.0
+        if self.vision_enabled and screen_width and screen_height:
+            # When the LLM receives a screenshot, the image is downscaled to
+            # fit MODEL_SCREENSHOT_MAX_SIDE. The LLM outputs coordinates in the
+            # downscaled space, so we must scale them back to device pixels
+            # before sending taps. ScreenshotOnlyStateProvider does the same.
+            display_width, display_height = fit_dimensions_to_max_side(
+                screen_width, screen_height
+            )
+            coordinate_scale_x = screen_width / display_width
+            coordinate_scale_y = screen_height / display_height
+
         return self._ui_cls(
             elements=elements,
             formatted_text=formatted_text,
@@ -251,4 +267,6 @@ class AndroidStateProvider(StateProvider):
             screen_width=screen_width,
             screen_height=screen_height,
             use_normalized=self.use_normalized,
+            coordinate_scale_x=coordinate_scale_x,
+            coordinate_scale_y=coordinate_scale_y,
         )


### PR DESCRIPTION
## Problem

`AndroidStateProvider` was returning `UIState` with `coordinate_scale_x/y = 1.0` (the default) even when vision was enabled. When the LLM receives a screenshot from a high-resolution device (e.g. 1080×2400), the image is downscaled to fit `MODEL_SCREENSHOT_MAX_SIDE=2048` before being sent to the model. The LLM outputs coordinates in that downscaled space. Without the scale correction, `UIState.convert_point` maps those coordinates at 1:1, so `click_at` taps land at the wrong device-pixel position.

Example from the issue: the LLM estimated a dismiss button at (651, 230), but the real device position was ~(1020, 170). The ratio 651/1020 ≈ 0.638 matches the model's apparent downscale factor.

The `click` path that resolves coordinates from a11y element bounds is not affected — it bypasses `convert_point`. Only `click_at` and `click_area`, which go through `convert_point`, needed the fix.

## Fix

`ScreenshotOnlyStateProvider` already handles this correctly: it calls `fit_dimensions_to_max_side` and passes `coordinate_scale_x = input_width / screen_width` to `UIState`. This PR brings the same logic to `AndroidStateProvider`:

- Add `vision_enabled: bool = False` parameter to `AndroidStateProvider.__init__`
- When `vision_enabled=True` and screen dimensions are known, compute `display_width, display_height = fit_dimensions_to_max_side(screen_width, screen_height)` and set `coordinate_scale_x = screen_width / display_width`, `coordinate_scale_y = screen_height / display_height`
- Pass `vision_enabled=vision_enabled` from `MobileAgent` startup

No change when vision is disabled or when the device resolution already fits within 2048px (scale = 1.0).

Closes #350

## Test plan

- [ ] Run with a high-res Android device (e.g. 1080×2400) and `fast_agent.vision=True` or `manager.vision=True`
- [ ] Verify that `click_at` coordinates on Compose overlays / tooltips (absent from a11y tree) now land at the correct device-pixel location
- [ ] Verify that `click` (a11y element bounds) still works correctly
- [ ] Verify that low-res devices (≤ 2048px longest side) are unaffected (scale stays 1.0)