### PR TITLE
fix(oauth): send ImageBlocks through AnthropicOAuthLLM instead of dropping them

### DIFF
--- a/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
@@ -20,8 +20,10 @@ from llama_index.core.base.llms.types import (
     ChatResponseGen,
     CompletionResponse,
     CompletionResponseGen,
+    ImageBlock,
     LLMMetadata,
     MessageRole,
+    TextBlock,
 )
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks import CallbackManager
@@ -664,6 +666,37 @@ class AnthropicOAuthLLM(CustomLLM):
                 texts.append(str(block["text"]))
         return "\n".join(texts)
 
+    @staticmethod
+    def _image_media_type(raw: bytes) -> str:
+        if raw.startswith(b"\xff\xd8"):
+            return "image/jpeg"
+        if raw.startswith(b"RIFF") and raw[8:12] == b"WEBP":
+            return "image/webp"
+        if raw.startswith(b"GIF8"):
+            return "image/gif"
+        return "image/png"
+
+    @classmethod
+    def _content_blocks(cls, message: ChatMessage) -> list[dict[str, Any]]:
+        blocks: list[dict[str, Any]] = []
+        for block in message.blocks or []:
+            if isinstance(block, TextBlock):
+                if block.text:
+                    blocks.append({"type": "text", "text": block.text})
+            elif isinstance(block, ImageBlock):
+                raw = block.resolve_image(as_base64=False).read()
+                blocks.append(
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": cls._image_media_type(raw),
+                            "data": base64.b64encode(raw).decode("ascii"),
+                        },
+                    }
+                )
+        return blocks
+
     def _to_provider_messages(
         self, messages: Sequence[ChatMessage]
     ) -> tuple[list[dict[str, Any]], list[str]]:
@@ -672,14 +705,21 @@ class AnthropicOAuthLLM(CustomLLM):
 
         for message in messages:
             role = message.role.value
-            content = message.content if isinstance(message.content, str) else ""
+            blocks = self._content_blocks(message)
             if role == MessageRole.SYSTEM.value:
-                if content:
-                    system_lines.append(content)
+                system_lines.extend(
+                    block["text"] for block in blocks if block["type"] == "text"
+                )
                 continue
             if role not in {MessageRole.USER.value, MessageRole.ASSISTANT.value}:
                 role = MessageRole.USER.value
-            provider_messages.append({"role": role, "content": content})
+            if any(block["type"] == "image" for block in blocks):
+                provider_messages.append({"role": role, "content": blocks})
+            else:
+                # Text-only messages keep the plain-string form the API also
+                # accepts, preserving existing request shapes.
+                content = message.content if isinstance(message.content, str) else ""
+                provider_messages.append({"role": role, "content": content})
 
         if not provider_messages:
             provider_messages.append({"role": MessageRole.USER.value, "content": ""})

--- a/tests/test_anthropic_oauth_llm.py
+++ b/tests/test_anthropic_oauth_llm.py
@@ -59,3 +59,104 @@ def test_opus_4_8_payload_sends_max_tokens_without_temperature():
     assert payload["model"] == "claude-opus-4-8"
     assert payload["max_tokens"] == 8192
     assert "temperature" not in payload
+
+
+def _chat_payload(messages):
+    llm = AnthropicOAuthLLM(access_token="test-token", credential_path=None)
+    session = _CapturingSession()
+    llm._session = session
+    llm.chat(messages)
+    return session.payload
+
+
+def _tiny_png() -> bytes:
+    from io import BytesIO
+
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (2, 2), color=(255, 0, 0)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_image_block_is_sent_as_base64_image_content():
+    import base64
+
+    from llama_index.core.base.llms.types import ImageBlock, TextBlock
+
+    png = _tiny_png()
+    payload = _chat_payload(
+        [
+            ChatMessage(
+                role=MessageRole.USER,
+                blocks=[TextBlock(text="what is this?"), ImageBlock(image=png)],
+            )
+        ]
+    )
+
+    content = payload["messages"][0]["content"]
+    assert isinstance(content, list)
+    assert [block["type"] for block in content] == ["text", "image"]
+    assert content[0]["text"] == "what is this?"
+    source = content[1]["source"]
+    assert source["type"] == "base64"
+    assert source["media_type"] == "image/png"
+    assert base64.b64decode(source["data"]) == png
+
+
+def test_image_only_message_is_sent_as_image_content():
+    from llama_index.core.base.llms.types import ImageBlock
+
+    payload = _chat_payload(
+        [ChatMessage(role=MessageRole.USER, blocks=[ImageBlock(image=_tiny_png())])]
+    )
+
+    content = payload["messages"][0]["content"]
+    assert isinstance(content, list)
+    assert [block["type"] for block in content] == ["image"]
+
+
+def test_jpeg_media_type_is_detected():
+    from io import BytesIO
+
+    from PIL import Image
+    from llama_index.core.base.llms.types import ImageBlock
+
+    buf = BytesIO()
+    Image.new("RGB", (2, 2)).save(buf, format="JPEG")
+    payload = _chat_payload(
+        [
+            ChatMessage(
+                role=MessageRole.USER,
+                blocks=[ImageBlock(image=buf.getvalue(), image_mimetype="image/jpeg")],
+            )
+        ]
+    )
+
+    assert payload["messages"][0]["content"][0]["source"]["media_type"] == "image/jpeg"
+
+
+def test_text_only_messages_keep_plain_string_content():
+    payload = _chat_payload(
+        [
+            ChatMessage(role=MessageRole.USER, content="hello"),
+            ChatMessage(role=MessageRole.ASSISTANT, content="hi"),
+            ChatMessage(role=MessageRole.USER, content="bye"),
+        ]
+    )
+
+    assert [m["content"] for m in payload["messages"]] == ["hello", "hi", "bye"]
+    assert all(isinstance(m["content"], str) for m in payload["messages"])
+
+
+def test_system_message_text_reaches_system_blocks():
+    payload = _chat_payload(
+        [
+            ChatMessage(role=MessageRole.SYSTEM, content="be terse"),
+            ChatMessage(role=MessageRole.USER, content="hello"),
+        ]
+    )
+
+    system_texts = [block["text"] for block in payload["system"]]
+    assert "be terse" in system_texts
+    assert all(m["role"] != "system" for m in payload["messages"])


### PR DESCRIPTION
## Problem

`AnthropicOAuthLLM._to_provider_messages` kept only plain-string content: `content = message.content if isinstance(message.content, str) else ""`. The screenshots that fast_agent/executor/manager attach as llama_index `ImageBlock`s when vision is enabled (e.g. `fast_agent.py` message assembly) were silently discarded — with `anthropic_oauth`, vision mode sent **no image at all** and Claude answered blind.

Found while investigating #350: in a grounding experiment, Claude's coordinate answers were center-of-screen guesses (constant x=500) and refusal-shaped text until image delivery was patched, after which it grounded accurately (mean y-error 32px on a 1080×2400 screen).

## Fix

- `_to_provider_messages` now converts message blocks to Anthropic Messages API content blocks: `TextBlock` → `{"type":"text"}`, `ImageBlock` → `{"type":"image","source":{"type":"base64",...}}` with media type sniffed from the bytes (png/jpeg/webp/gif).
- Text-only messages keep the plain-string content form (no request-shape change for existing traffic).
- System-message text still flows into the system blocks; non-text system blocks are ignored.
- Streaming is untouched (`stream_chat` remains NotImplemented).

## Test plan

- [x] 5 new unit tests in `tests/test_anthropic_oauth_llm.py` (text+image, image-only, jpeg media type, text-only string form preserved, system text routing) — 8/8 pass
- [x] Live check via `load_llm("anthropic_oauth")` + emulator screenshot: Claude correctly answers "Android Settings app main screen"

Part of the fix series for #350 (the coordinate-contract PR follows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)