### PR TITLE
feat(provider): port the vision coordinate contract to IOSStateProvider

### DIFF
--- a/mobilerun/agent/droid/droid_agent.py
+++ b/mobilerun/agent/droid/droid_agent.py
@@ -548,6 +548,7 @@ class MobileAgent(Workflow):
             self.state_provider = IOSStateProvider(
                 driver,
                 use_normalized=self.config.agent.use_normalized_coordinates,
+                vision_enabled=vision_enabled,
             )
         else:
             tree_filter = ConciseFilter() if vision_enabled else DetailedFilter()

--- a/mobilerun/tools/ui/ios_provider.py
+++ b/mobilerun/tools/ui/ios_provider.py
@@ -66,7 +66,14 @@ class IOSStateProvider(StateProvider):
         # without the contract a vision model answers in image space and taps
         # land wrong. Normalized [0-1000] coordinates are scale-invariant and
         # opt out, mirroring AndroidStateProvider.
-        self.resize_model_screenshot = vision_enabled and not use_normalized
+        #
+        # The flag is re-evaluated on every get_state: it must describe the
+        # CURRENT state's contract, because the agents resize the screenshot
+        # they captured based on it. If the contract could not be established
+        # for a state (screenshot probe failed), resizing that step's image
+        # would desynchronize the model's space from convert_point.
+        self._vision_contract_intent = vision_enabled and not use_normalized
+        self.resize_model_screenshot = self._vision_contract_intent
 
     async def get_state(self) -> UIState:
         try:
@@ -75,6 +82,10 @@ class IOSStateProvider(StateProvider):
             raise
         except Exception as e:
             logger.warning(f"iOS state retrieval failed, returning empty state: {e}")
+            # No contract for this state — agents must not resize the
+            # screenshot they attach alongside it.
+            if self._vision_contract_intent:
+                self.resize_model_screenshot = False
             return UIState(
                 elements=[],
                 formatted_text="No UI elements available — device may be loading.",
@@ -109,7 +120,7 @@ class IOSStateProvider(StateProvider):
         coordinate_scale_y = 1.0
         display_width = None
         display_height = None
-        if self.resize_model_screenshot and screen_width and screen_height:
+        if self._vision_contract_intent and screen_width and screen_height:
             try:
                 screenshot = await self.driver.screenshot()
                 shot_width, shot_height = image_dimensions(screenshot)
@@ -128,6 +139,10 @@ class IOSStateProvider(StateProvider):
                 display_height = None
                 coordinate_scale_x = 1.0
                 coordinate_scale_y = 1.0
+        if self._vision_contract_intent:
+            # Keep agent-side resizing paired with the contract this state
+            # actually declares.
+            self.resize_model_screenshot = bool(display_width and display_height)
 
         if display_width and display_height:
             # Model-facing bounds in display space; "bounds" (points) keep

--- a/mobilerun/tools/ui/ios_provider.py
+++ b/mobilerun/tools/ui/ios_provider.py
@@ -16,6 +16,10 @@ from typing import Any, Dict, List
 
 from mobilerun_core_cli.driver.base import DeviceDisconnectedError, DeviceDriver
 
+from mobilerun.tools.helpers.images import (
+    fit_dimensions_to_max_side,
+    image_dimensions,
+)
 from mobilerun.tools.ui.provider import StateProvider
 from mobilerun.tools.ui.state import UIState
 
@@ -49,9 +53,20 @@ class IOSStateProvider(StateProvider):
 
     supported = {"element_index", "convert_point"}
 
-    def __init__(self, driver: DeviceDriver, use_normalized: bool = False) -> None:
+    def __init__(
+        self,
+        driver: DeviceDriver,
+        use_normalized: bool = False,
+        vision_enabled: bool = False,
+    ) -> None:
         super().__init__(driver)
         self.use_normalized = use_normalized
+        self.vision_enabled = vision_enabled
+        # iOS screenshots are physical pixels while taps/bounds are points, so
+        # without the contract a vision model answers in image space and taps
+        # land wrong. Normalized [0-1000] coordinates are scale-invariant and
+        # opt out, mirroring AndroidStateProvider.
+        self.resize_model_screenshot = vision_enabled and not use_normalized
 
     async def get_state(self) -> UIState:
         try:
@@ -80,12 +95,72 @@ class IOSStateProvider(StateProvider):
         elements = _parse_a11y_tree(a11y_text)
         phone_state = _normalize_phone_state(phone_state, a11y_text)
 
-        # Screen size from device_context
+        # Screen size from device_context (points — the tap input space)
         screen_bounds = device_context.get("screen_bounds", {})
         screen_width = int(screen_bounds.get("width", 390))
         screen_height = int(screen_bounds.get("height", 844))
 
+        # Vision coordinate contract: the screenshot agents attach is resized
+        # (with a labeled grid) into a display space derived from the actual
+        # physical-pixel screenshot; the portal reports only points, so the
+        # physical dimensions must be measured from real bytes (the device
+        # scale factor varies, 2x/3x).
+        coordinate_scale_x = 1.0
+        coordinate_scale_y = 1.0
+        display_width = None
+        display_height = None
+        if self.resize_model_screenshot and screen_width and screen_height:
+            try:
+                screenshot = await self.driver.screenshot()
+                shot_width, shot_height = image_dimensions(screenshot)
+                display_width, display_height = fit_dimensions_to_max_side(
+                    shot_width, shot_height
+                )
+                # convert_point maps model output back to POINTS, not pixels
+                coordinate_scale_x = screen_width / display_width
+                coordinate_scale_y = screen_height / display_height
+            except Exception as e:
+                logger.warning(
+                    f"iOS vision coordinate contract disabled for this state "
+                    f"(screenshot probe failed): {e}"
+                )
+                display_width = None
+                display_height = None
+                coordinate_scale_x = 1.0
+                coordinate_scale_y = 1.0
+
+        if display_width and display_height:
+            # Model-facing bounds in display space; "bounds" (points) keep
+            # driving element taps.
+            for element in elements:
+                left, top, right, bottom = (
+                    int(part) for part in element["bounds"].split(",")
+                )
+                element["displayBounds"] = ",".join(
+                    str(round(value / scale))
+                    for value, scale in zip(
+                        (left, top, right, bottom),
+                        (
+                            coordinate_scale_x,
+                            coordinate_scale_y,
+                            coordinate_scale_x,
+                            coordinate_scale_y,
+                        ),
+                    )
+                )
+
         formatted_text = _format_elements(elements, screen_width, screen_height)
+
+        if display_width and display_height:
+            formatted_text += (
+                f"\n\nAll coordinates in this device state (element bounds above, "
+                f"and any x/y you provide to coordinate actions) are in a "
+                f"{display_width}x{display_height} coordinate space — the device "
+                f"screen scaled to the screenshot shown to you. "
+                f"When a screenshot is provided it matches this "
+                f"{display_width}x{display_height} space and carries a labeled "
+                f"coordinate grid for reference."
+            )
 
         # Extract focused text from phone_state
         focused_element = phone_state.get("focusedElement")
@@ -101,6 +176,8 @@ class IOSStateProvider(StateProvider):
             screen_width=screen_width,
             screen_height=screen_height,
             use_normalized=self.use_normalized,
+            coordinate_scale_x=coordinate_scale_x,
+            coordinate_scale_y=coordinate_scale_y,
         )
 
 
@@ -261,7 +338,9 @@ def _format_elements(
         idx = el.get("index", 0)
         cls = el.get("className", "Unknown")
         text = el.get("text", "")
-        bounds = el.get("bounds", "")
+        # Model-facing text shows display-space bounds when the screenshot is
+        # resized for the model; "bounds" (points) drive real taps.
+        bounds = el.get("displayBounds") or el.get("bounds", "")
 
         parts = [f"{idx}. {cls}:"]
         if text:

--- a/mobilerun/tools/ui/provider.py
+++ b/mobilerun/tools/ui/provider.py
@@ -200,7 +200,12 @@ class AndroidStateProvider(StateProvider):
         self.screenshot_matches_input_coords = not use_normalized
         # Normalized [0-1000] coordinates are scale-invariant, so the
         # deterministic-space contract is only needed for pixel coordinates.
-        self.resize_model_screenshot = vision_enabled and not use_normalized
+        # Re-evaluated per get_state: the flag must describe the CURRENT
+        # state's contract — if screen bounds are unavailable for a state,
+        # resizing that step's screenshot would desynchronize the model's
+        # space from convert_point.
+        self._vision_contract_intent = vision_enabled and not use_normalized
+        self.resize_model_screenshot = self._vision_contract_intent
 
     async def _recover_portal(self) -> None:
         """Restart Portal's accessibility service and TCP socket server."""
@@ -267,12 +272,16 @@ class AndroidStateProvider(StateProvider):
         coordinate_scale_y = 1.0
         display_width = None
         display_height = None
-        if self.resize_model_screenshot and screen_width and screen_height:
+        if self._vision_contract_intent and screen_width and screen_height:
             display_width, display_height = fit_dimensions_to_max_side(
                 screen_width, screen_height
             )
             coordinate_scale_x = screen_width / display_width
             coordinate_scale_y = screen_height / display_height
+        if self._vision_contract_intent:
+            # Keep agent-side resizing paired with the contract this state
+            # actually declares (screen bounds can be missing for a state).
+            self.resize_model_screenshot = bool(display_width and display_height)
 
         self.tree_formatter.screen_width = screen_width
         self.tree_formatter.screen_height = screen_height

--- a/tests/test_android_vision_coordinate_contract.py
+++ b/tests/test_android_vision_coordinate_contract.py
@@ -149,6 +149,28 @@ def test_resize_flags_pair_providers_with_agent_gating():
         assert "resize_image_to_max_side_with_grid" in source, module.__name__
 
 
+def test_missing_screen_bounds_disables_resize_for_that_state():
+    """When a state arrives without screen bounds, no contract can be
+    declared — the agents must not resize that step's screenshot either,
+    or the model's space desynchronizes from convert_point."""
+    provider = _provider(vision_enabled=True)
+    no_bounds = _combined_data()
+    no_bounds["device_context"]["screen_bounds"] = {}
+    provider.driver.get_ui_tree.return_value = no_bounds
+
+    state = _get_state(provider)
+
+    assert state.coordinate_scale_x == 1.0
+    assert "coordinate space" not in state.formatted_text
+    assert should_resize_model_screenshot(provider) is False
+
+    # Bounds return → contract and resize gate come back together
+    provider.driver.get_ui_tree.return_value = _combined_data()
+    state2 = _get_state(provider)
+    assert state2.coordinate_scale_x != 1.0
+    assert should_resize_model_screenshot(provider) is True
+
+
 def test_legacy_injected_screenshot_providers_keep_getting_resized():
     """Injected providers that only implement the pre-existing
     ``requires_coordinate_tools`` contract must still get resized screenshots:

--- a/tests/test_ios_vision_coordinate_contract.py
+++ b/tests/test_ios_vision_coordinate_contract.py
@@ -36,12 +36,18 @@ def _png(width, height):
 
 
 class FakeIOSDriver:
-    def __init__(self, screenshot_bytes=None, screenshot_error=None):
-        self._shot = screenshot_bytes
-        self._err = screenshot_error
+    def __init__(self, screenshot_bytes=None, screenshot_error=None, screenshot_plan=None):
+        # screenshot_plan: per-call behaviors (bytes or Exception); the last
+        # entry repeats. Overrides screenshot_bytes/screenshot_error.
+        self._plan = screenshot_plan or (
+            [screenshot_error] if screenshot_error else [screenshot_bytes]
+        )
         self.screenshot_calls = 0
+        self.ui_tree_error = None
 
     async def get_ui_tree(self):
+        if self.ui_tree_error:
+            raise self.ui_tree_error
         return {
             "phone_state": {"currentApp": "Settings", "packageName": "com.apple.Preferences"},
             "device_context": {"screen_bounds": {"width": POINTS_W, "height": POINTS_H}},
@@ -49,10 +55,11 @@ class FakeIOSDriver:
         }
 
     async def screenshot(self):
+        step = self._plan[min(self.screenshot_calls, len(self._plan) - 1)]
         self.screenshot_calls += 1
-        if self._err:
-            raise self._err
-        return self._shot
+        if isinstance(step, Exception):
+            raise step
+        return step
 
 
 def _state(provider):
@@ -129,6 +136,46 @@ def test_screenshot_failure_falls_back_to_legacy_behavior():
     assert "coordinate space" not in state.formatted_text
     assert "displayBounds" not in str(state.elements)
     assert state.convert_point(220, 478) == (220, 478)
+    # The resize gate must fall back WITH the state: agents capture their
+    # screenshot before get_state, and resizing it while this state converts
+    # 1:1 would desynchronize the model's space from convert_point.
+    assert should_resize_model_screenshot(provider) is False
+
+
+def test_probe_failure_disables_resize_for_agent_captured_screenshot():
+    """The review scenario, in the agents' real order: the agent's own
+    capture succeeds, the provider's probe fails — that step must not be
+    resized."""
+    driver = FakeIOSDriver(screenshot_plan=[
+        _png(PIXELS_W, PIXELS_H),          # 1: agent's capture (succeeds)
+        RuntimeError("transient hiccup"),  # 2: provider probe (fails)
+        _png(PIXELS_W, PIXELS_H),          # 3+: recovery
+    ])
+    provider = IOSStateProvider(driver, vision_enabled=True)
+
+    agent_screenshot = asyncio.run(driver.screenshot())  # agents capture first
+    state = _state(provider)                             # probe fails inside
+
+    assert agent_screenshot is not None
+    assert state.coordinate_scale_x == 1.0
+    assert should_resize_model_screenshot(provider) is False  # raw image sent
+
+    # Next step recovers: probe succeeds, contract and gate return together
+    state2 = _state(provider)
+    assert should_resize_model_screenshot(provider) is True
+    assert state2.coordinate_scale_x != 1.0
+    assert "coordinate space" in state2.formatted_text
+
+
+def test_ui_tree_failure_also_disables_resize():
+    driver = FakeIOSDriver(screenshot_bytes=_png(PIXELS_W, PIXELS_H))
+    provider = IOSStateProvider(driver, vision_enabled=True)
+    driver.ui_tree_error = RuntimeError("tree fetch failed")
+
+    state = _state(provider)
+
+    assert state.coordinate_scale_x == 1.0
+    assert should_resize_model_screenshot(provider) is False
 
 
 def test_resize_flag_pairs_with_agent_gating():

--- a/tests/test_ios_vision_coordinate_contract.py
+++ b/tests/test_ios_vision_coordinate_contract.py
@@ -1,0 +1,159 @@
+"""Tests for the iOS a11y+vision coordinate contract.
+
+iOS screenshots are physical pixels while taps and a11y bounds are points,
+so the display space is derived from the actual screenshot bytes and
+``convert_point`` maps the model's display-space output back to POINTS.
+Mirrors tests/test_android_vision_coordinate_contract.py.
+"""
+
+import asyncio
+from io import BytesIO
+from types import SimpleNamespace
+
+from PIL import Image
+
+from mobilerun.agent.utils.actions import _convert_action_point
+from mobilerun.tools.helpers.images import fit_dimensions_to_max_side
+from mobilerun.tools.ui.ios_provider import IOSStateProvider
+from mobilerun.tools.ui.provider import should_resize_model_screenshot
+
+POINTS_W, POINTS_H = 440, 956
+PIXELS_W, PIXELS_H = 1320, 2868  # 3x physical screenshot
+
+RAW_A11Y = """Attributes: Application, pid: 123, label: 'Settings'
+Element subtree:
+ ->Application, pid: 123, label: 'Settings'
+    Window (Main), {{0.0, 0.0}, {440.0, 956.0}}
+      Cell, {{20.0, 200.0}, {400.0, 44.0}}, label: 'General'
+      StaticText, {{20.0, 119.7}, {133.0, 40.7}}, label: 'Settings'
+"""
+
+
+def _png(width, height):
+    buf = BytesIO()
+    Image.new("RGB", (width, height), color=(10, 20, 30)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class FakeIOSDriver:
+    def __init__(self, screenshot_bytes=None, screenshot_error=None):
+        self._shot = screenshot_bytes
+        self._err = screenshot_error
+        self.screenshot_calls = 0
+
+    async def get_ui_tree(self):
+        return {
+            "phone_state": {"currentApp": "Settings", "packageName": "com.apple.Preferences"},
+            "device_context": {"screen_bounds": {"width": POINTS_W, "height": POINTS_H}},
+            "a11y_tree": RAW_A11Y,
+        }
+
+    async def screenshot(self):
+        self.screenshot_calls += 1
+        if self._err:
+            raise self._err
+        return self._shot
+
+
+def _state(provider):
+    return asyncio.run(provider.get_state())
+
+
+def _general_element(state):
+    return next(e for e in state.elements if e.get("text") == "General")
+
+
+def test_vision_disabled_keeps_legacy_behavior():
+    driver = FakeIOSDriver(screenshot_bytes=_png(8, 8))
+    state = _state(IOSStateProvider(driver))
+
+    assert state.coordinate_scale_x == 1.0
+    assert state.coordinate_scale_y == 1.0
+    assert "coordinate space" not in state.formatted_text
+    assert "displayBounds" not in str(state.elements)
+    assert state.convert_point(220, 478) == (220, 478)
+    # no extra screenshot traffic in non-vision mode
+    assert driver.screenshot_calls == 0
+
+
+def test_vision_enabled_declares_display_space_and_scales_to_points():
+    driver = FakeIOSDriver(screenshot_bytes=_png(PIXELS_W, PIXELS_H))
+    provider = IOSStateProvider(driver, vision_enabled=True)
+    state = _state(provider)
+
+    display_w, display_h = fit_dimensions_to_max_side(PIXELS_W, PIXELS_H)
+    assert (display_w, display_h) == (943, 2048)
+    assert state.coordinate_scale_x == POINTS_W / display_w
+    assert state.coordinate_scale_y == POINTS_H / display_h
+
+    # Contract declared in the display space
+    assert f"{display_w}x{display_h} coordinate space" in state.formatted_text
+
+    # Model-facing bounds in display space; tap bounds stay points
+    element = _general_element(state)
+    assert element["bounds"] == "20,200,420,244"
+    scale_x, scale_y = state.coordinate_scale_x, state.coordinate_scale_y
+    expected_display = ",".join(
+        str(round(v / s))
+        for v, s in zip((20, 200, 420, 244), (scale_x, scale_y, scale_x, scale_y))
+    )
+    assert element["displayBounds"] == expected_display
+    assert expected_display in state.formatted_text
+    assert "(20,200,420,244)" not in state.formatted_text
+
+    # convert_point maps display-space output back to POINTS (hard anchors)
+    assert state.convert_point(471, 1024) == (220, 478)
+    # element tap path keeps points
+    assert state.get_element_coords(element["index"]) == (220, 222)
+    assert driver.screenshot_calls == 1
+
+
+def test_normalized_mode_opts_out_of_the_contract():
+    driver = FakeIOSDriver(screenshot_bytes=_png(PIXELS_W, PIXELS_H))
+    provider = IOSStateProvider(driver, use_normalized=True, vision_enabled=True)
+    state = _state(provider)
+
+    assert provider.resize_model_screenshot is False
+    assert state.coordinate_scale_x == 1.0
+    assert "coordinate space" not in state.formatted_text
+    assert driver.screenshot_calls == 0
+
+
+def test_screenshot_failure_falls_back_to_legacy_behavior():
+    driver = FakeIOSDriver(screenshot_error=RuntimeError("portal hiccup"))
+    provider = IOSStateProvider(driver, vision_enabled=True)
+    state = _state(provider)
+
+    assert state.coordinate_scale_x == 1.0
+    assert state.coordinate_scale_y == 1.0
+    assert "coordinate space" not in state.formatted_text
+    assert "displayBounds" not in str(state.elements)
+    assert state.convert_point(220, 478) == (220, 478)
+
+
+def test_resize_flag_pairs_with_agent_gating():
+    driver = FakeIOSDriver(screenshot_bytes=_png(PIXELS_W, PIXELS_H))
+    assert should_resize_model_screenshot(IOSStateProvider(driver, vision_enabled=True))
+    assert not should_resize_model_screenshot(IOSStateProvider(driver))
+    assert not should_resize_model_screenshot(
+        IOSStateProvider(driver, use_normalized=True, vision_enabled=True)
+    )
+
+
+def test_convert_action_point_validates_ios_model_space():
+    driver = FakeIOSDriver(screenshot_bytes=_png(PIXELS_W, PIXELS_H))
+    provider = IOSStateProvider(driver, vision_enabled=True)
+    state = _state(provider)
+    ctx = SimpleNamespace(ui=state, state_provider=provider)
+
+    # display-space coordinates convert to points
+    assert _convert_action_point(471, 1024, ctx=ctx) == (220, 478)
+
+    # raw physical-pixel coordinates (the pre-contract failure mode) are
+    # outside the 943x2048 display space and get rejected
+    try:
+        _convert_action_point(1200, 2500, ctx=ctx)
+    except ValueError as e:
+        assert "943x2048" in str(e)
+    else:
+        raise AssertionError("expected ValueError for image-space point")


### PR DESCRIPTION
## Problem

Follow-up to #358, which fixed the vision coordinate-space mismatch for Android only. iOS has the same bug class — measured live on a physical iPhone 17 Pro Max via ios-portal, identically on released 0.6.4 and current main: in vision mode the **raw physical-pixel screenshot** (1320×2868) is attached to LLM messages while taps and a11y bounds use **points** (440×956) and `coordinate_scale` stays 1.0. Models answer in image space; observed live: `convert_point(388, 1780)` on a 956-point screen — out of bounds. Scroll gestures survive via clamping; precision taps would not. `click_at` is masked on iOS, but default-enabled `swipe` rides this path.

## Fix — same contract triple, with the iOS twist

- `IOSStateProvider` gains `vision_enabled` and sets `resize_model_screenshot`, so the shared agent gate (from #358) resizes the vision screenshot with the labeled grid — no agent changes needed.
- **The display space is derived from actual screenshot bytes**: the portal's `/state` reports only points and the device scale factor varies (2x/3x), so physical dimensions must be measured (`image_dimensions`), exactly as `ScreenshotOnlyStateProvider` does. One extra screenshot per `get_state` in vision mode; probe failure degrades gracefully to legacy behavior.
- `coordinate_scale = points / display` — `convert_point` maps the model's display-space output back to **points**, not pixels (scale < 1, unlike Android).
- Model-facing bounds emitted in display space (`displayBounds`); `bounds` (points) keep driving element taps. Contract declared in `formatted_text`; the existing shared guardrail rejects out-of-space coordinates (a raw physical-pixel coordinate like (1200, 2500) now gets a corrective error instead of a wild tap).
- Normalized mode opts out; non-vision is untouched (zero extra screenshot traffic — asserted by test).

## Testing

- **145/145 unit tests**, 6 new in `tests/test_ios_vision_coordinate_contract.py` (display-space declaration + points scale-back with hard anchors, points-tap preservation, normalized opt-out, screenshot-failure fallback, agent-gate pairing, guardrail rejection of image-space coords).
- **Live on the iPhone 17 Pro simulator** (1206×2622 physical / 402×874 points): pipeline probe shows vision attaches 942×2048 grid images with scale 0.4268 and lossless display→points round-trip (display center → exact points center); live vision agent runs with **gpt-5.4-mini** and **claude-opus-4-7** both emit display-space swipes converting to in-bounds points (previously out-of-bounds on hardware); non-vision runs click via points identically to released 0.6.4 (control run on 0.6.4 included).
- Physical-device baseline (pre-fix behavior) was captured earlier on an iPhone 17 Pro Max — happy to re-verify this branch on hardware before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)