### PR TITLE
docs: add Python 3.14 incompatibility warning to quickstart

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -16,9 +16,13 @@ This guide will help you get Mobilerun installed and running quickly, controllin
 
 ### Prerequisites
 
+<Warning>
+**Python 3.14 is not yet supported.** Installing Mobilerun on Python 3.14 will silently fall back to an older version (e.g. 0.3.9) due to a dependency that does not yet support Python 3.14. Use Python 3.11, 3.12, or 3.13.
+</Warning>
+
 Before installing Mobilerun, ensure you have:
 
-1. **Python 3.11-3.13** installed on your system
+1. **Python 3.11, 3.12, or 3.13** installed on your system
 2. [Android Debug Bridge (adb)](https://developer.android.com/studio/releases/platform-tools) installed and configured
 3. **Android device** with:
    - [Developer options enabled](https://developer.android.com/studio/debug/dev-options)


### PR DESCRIPTION
## Summary

Python 3.14 is not yet supported by Mobilerun because `arize-phoenix` (a dependency) does not support it. When users install Mobilerun on Python 3.14, package managers like `pipx` and `uv` silently fall back to an older version (e.g. 0.3.9) instead of the latest, which is confusing and leads to bug reports against old code.

The README already has a clear note about this ([line 61](https://github.com/droidrun/mobilerun/blob/main/README.md#L61)), but the quickstart page — the first place most users land — did not.

Fixes #268

## Changes

- `docs/quickstart.mdx`: Adds a `<Warning>` callout under Prerequisites explaining that Python 3.14 is not yet supported and the silent fallback behavior. Clarifies the supported range from `3.11-3.13` to `3.11, 3.12, or 3.13`.