### PR TITLE
fix(provider): deterministic coordinate contract for a11y+vision mode

### DIFF
--- a/mobilerun/agent/droid/droid_agent.py
+++ b/mobilerun/agent/droid/droid_agent.py
@@ -465,8 +465,12 @@ class MobileAgent(Workflow):
 
         # ── 1. Create driver ──────────────────────────────────────────
         if self.config.agent.reasoning:
+            # The executor emits the coordinate actions, so its vision flag
+            # matters as much as the manager's for the coordinate contract.
             vision_enabled = (
-                self.config.agent.vision_only or self.config.agent.manager.vision
+                self.config.agent.vision_only
+                or self.config.agent.manager.vision
+                or self.config.agent.executor.vision
             )
         else:
             vision_enabled = (
@@ -554,6 +558,7 @@ class MobileAgent(Workflow):
                 tree_formatter=tree_formatter,
                 use_normalized=self.config.agent.use_normalized_coordinates,
                 stealth=stealth_enabled,
+                vision_enabled=vision_enabled,
             )
 
         # ── 3. Build tool registry ────────────────────────────────────

--- a/mobilerun/agent/executor/executor_agent.py
+++ b/mobilerun/agent/executor/executor_agent.py
@@ -139,7 +139,7 @@ class ExecutorAgent(Workflow):
             if screenshot is not None:
                 if getattr(
                     self.action_ctx.state_provider,
-                    "requires_coordinate_tools",
+                    "resize_model_screenshot",
                     False,
                 ):
                     screenshot = resize_image_to_max_side_with_grid(screenshot)

--- a/mobilerun/agent/executor/executor_agent.py
+++ b/mobilerun/agent/executor/executor_agent.py
@@ -31,6 +31,7 @@ from mobilerun.agent.utils.prompt_resolver import PromptResolver
 from mobilerun.config_manager.config_manager import AgentConfig
 from mobilerun.config_manager.prompt_loader import PromptLoader
 from mobilerun.tools.helpers.images import resize_image_to_max_side_with_grid
+from mobilerun.tools.ui.provider import should_resize_model_screenshot
 
 if TYPE_CHECKING:
     from mobilerun.agent.action_context import ActionContext
@@ -137,11 +138,7 @@ class ExecutorAgent(Workflow):
         if self.vision:
             screenshot = self.shared_state.screenshot
             if screenshot is not None:
-                if getattr(
-                    self.action_ctx.state_provider,
-                    "resize_model_screenshot",
-                    False,
-                ):
+                if should_resize_model_screenshot(self.action_ctx.state_provider):
                     screenshot = resize_image_to_max_side_with_grid(screenshot)
                 messages[0].blocks.append(ImageBlock(image=screenshot))
                 logger.debug("📸 Using screenshot for Executor")

--- a/mobilerun/agent/fast_agent/fast_agent.py
+++ b/mobilerun/agent/fast_agent/fast_agent.py
@@ -326,7 +326,7 @@ class FastAgent(Workflow):
 
             # Screenshot → last user message
             if self.vision and screenshot:
-                if getattr(self.state_provider, "requires_coordinate_tools", False):
+                if getattr(self.state_provider, "resize_model_screenshot", False):
                     screenshot = resize_image_to_max_side_with_grid(screenshot)
                 messages_to_send[last_user_idx].blocks.append(
                     ImageBlock(image=screenshot)

--- a/mobilerun/agent/fast_agent/fast_agent.py
+++ b/mobilerun/agent/fast_agent/fast_agent.py
@@ -47,6 +47,7 @@ from mobilerun.agent.utils.tracing_setup import record_langfuse_screenshot
 from mobilerun.config_manager.config_manager import AgentConfig, TracingConfig
 from mobilerun.config_manager.prompt_loader import PromptLoader
 from mobilerun.tools.helpers.images import resize_image_to_max_side_with_grid
+from mobilerun.tools.ui.provider import should_resize_model_screenshot
 
 if TYPE_CHECKING:
     from mobilerun.agent.action_context import ActionContext
@@ -326,7 +327,7 @@ class FastAgent(Workflow):
 
             # Screenshot → last user message
             if self.vision and screenshot:
-                if getattr(self.state_provider, "resize_model_screenshot", False):
+                if should_resize_model_screenshot(self.state_provider):
                     screenshot = resize_image_to_max_side_with_grid(screenshot)
                 messages_to_send[last_user_idx].blocks.append(
                     ImageBlock(image=screenshot)

--- a/mobilerun/agent/manager/manager_agent.py
+++ b/mobilerun/agent/manager/manager_agent.py
@@ -290,7 +290,7 @@ class ManagerAgent(Workflow):
 
             # Add screenshot if vision enabled
             if screenshot and self.vision:
-                if getattr(self.state_provider, "requires_coordinate_tools", False):
+                if getattr(self.state_provider, "resize_model_screenshot", False):
                     screenshot = resize_image_to_max_side_with_grid(screenshot)
                 messages[last_user_idx].blocks.append(ImageBlock(image=screenshot))
 

--- a/mobilerun/agent/manager/manager_agent.py
+++ b/mobilerun/agent/manager/manager_agent.py
@@ -49,6 +49,7 @@ from mobilerun.app_cards.providers import (
 )
 from mobilerun.config_manager.prompt_loader import PromptLoader
 from mobilerun.tools.helpers.images import resize_image_to_max_side_with_grid
+from mobilerun.tools.ui.provider import should_resize_model_screenshot
 
 if TYPE_CHECKING:
     from mobilerun.agent.action_context import ActionContext
@@ -290,7 +291,7 @@ class ManagerAgent(Workflow):
 
             # Add screenshot if vision enabled
             if screenshot and self.vision:
-                if getattr(self.state_provider, "resize_model_screenshot", False):
+                if should_resize_model_screenshot(self.state_provider):
                     screenshot = resize_image_to_max_side_with_grid(screenshot)
                 messages[last_user_idx].blocks.append(ImageBlock(image=screenshot))
 

--- a/mobilerun/agent/manager/stateless_manager_agent.py
+++ b/mobilerun/agent/manager/stateless_manager_agent.py
@@ -27,6 +27,7 @@ from mobilerun.agent.utils.prompt_resolver import PromptResolver
 from mobilerun.agent.utils.tracing_setup import record_langfuse_screenshot
 from mobilerun.config_manager.prompt_loader import PromptLoader
 from mobilerun.tools.helpers.images import resize_image_to_max_side_with_grid
+from mobilerun.tools.ui.provider import should_resize_model_screenshot
 
 if TYPE_CHECKING:
     from mobilerun.agent.action_context import ActionContext
@@ -230,7 +231,7 @@ class StatelessManagerAgent(Workflow):
         messages = [{"role": "user", "content": [{"text": prompt_text}]}]
 
         if self.vision and screenshot:
-            if getattr(self.state_provider, "resize_model_screenshot", False):
+            if should_resize_model_screenshot(self.state_provider):
                 screenshot = resize_image_to_max_side_with_grid(screenshot)
             messages[0]["content"].append({"image": screenshot})
 

--- a/mobilerun/agent/manager/stateless_manager_agent.py
+++ b/mobilerun/agent/manager/stateless_manager_agent.py
@@ -230,7 +230,7 @@ class StatelessManagerAgent(Workflow):
         messages = [{"role": "user", "content": [{"text": prompt_text}]}]
 
         if self.vision and screenshot:
-            if getattr(self.state_provider, "requires_coordinate_tools", False):
+            if getattr(self.state_provider, "resize_model_screenshot", False):
                 screenshot = resize_image_to_max_side_with_grid(screenshot)
             messages[0]["content"].append({"image": screenshot})
 

--- a/mobilerun/agent/utils/actions.py
+++ b/mobilerun/agent/utils/actions.py
@@ -66,10 +66,61 @@ def _validate_screenshot_only_point(
         raise ValueError(_screenshot_only_coordinate_error(ctx))
 
 
+def _model_space_dimensions(ctx: "ActionContext") -> tuple[float, float] | None:
+    """Return the (width, height) coordinate space the model was shown.
+
+    Only applies when the provider declared a scaled coordinate contract
+    (``resize_model_screenshot``) outside screenshot-only mode: the UIState
+    keeps native screen dimensions while the model sees and answers in the
+    ``native / coordinate_scale`` display space.
+    """
+    if _uses_screenshot_only_coordinates(ctx):
+        return None
+    if not getattr(ctx.state_provider, "resize_model_screenshot", False):
+        return None
+    if getattr(ctx.ui, "use_normalized", False):
+        return None
+    try:
+        scale_x = float(ctx.ui.coordinate_scale_x)
+        scale_y = float(ctx.ui.coordinate_scale_y)
+        width = float(ctx.ui.screen_width) / scale_x
+        height = float(ctx.ui.screen_height) / scale_y
+    except (TypeError, ValueError, ZeroDivisionError):
+        return None
+    if width <= 0 or height <= 0:
+        return None
+    return width, height
+
+
+def _validate_model_space_point(
+    x: int | float, y: int | float, *, ctx: "ActionContext"
+) -> None:
+    dims = _model_space_dimensions(ctx)
+    if dims is None:
+        return
+    width, height = dims
+    try:
+        px = float(x)
+        py = float(y)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Coordinates must be numbers inside the {round(width)}x{round(height)} "
+            "coordinate space of the provided device state."
+        ) from exc
+    if px < 0 or px >= width or py < 0 or py >= height:
+        raise ValueError(
+            f"Coordinates ({x}, {y}) are outside the {round(width)}x{round(height)} "
+            "coordinate space of the provided device state. Use the element "
+            "bounds and screenshot shown to you and retry with coordinates "
+            "inside that space."
+        )
+
+
 def _convert_action_point(
     x: int | float, y: int | float, *, ctx: "ActionContext"
 ) -> tuple[int, int]:
     _validate_screenshot_only_point(x, y, ctx=ctx)
+    _validate_model_space_point(x, y, ctx=ctx)
     abs_x, abs_y = ctx.ui.convert_point(x, y)
     return int(round(abs_x)), int(round(abs_y))
 

--- a/mobilerun/agent/utils/signatures.py
+++ b/mobilerun/agent/utils/signatures.py
@@ -84,21 +84,25 @@ async def build_tool_registry(
         )
     else:
         click_at_description = (
-            "Click at screen position (x, y). "
+            "Click at position (x, y), in the same coordinate space as the "
+            "element bounds in the device state. "
             'Usage: {"action": "click_at", "x": 500, "y": 300}'
         )
         click_area_description = (
-            "Click the center of area (x1, y1, x2, y2). Use click_area only "
-            "for large, unambiguous targets. "
+            "Click the center of area (x1, y1, x2, y2), in the same coordinate "
+            "space as the element bounds in the device state. Use click_area "
+            "only for large, unambiguous targets. "
             'Usage: {"action": "click_area", "x1": 100, "y1": 200, "x2": 300, "y2": 400}'
         )
         long_press_at_description = (
-            "Long press at screen position (x, y). "
+            "Long press at position (x, y), in the same coordinate space as "
+            "the element bounds in the device state. "
             'Usage: {"action": "long_press_at", "x": 500, "y": 300}'
         )
         swipe_description = (
             "Swipe from the position with coordinate to the position with "
-            "coordinate2. Duration is in seconds (default: 1.0). "
+            "coordinate2, in the same coordinate space as the element bounds "
+            "in the device state. Duration is in seconds (default: 1.0). "
             'Usage Example: {"action": "swipe", "coordinate": [x1, y1], "coordinate2": [x2, y2], "duration": 1.5}'
         )
 

--- a/mobilerun/tools/formatters/indexed_formatter.py
+++ b/mobilerun/tools/formatters/indexed_formatter.py
@@ -13,6 +13,11 @@ class IndexedFormatter(TreeFormatter):
         self.screen_width: Optional[int] = None
         self.screen_height: Optional[int] = None
         self.use_normalized: bool = False
+        # Native-pixels-per-displayed-pixel of the screenshot shown to the
+        # model. When != 1.0, the bounds in the model-facing text are emitted
+        # in display space while ``bounds`` (used for real taps) stay native.
+        self.display_scale_x: float = 1.0
+        self.display_scale_y: float = 1.0
 
     def format(
         self, filtered_tree: Optional[Dict[str, Any]], phone_state: Dict[str, Any]
@@ -113,7 +118,9 @@ class IndexedFormatter(TreeFormatter):
             class_name = element.get("className", "")
             resource_id = element.get("resourceId", "")
             text = element.get("text", "")
-            bounds = element.get("bounds", "")
+            # Model-facing text shows display-space bounds when the screenshot
+            # is resized for the model; "bounds" (native pixels) drive real taps.
+            bounds = element.get("displayBounds") or element.get("bounds", "")
             checkedState = element.get("checkedState", "")
             children = element.get("children", [])
 
@@ -170,9 +177,23 @@ class IndexedFormatter(TreeFormatter):
         bounds = node.get("boundsInScreen", {})
         bounds_str = f"{bounds.get('left', 0)},{bounds.get('top', 0)},{bounds.get('right', 0)},{bounds.get('bottom', 0)}"
 
+        display_bounds_str = None
         if self.use_normalized and self.screen_width and self.screen_height:
             bounds_str = bounds_to_normalized(
                 bounds_str, self.screen_width, self.screen_height
+            )
+        elif self.display_scale_x != 1.0 or self.display_scale_y != 1.0:
+            display_bounds_str = ",".join(
+                str(round(value / scale))
+                for value, scale in zip(
+                    (int(part) for part in bounds_str.split(",")),
+                    (
+                        self.display_scale_x,
+                        self.display_scale_y,
+                        self.display_scale_x,
+                        self.display_scale_y,
+                    ),
+                )
             )
 
         text = (
@@ -191,7 +212,7 @@ class IndexedFormatter(TreeFormatter):
                 "isChecked=True" if node.get("isChecked") else "isChecked=False"
             )
 
-        return {
+        formatted = {
             "index": index,
             "resourceId": node.get("resourceId", ""),
             "className": short_class,
@@ -200,3 +221,6 @@ class IndexedFormatter(TreeFormatter):
             "bounds": bounds_str,
             "children": [],
         }
+        if display_bounds_str is not None:
+            formatted["displayBounds"] = display_bounds_str
+        return formatted

--- a/mobilerun/tools/ui/provider.py
+++ b/mobilerun/tools/ui/provider.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
 
 from mobilerun_core_cli.driver.base import DeviceDisconnectedError
 
+from mobilerun.tools.helpers.images import fit_dimensions_to_max_side
 from mobilerun.tools.ui.state import UIState
 from mobilerun.tools.ui.stealth_state import StealthUIState
 
@@ -135,6 +136,13 @@ class StateProvider:
     # picking from the screenshot would tap the wrong location. Screenshot-only
     # providers handle scaling explicitly via ``coordinate_scale_x/y``.
     screenshot_matches_input_coords: bool = False
+    # True when the screenshot attached to LLM messages must first be resized
+    # (with a labeled coordinate grid) into the deterministic coordinate space
+    # the provider declared in ``formatted_text`` and compensates for via
+    # ``coordinate_scale_x/y``. Vision-model output spaces are otherwise
+    # model-dependent: a raw native screenshot is downscaled inside the LLM
+    # provider's API and different models answer in different spaces.
+    resize_model_screenshot: bool = False
 
     def __init__(self, driver: "DeviceDriver") -> None:
         self.driver = driver
@@ -161,18 +169,23 @@ class AndroidStateProvider(StateProvider):
         use_normalized: bool = False,
         stealth: bool = False,
         ui_cls: "type[UIState] | None" = None,
+        vision_enabled: bool = False,
     ) -> None:
         super().__init__(driver)
         self.tree_filter = tree_filter
         self.tree_formatter = tree_formatter
         self.use_normalized = use_normalized
         self._ui_cls = ui_cls or (StealthUIState if stealth else UIState)
+        self.vision_enabled = vision_enabled
         # Android screenshots and input taps share device-pixel coordinates,
         # but only when not in normalized mode. ``use_normalized=True`` makes
         # ``UIState.convert_point`` treat inputs as [0-1000] normalized
         # coordinates, which is incompatible with picking coordinates off the
         # screenshot — keep click_at masked in that case.
         self.screenshot_matches_input_coords = not use_normalized
+        # Normalized [0-1000] coordinates are scale-invariant, so the
+        # deterministic-space contract is only needed for pixel coordinates.
+        self.resize_model_screenshot = vision_enabled and not use_normalized
 
     async def _recover_portal(self) -> None:
         """Restart Portal's accessibility service and TCP socket server."""
@@ -235,13 +248,43 @@ class AndroidStateProvider(StateProvider):
 
         filtered = self.tree_filter.filter(combined_data["a11y_tree"], device_context)
 
+        coordinate_scale_x = 1.0
+        coordinate_scale_y = 1.0
+        display_width = None
+        display_height = None
+        if self.resize_model_screenshot and screen_width and screen_height:
+            display_width, display_height = fit_dimensions_to_max_side(
+                screen_width, screen_height
+            )
+            coordinate_scale_x = screen_width / display_width
+            coordinate_scale_y = screen_height / display_height
+
         self.tree_formatter.screen_width = screen_width
         self.tree_formatter.screen_height = screen_height
         self.tree_formatter.use_normalized = self.use_normalized
+        # Model-facing bounds text is emitted in the display space the model
+        # actually sees; tap bounds in ``elements`` stay native device pixels.
+        self.tree_formatter.display_scale_x = coordinate_scale_x
+        self.tree_formatter.display_scale_y = coordinate_scale_y
 
         formatted_text, focused_text, elements, phone_state = (
             self.tree_formatter.format(filtered, combined_data["phone_state"])
         )
+
+        if display_width and display_height:
+            scaled_note = (
+                f" — the {screen_width}x{screen_height} device screen scaled down"
+                if (display_width, display_height) != (screen_width, screen_height)
+                else ""
+            )
+            formatted_text += (
+                f"\n\nAll coordinates in this device state (element bounds above, "
+                f"and any x/y you provide to coordinate actions) are in a "
+                f"{display_width}x{display_height} coordinate space{scaled_note}. "
+                f"When a screenshot is provided it matches this "
+                f"{display_width}x{display_height} space and carries a labeled "
+                f"coordinate grid for reference."
+            )
 
         return self._ui_cls(
             elements=elements,
@@ -251,4 +294,6 @@ class AndroidStateProvider(StateProvider):
             screen_width=screen_width,
             screen_height=screen_height,
             use_normalized=self.use_normalized,
+            coordinate_scale_x=coordinate_scale_x,
+            coordinate_scale_y=coordinate_scale_y,
         )

--- a/mobilerun/tools/ui/provider.py
+++ b/mobilerun/tools/ui/provider.py
@@ -151,6 +151,21 @@ class StateProvider:
         raise NotImplementedError
 
 
+def should_resize_model_screenshot(state_provider: Any) -> bool:
+    """True when screenshots attached to LLM messages must be resized (with
+    the labeled grid) into the coordinate space the provider declared.
+
+    Falls back to the legacy ``requires_coordinate_tools`` contract: injected
+    screenshot-only providers that predate ``resize_model_screenshot`` are
+    still treated as screenshot-coordinate mode by the tool registry, prompts,
+    and validation, so they must keep receiving resized screenshots too.
+    """
+    return bool(
+        getattr(state_provider, "resize_model_screenshot", False)
+        or getattr(state_provider, "requires_coordinate_tools", False)
+    )
+
+
 class AndroidStateProvider(StateProvider):
     """Fetches state from an Android device via ``driver.get_ui_tree()``.
 

--- a/mobilerun/tools/ui/screenshot_provider.py
+++ b/mobilerun/tools/ui/screenshot_provider.py
@@ -17,6 +17,7 @@ class ScreenshotOnlyStateProvider(StateProvider):
 
     supported = {"convert_point", "direct_text_input"}
     requires_coordinate_tools = True
+    resize_model_screenshot = True
 
     def __init__(self, driver: "DeviceDriver") -> None:
         super().__init__(driver)

--- a/tests/eval_coordinate_grounding.py
+++ b/tests/eval_coordinate_grounding.py
@@ -1,0 +1,142 @@
+"""Manual eval: per-model coordinate grounding through the real a11y+vision pipeline.
+
+Not collected by pytest (no ``test_`` prefix) — it needs a connected Android
+device and configured LLM credentials. Run it whenever adding a model/provider
+or touching the coordinate contract:
+
+    .venv/bin/python tests/eval_coordinate_grounding.py [serial]
+
+For each provider it builds the real ``AndroidStateProvider(vision_enabled=True)``
+state, attaches the exact resized+grid screenshot the agents send, asks the
+model for click_at coordinates of known on-screen labels, converts them through
+``_convert_action_point``, and scores against native a11y bounds.
+
+Background (measured 2026-06-11, issue #350): model output spaces are
+model-dependent when the contract is absent — gpt-5.4-mini answered in a
+~1.18x-downscaled space, claude-opus-4-7 in near-native space, so no fixed
+multiplier can be correct. With the resize+grid+declared-dims contract both
+answered in the declared space (mean y-error 16px / 28px vs 213px broken).
+"""
+
+import asyncio
+import re
+import sys
+from types import SimpleNamespace
+
+from llama_index.core.base.llms.types import ChatMessage, ImageBlock, TextBlock
+
+from mobilerun.agent.utils.actions import _convert_action_point
+from mobilerun.agent.utils.llm_picker import load_llm
+from mobilerun.tools.filters import ConciseFilter
+from mobilerun.tools.formatters import IndexedFormatter
+from mobilerun.tools.helpers.images import resize_image_to_max_side_with_grid
+from mobilerun.tools.ui.provider import AndroidStateProvider
+
+PROVIDERS = [
+    ("openai", "openai_oauth", "gpt-5.4-mini"),
+    ("anthropic", "anthropic_oauth", "claude-opus-4-7"),
+    # gemini_oauth_code_assist quota is too tight for repeated vision calls;
+    # add it back when evaluating Gemini support.
+]
+MAX_TARGETS = 4
+
+
+def _parse_xy(text: str):
+    m = re.search(r'"x"\s*:\s*(-?\d+(?:\.\d+)?)\s*,\s*"y"\s*:\s*(-?\d+(?:\.\d+)?)', text)
+    if m:
+        return float(m.group(1)), float(m.group(2))
+    nums = re.findall(r"-?\d+(?:\.\d+)?", text)
+    return (float(nums[0]), float(nums[1])) if len(nums) >= 2 else None
+
+
+def _pick_targets(state):
+    flat = []
+
+    def walk(elements):
+        for element in elements:
+            flat.append(element)
+            walk(element.get("children") or [])
+
+    walk(state.elements)
+    targets, seen = [], set()
+    for element in flat:
+        text = (element.get("text") or "").strip()
+        if not text or len(text) <= 6 or not element.get("bounds"):
+            continue
+        if text in seen:
+            continue
+        left, top, right, bottom = [int(p) for p in element["bounds"].split(",")]
+        if 150 <= right - left <= 1050 and 30 <= bottom - top <= 260 and top >= 150:
+            seen.add(text)
+            targets.append((text, (left, top, right, bottom)))
+    step = max(1, len(targets) // MAX_TARGETS)
+    return targets[::step][:MAX_TARGETS]
+
+
+async def main(serial: str) -> None:
+    from mobilerun_core_cli.driver.android import AndroidDriver
+
+    driver = AndroidDriver(serial=serial)
+    await driver.connect()
+    provider = AndroidStateProvider(
+        driver,
+        tree_filter=ConciseFilter(),
+        tree_formatter=IndexedFormatter(),
+        vision_enabled=True,
+    )
+    state = await provider.get_state()
+    screenshot = await driver.screenshot()
+    sent_image = resize_image_to_max_side_with_grid(screenshot)
+    ctx = SimpleNamespace(ui=state, state_provider=provider)
+
+    targets = _pick_targets(state)
+    if not targets:
+        print("No suitable targets on screen — open a list-style screen (e.g. Settings).")
+        sys.exit(1)
+    print(f"targets: {[t for t, _ in targets]}")
+
+    for name, provider_key, model in PROVIDERS:
+        try:
+            llm = load_llm(provider_key, model=model)
+        except Exception as e:
+            print(f"--- {name}: SKIP ({type(e).__name__}: {e})")
+            continue
+        print(f"--- {name} ({model}) ---")
+        for text, (left, top, right, bottom) in targets:
+            message = ChatMessage(
+                role="user",
+                blocks=[
+                    TextBlock(
+                        text=(
+                            "You control an Android phone. Here is the current "
+                            "device state:\n\n" + state.formatted_text + "\n\n"
+                            f"You want to click_at the list item with text '{text}'. "
+                            'Respond with ONLY JSON {"x": <int>, "y": <int>} '
+                            "for the click_at action."
+                        )
+                    ),
+                    ImageBlock(image=sent_image),
+                ],
+            )
+            response = await llm.achat([message])
+            xy = _parse_xy(str(response.message.content))
+            if xy is None:
+                print(f"  {text[:32]:34} UNPARSEABLE: {str(response.message.content)[:60]!r}")
+                continue
+            try:
+                device_x, device_y = _convert_action_point(xy[0], xy[1], ctx=ctx)
+            except ValueError as e:
+                print(f"  {text[:32]:34} REJECTED: {str(e)[:70]}")
+                continue
+            center_x, center_y = (left + right) / 2, (top + bottom) / 2
+            hit = left <= device_x <= right and top <= device_y <= bottom
+            dist = ((device_x - center_x) ** 2 + (device_y - center_y) ** 2) ** 0.5
+            print(
+                f"  {text[:32]:34} model={tuple(int(v) for v in xy)} -> "
+                f"native=({device_x},{device_y}) center=({center_x:.0f},{center_y:.0f}) "
+                f"hit={hit} dist={dist:.0f}px"
+            )
+
+
+if __name__ == "__main__":
+    asyncio.run(main(sys.argv[1] if len(sys.argv) > 1 else "emulator-5554"))

--- a/tests/test_android_vision_coordinate_contract.py
+++ b/tests/test_android_vision_coordinate_contract.py
@@ -1,0 +1,193 @@
+"""Tests for the a11y+vision coordinate contract (issue #350).
+
+When vision is enabled on AndroidStateProvider, the screenshot the agents
+attach is resized (with a labeled grid) into a deterministic display space;
+the provider declares that space in formatted_text, emits model-facing
+bounds in it, and convert_point scales the model's coordinates back to
+native device pixels. Element-index taps keep using native bounds.
+"""
+
+import asyncio
+import inspect
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from PIL import Image
+
+from mobilerun.agent.utils import actions as actions_module
+from mobilerun.agent.utils.actions import _convert_action_point
+from mobilerun.tools.formatters import IndexedFormatter
+from mobilerun.tools.helpers.images import (
+    fit_dimensions_to_max_side,
+    image_dimensions,
+    resize_image_to_max_side_with_grid,
+)
+from mobilerun.tools.ui.provider import AndroidStateProvider, StateProvider
+from mobilerun.tools.ui.screenshot_provider import ScreenshotOnlyStateProvider
+
+NATIVE_W, NATIVE_H = 1080, 2400
+
+
+def _combined_data(width=NATIVE_W, height=NATIVE_H):
+    return {
+        "a11y_tree": {
+            "boundsInScreen": {"left": 0, "top": 0, "right": width, "bottom": height},
+            "className": "android.widget.FrameLayout",
+            "text": "root",
+            "children": [
+                {
+                    "boundsInScreen": {
+                        "left": 221,
+                        "top": 409,
+                        "right": 600,
+                        "bottom": 460,
+                    },
+                    "className": "android.widget.TextView",
+                    "text": "Services & preferences",
+                    "children": [],
+                }
+            ],
+        },
+        "device_context": {"screen_bounds": {"width": width, "height": height}},
+        "phone_state": {"currentApp": "Settings", "packageName": "com.android.settings"},
+    }
+
+
+def _provider(width=NATIVE_W, height=NATIVE_H, **kwargs):
+    driver = SimpleNamespace(
+        get_ui_tree=AsyncMock(return_value=_combined_data(width, height))
+    )
+    return AndroidStateProvider(
+        driver,
+        tree_filter=SimpleNamespace(filter=lambda tree, ctx: tree),
+        tree_formatter=IndexedFormatter(),
+        **kwargs,
+    )
+
+
+def _get_state(provider):
+    return asyncio.run(provider.get_state())
+
+
+def test_vision_disabled_keeps_legacy_behavior():
+    state = _get_state(_provider())
+
+    assert state.coordinate_scale_x == 1.0
+    assert state.coordinate_scale_y == 1.0
+    assert "coordinate space" not in state.formatted_text
+    assert "displayBounds" not in str(state.elements)
+    assert "221,409,600,460" in state.formatted_text
+    assert state.convert_point(540, 1200) == (540, 1200)
+
+
+def test_vision_enabled_declares_display_space_and_scales_back():
+    state = _get_state(_provider(vision_enabled=True))
+
+    display_w, display_h = fit_dimensions_to_max_side(NATIVE_W, NATIVE_H)
+    assert (display_w, display_h) == (922, 2048)
+    assert state.coordinate_scale_x == NATIVE_W / display_w
+    assert state.coordinate_scale_y == NATIVE_H / display_h
+
+    # Contract is declared, in display space
+    assert f"{display_w}x{display_h} coordinate space" in state.formatted_text
+    # Model-facing bounds are display-space; native bounds no longer leak there
+    assert "189,349,512,393" in state.formatted_text
+    assert "221,409,600,460" not in state.formatted_text
+
+    # convert_point maps display-space model output back to native pixels
+    x, y = state.convert_point(461, 371)  # display center of the element
+    assert abs(x - 540) <= 2 and abs(y - 434) <= 2
+
+    # Element-index taps keep native coordinates (the real-tap path)
+    element = state.get_element(2)
+    assert element["bounds"] == "221,409,600,460"
+    assert element["displayBounds"] == "189,349,512,393"
+    assert state.get_element_coords(2) == (410, 434)
+
+
+def test_small_screens_keep_scale_one_but_still_declare_space():
+    state = _get_state(_provider(height=1920, vision_enabled=True))
+
+    assert state.coordinate_scale_x == 1.0
+    assert state.coordinate_scale_y == 1.0
+    assert "1080x1920 coordinate space" in state.formatted_text
+    assert "scaled down" not in state.formatted_text
+    assert "displayBounds" not in str(state.elements)
+
+
+def test_normalized_mode_opts_out_of_the_contract():
+    provider = _provider(vision_enabled=True, use_normalized=True)
+    state = _get_state(provider)
+
+    assert provider.resize_model_screenshot is False
+    assert state.coordinate_scale_x == 1.0
+    assert "coordinate space" not in state.formatted_text
+
+
+def test_resize_flags_pair_providers_with_agent_gating():
+    # The providers declare the flag…
+    assert StateProvider.resize_model_screenshot is False
+    assert ScreenshotOnlyStateProvider.resize_model_screenshot is True
+    assert _provider(vision_enabled=True).resize_model_screenshot is True
+    assert _provider().resize_model_screenshot is False
+
+    # …and every agent that attaches screenshots gates its resize on it.
+    # (This pairing is what makes the provider's coordinate_scale valid.)
+    import mobilerun.agent.executor.executor_agent as executor_agent
+    import mobilerun.agent.fast_agent.fast_agent as fast_agent
+    import mobilerun.agent.manager.manager_agent as manager_agent
+    import mobilerun.agent.manager.stateless_manager_agent as stateless_manager_agent
+
+    for module in (fast_agent, executor_agent, manager_agent, stateless_manager_agent):
+        source = inspect.getsource(module)
+        assert "resize_model_screenshot" in source, module.__name__
+        assert "resize_image_to_max_side_with_grid" in source, module.__name__
+
+
+def test_provider_scale_matches_what_agents_actually_send():
+    """The invariant that PR #355 lacked: the provider's scale must describe
+    the image the agents really attach."""
+    buf = BytesIO()
+    Image.new("RGB", (NATIVE_W, NATIVE_H)).save(buf, format="PNG")
+    sent = resize_image_to_max_side_with_grid(buf.getvalue())
+    sent_w, sent_h = image_dimensions(sent)
+
+    state = _get_state(_provider(vision_enabled=True))
+    assert sent_w == round(NATIVE_W / state.coordinate_scale_x)
+    assert sent_h == round(NATIVE_H / state.coordinate_scale_y)
+
+
+def _action_ctx(state, provider):
+    return SimpleNamespace(ui=state, state_provider=provider)
+
+
+def test_convert_action_point_validates_model_space():
+    provider = _provider(vision_enabled=True)
+    state = _get_state(provider)
+    ctx = _action_ctx(state, provider)
+
+    # In-space coordinates convert to native pixels
+    assert _convert_action_point(461, 1024, ctx=ctx) == (540, 1200)
+
+    # Out-of-space coordinates (native-space habits) are rejected with a
+    # message instead of tapping off-screen
+    try:
+        _convert_action_point(1000, 2300, ctx=ctx)
+    except ValueError as e:
+        assert "922x2048" in str(e)
+    else:
+        raise AssertionError("expected ValueError for out-of-space point")
+
+
+def test_convert_action_point_unchanged_without_contract():
+    provider = _provider()
+    state = _get_state(provider)
+    ctx = _action_ctx(state, provider)
+
+    assert _convert_action_point(1000, 2300, ctx=ctx) == (1000, 2300)
+
+
+def test_validation_helper_is_wired_into_convert():
+    source = inspect.getsource(actions_module._convert_action_point)
+    assert "_validate_model_space_point" in source

--- a/tests/test_android_vision_coordinate_contract.py
+++ b/tests/test_android_vision_coordinate_contract.py
@@ -23,7 +23,11 @@ from mobilerun.tools.helpers.images import (
     image_dimensions,
     resize_image_to_max_side_with_grid,
 )
-from mobilerun.tools.ui.provider import AndroidStateProvider, StateProvider
+from mobilerun.tools.ui.provider import (
+    AndroidStateProvider,
+    StateProvider,
+    should_resize_model_screenshot,
+)
 from mobilerun.tools.ui.screenshot_provider import ScreenshotOnlyStateProvider
 
 NATIVE_W, NATIVE_H = 1080, 2400
@@ -132,8 +136,8 @@ def test_resize_flags_pair_providers_with_agent_gating():
     assert _provider(vision_enabled=True).resize_model_screenshot is True
     assert _provider().resize_model_screenshot is False
 
-    # …and every agent that attaches screenshots gates its resize on it.
-    # (This pairing is what makes the provider's coordinate_scale valid.)
+    # …and every agent that attaches screenshots gates its resize on the
+    # shared helper. (This pairing is what makes coordinate_scale valid.)
     import mobilerun.agent.executor.executor_agent as executor_agent
     import mobilerun.agent.fast_agent.fast_agent as fast_agent
     import mobilerun.agent.manager.manager_agent as manager_agent
@@ -141,8 +145,36 @@ def test_resize_flags_pair_providers_with_agent_gating():
 
     for module in (fast_agent, executor_agent, manager_agent, stateless_manager_agent):
         source = inspect.getsource(module)
-        assert "resize_model_screenshot" in source, module.__name__
+        assert "should_resize_model_screenshot" in source, module.__name__
         assert "resize_image_to_max_side_with_grid" in source, module.__name__
+
+
+def test_legacy_injected_screenshot_providers_keep_getting_resized():
+    """Injected providers that only implement the pre-existing
+    ``requires_coordinate_tools`` contract must still get resized screenshots:
+    the tool registry, prompts, and validation all still treat them as
+    screenshot-coordinate mode."""
+
+    class LegacyScreenshotProvider(StateProvider):
+        requires_coordinate_tools = True
+
+    assert should_resize_model_screenshot(LegacyScreenshotProvider(SimpleNamespace()))
+
+    class DuckTypedLegacyProvider:
+        requires_coordinate_tools = True
+
+    assert should_resize_model_screenshot(DuckTypedLegacyProvider())
+
+    # Non-coordinate providers are unaffected
+    assert not should_resize_model_screenshot(StateProvider(SimpleNamespace()))
+    assert not should_resize_model_screenshot(_provider())
+    assert not should_resize_model_screenshot(SimpleNamespace())
+
+    # And the new contract still activates it
+    assert should_resize_model_screenshot(_provider(vision_enabled=True))
+    assert should_resize_model_screenshot(
+        ScreenshotOnlyStateProvider(SimpleNamespace())
+    )
 
 
 def test_provider_scale_matches_what_agents_actually_send():

--- a/tests/test_visual_remote_connection.py
+++ b/tests/test_visual_remote_connection.py
@@ -464,7 +464,7 @@ class ScreenshotOnlyStateProviderTest(unittest.TestCase):
             self.assertNotIn("Do not tap toggles", description)
 
         self.assertIn(
-            "Click at screen position", registry.tools["click_at"].description
+            "Click at position", registry.tools["click_at"].description
         )
         self.assertIn("Duration is in seconds", registry.tools["swipe"].description)
 


### PR DESCRIPTION
Closes #350. Supersedes #355.

**Stacked on #357** (anthropic_oauth image delivery) — merge that first, then retarget/merge this.

## Problem

With `AndroidStateProvider` + vision, the raw native screenshot (e.g. 1080×2400) is attached to LLM messages while `coordinate_scale` stays 1.0. Vision models downscale large images *inside the provider API* and answer in **model-dependent** spaces — measured on a 1080×2400 emulator with a11y ground truth:

| model | output space (no contract) | mean y-error |
|---|---|---|
| gpt-5.4-mini | ~1.18×-downscaled | 213px, 0/4 hits |
| claude-opus-4-7 | near-native (~1.0) | 32px |

So screenshot-estimated `click_at`/`swipe` coordinates land off-target for some models, and **no fixed multiplier can be right for all of them** (a 2048-fit constant, as #355 proposed, roughly matches GPT but corrupts Claude's already-native outputs — reproduced live as off-screen swipes). Normalized 0-1000 output was also measured and rejected: Claude flip-flops between spaces.

## Fix — port the ScreenshotOnly contract triple to the a11y+vision path

1. **Resize**: agents resize the vision screenshot with the labeled grid whenever the provider sets `resize_model_screenshot` (new gate; `ScreenshotOnlyStateProvider` sets it alongside `requires_coordinate_tools`, behavior unchanged there).
2. **Declare**: `AndroidStateProvider(vision_enabled=True)` computes the display space with the same `fit_dimensions_to_max_side`, appends the coordinate-space contract to `formatted_text`, and emits model-facing element bounds in display space — while `bounds` (the real-tap path via `get_element_coords`) stays native. Coordinate-tool descriptions now state the space.
3. **Scale back**: `coordinate_scale = native/display`, so `convert_point` maps model output to device pixels.

Plus:
- Reasoning mode now also activates the contract when **executor**.vision is set — the executor is the agent emitting coordinate actions.
- Guardrail: out-of-space coordinates are rejected with a corrective message instead of tapped (mirrors `_validate_screenshot_only_point`).
- Normalized mode opts out ([0-1000] is scale-invariant).

## Testing

- **138/138 unit tests** pass, including 9 new ones — notably `test_provider_scale_matches_what_agents_actually_send`, the pairing invariant #355 lacked (provider scale must describe the image agents really attach).
- **Live agent run (GPT, vision)**: every step attaches 922×2048 grid image; model swipes in display space; `convert_point` outputs in-bounds native pixels (pre-fix: raw 1080×2400 attached, swipe converted to x=1112 on a 1080px screen).
- **Live agent run (Claude via #357, vision)**: image delivered, display-space swipe converted in-bounds, multi-step task completed.
- **Full-chain grounding eval** (real provider state + exact attached image + `_convert_action_point`, scored against native a11y bounds): gpt-5.4-mini **3/3 hits** (~57px from center), claude-opus-4-7 2/3 with one 1px hit (the "miss" tapped the row's horizontal center of a left-aligned label).
- `tests/eval_coordinate_grounding.py` (not pytest-collected; needs device+LLM) re-runs this measurement when adding models or touching the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)