### PR TITLE
fix(oauth): send ImageBlocks through GeminiOAuthCodeAssistLLM instead of dropping them

### DIFF
--- a/mobilerun/agent/utils/oauth/gemini_oauth_code_assist_llm.py
+++ b/mobilerun/agent/utils/oauth/gemini_oauth_code_assist_llm.py
@@ -20,8 +20,10 @@ from llama_index.core.base.llms.types import (
     ChatResponseGen,
     CompletionResponse,
     CompletionResponseGen,
+    ImageBlock,
     LLMMetadata,
     MessageRole,
+    TextBlock,
 )
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks import CallbackManager
@@ -748,25 +750,62 @@ class GeminiOAuthCodeAssistLLM(CustomLLM):
             return message.content
         return ""
 
+    @staticmethod
+    def _image_mime_type(raw: bytes) -> str:
+        if raw.startswith(b"\xff\xd8"):
+            return "image/jpeg"
+        if raw.startswith(b"RIFF") and raw[8:12] == b"WEBP":
+            return "image/webp"
+        if raw.startswith(b"GIF8"):
+            return "image/gif"
+        return "image/png"
+
+    @classmethod
+    def _message_parts(cls, message: ChatMessage) -> list[Dict[str, Any]]:
+        parts: list[Dict[str, Any]] = []
+        for block in message.blocks or []:
+            if isinstance(block, TextBlock):
+                if block.text:
+                    parts.append({"text": block.text})
+            elif isinstance(block, ImageBlock):
+                raw = block.resolve_image(as_base64=False).read()
+                parts.append(
+                    {
+                        "inlineData": {
+                            "mimeType": cls._image_mime_type(raw),
+                            "data": base64.b64encode(raw).decode("ascii"),
+                        }
+                    }
+                )
+        return parts
+
     def _to_code_assist_request(
         self,
         messages: Sequence[ChatMessage],
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        converted_messages = self.convert_chat_messages(messages)
-
+        # NOTE: deliberately not using ``self.convert_chat_messages`` — the
+        # llama_index base helper is text-only and raises on ImageBlocks.
         contents: list[Dict[str, Any]] = []
         system_chunks: list[str] = []
 
-        for msg in converted_messages:
-            text = self._message_text(msg)
+        for msg in messages:
+            parts = self._message_parts(msg)
             if msg.role == MessageRole.SYSTEM:
-                if text:
-                    system_chunks.append(text)
+                system_chunks.extend(
+                    part["text"] for part in parts if part.get("text")
+                )
                 continue
 
             role = "model" if msg.role == MessageRole.ASSISTANT else "user"
-            contents.append({"role": role, "parts": [{"text": text}]})
+            if any("inlineData" in part for part in parts):
+                contents.append({"role": role, "parts": parts})
+            else:
+                # Text-only messages keep the single-text-part shape the API
+                # already receives.
+                contents.append(
+                    {"role": role, "parts": [{"text": self._message_text(msg)}]}
+                )
 
         if not contents:
             contents.append({"role": "user", "parts": [{"text": ""}]})

--- a/tests/test_gemini_oauth_llm.py
+++ b/tests/test_gemini_oauth_llm.py
@@ -34,3 +34,97 @@ def test_gemini_oauth_profile_sends_gemini_flash_lite_verbatim(tmp_path) -> None
     assert profile.provider == "gemini_oauth_code_assist"
     assert profile.model == "gemini-3.1-flash-lite"
     assert payload["model"] == "gemini-3.1-flash-lite"
+
+
+def _gemini_llm():
+    from mobilerun.agent.utils.oauth.gemini_oauth_code_assist_llm import (
+        GeminiOAuthCodeAssistLLM,
+    )
+
+    return GeminiOAuthCodeAssistLLM(access_token="test-token", credential_path=None)
+
+
+def _tiny_image(fmt: str) -> bytes:
+    from io import BytesIO
+
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (2, 2), color=(255, 0, 0)).save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def test_image_block_is_sent_as_inline_data_part():
+    import base64
+
+    from llama_index.core.base.llms.types import ImageBlock, TextBlock
+
+    png = _tiny_image("PNG")
+    payload = _gemini_llm()._to_code_assist_request(
+        [
+            ChatMessage(
+                role=MessageRole.USER,
+                blocks=[TextBlock(text="what is this?"), ImageBlock(image=png)],
+            )
+        ]
+    )
+
+    parts = payload["request"]["contents"][0]["parts"]
+    assert parts[0] == {"text": "what is this?"}
+    inline = parts[1]["inlineData"]
+    assert inline["mimeType"] == "image/png"
+    assert base64.b64decode(inline["data"]) == png
+
+
+def test_image_only_message_is_sent_as_inline_data():
+    from llama_index.core.base.llms.types import ImageBlock
+
+    payload = _gemini_llm()._to_code_assist_request(
+        [ChatMessage(role=MessageRole.USER, blocks=[ImageBlock(image=_tiny_image("PNG"))])]
+    )
+
+    parts = payload["request"]["contents"][0]["parts"]
+    assert len(parts) == 1 and "inlineData" in parts[0]
+
+
+def test_jpeg_mime_type_is_detected():
+    from llama_index.core.base.llms.types import ImageBlock
+
+    payload = _gemini_llm()._to_code_assist_request(
+        [
+            ChatMessage(
+                role=MessageRole.USER,
+                blocks=[
+                    ImageBlock(image=_tiny_image("JPEG"), image_mimetype="image/jpeg")
+                ],
+            )
+        ]
+    )
+
+    inline = payload["request"]["contents"][0]["parts"][0]["inlineData"]
+    assert inline["mimeType"] == "image/jpeg"
+
+
+def test_text_only_messages_keep_single_text_part_shape():
+    payload = _gemini_llm()._to_code_assist_request(
+        [
+            ChatMessage(role=MessageRole.USER, content="hello"),
+            ChatMessage(role=MessageRole.ASSISTANT, content="hi"),
+        ]
+    )
+
+    contents = payload["request"]["contents"]
+    assert contents[0] == {"role": "user", "parts": [{"text": "hello"}]}
+    assert contents[1] == {"role": "model", "parts": [{"text": "hi"}]}
+
+
+def test_system_message_text_reaches_system_instruction():
+    payload = _gemini_llm()._to_code_assist_request(
+        [
+            ChatMessage(role=MessageRole.SYSTEM, content="be terse"),
+            ChatMessage(role=MessageRole.USER, content="hello"),
+        ]
+    )
+
+    assert "be terse" in payload["request"]["systemInstruction"]["parts"][0]["text"]
+    assert all(c["role"] != "system" for c in payload["request"]["contents"])


### PR DESCRIPTION
## Problem

Same bug class as #357 (AnthropicOAuthLLM): `_to_code_assist_request` kept only plain-string message content, so the screenshots that fast_agent/executor/manager attach as llama_index `ImageBlock`s in vision mode never reached Gemini. Empirically confirmed: a "what does this screenshot show?" probe answered the literal string **"NO IMAGE"**.

## Fix

- Message blocks are converted to `generateContent` parts: `TextBlock` → `{"text": ...}`, `ImageBlock` → `{"inlineData": {"mimeType": ..., "data": <base64>}}` with the mime type sniffed from the bytes (png/jpeg/webp/gif).
- Text-only messages keep the existing single-text-part request shape (no change for current traffic); system text still flows into `systemInstruction`.
- The builder no longer routes through llama_index's `convert_chat_messages` — that base helper is text-only and raises `ValueError` on image-only messages, which is part of how the drop went unnoticed.

## Test plan

- [x] 5 new unit tests in `tests/test_gemini_oauth_llm.py` (text+image part order with base64 round-trip, image-only, jpeg mime sniffing, text-only shape preserved, system-instruction routing) — full suite 153/153.
- [x] Live sight-check via `load_llm("gemini_oauth_code_assist")` + emulator screenshot: answers "About emulated device (Android settings)" — exactly the on-screen content (previously "NO IMAGE"). `gemini-3.1-pro-preview` hit its usual Code Assist timeout/quota, so the delivery check ran on `gemini-2.5-flash`; the conversion path is model-independent.

Note: this makes images *reach* Gemini; whether a given Gemini model grounds coordinates well enough for vision-driven coordinate actions is a separate evaluation (`tests/eval_coordinate_grounding.py`), pending Code Assist quota for pro-tier models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)