### PR TITLE
fix(vision): declare each model's effective screenshot size (#365)

### DIFF
--- a/mobilerun/agent/droid/droid_agent.py
+++ b/mobilerun/agent/droid/droid_agent.py
@@ -50,6 +50,7 @@ from mobilerun.agent.utils.llm_loader import (
 )
 from mobilerun.agent.utils.prompt_resolver import PromptResolver
 from mobilerun.agent.utils.signatures import build_tool_registry
+from mobilerun.agent.utils.vision_sizing import VisionResizePolicy
 from mobilerun.agent.utils.tracing_setup import (
     apply_session_context,
     record_langfuse_screenshot,
@@ -477,6 +478,37 @@ class MobileAgent(Workflow):
                 self.config.agent.vision_only or self.config.agent.fast_agent.vision
             )
 
+        # Resolve the model-facing screenshot size once, from every vision LLM
+        # that will receive a screenshot, so the declared coordinate space equals
+        # what each model actually grounds on after any provider-side downsize.
+        # Conservative: use the smallest effective size across all recipients.
+        if self.config.agent.reasoning:
+            vision_llms = [
+                llm
+                for use, llm in (
+                    (
+                        self.config.agent.vision_only
+                        or self.config.agent.manager.vision,
+                        self.manager_llm,
+                    ),
+                    (
+                        self.config.agent.vision_only
+                        or self.config.agent.executor.vision,
+                        self.executor_llm,
+                    ),
+                )
+                if use and llm is not None
+            ]
+        elif (
+            self.config.agent.vision_only or self.config.agent.fast_agent.vision
+        ) and self.fast_agent_llm is not None:
+            vision_llms = [self.fast_agent_llm]
+        else:
+            vision_llms = []
+        vision_resize_policy = VisionResizePolicy.from_llms(
+            vision_llms, max_side_cap=self.config.agent.model_screenshot_max_side
+        )
+
         is_ios = self.resolved_device_config.platform.lower() == "ios"
         control_backend = _normalize_control_backend(
             self.resolved_device_config.control_backend
@@ -543,12 +575,15 @@ class MobileAgent(Workflow):
         if self._injected_state_provider is not None:
             self.state_provider = self._injected_state_provider
         elif self.config.agent.vision_only or is_visual_remote:
-            self.state_provider = ScreenshotOnlyStateProvider(driver)
+            self.state_provider = ScreenshotOnlyStateProvider(
+                driver, vision_resize_policy=vision_resize_policy
+            )
         elif is_ios:
             self.state_provider = IOSStateProvider(
                 driver,
                 use_normalized=self.config.agent.use_normalized_coordinates,
                 vision_enabled=vision_enabled,
+                vision_resize_policy=vision_resize_policy,
             )
         else:
             tree_filter = ConciseFilter() if vision_enabled else DetailedFilter()
@@ -560,6 +595,7 @@ class MobileAgent(Workflow):
                 use_normalized=self.config.agent.use_normalized_coordinates,
                 stealth=stealth_enabled,
                 vision_enabled=vision_enabled,
+                vision_resize_policy=vision_resize_policy,
             )
 
         # ── 3. Build tool registry ────────────────────────────────────

--- a/mobilerun/agent/executor/executor_agent.py
+++ b/mobilerun/agent/executor/executor_agent.py
@@ -30,8 +30,10 @@ from mobilerun.agent.utils.inference import acall_with_retries
 from mobilerun.agent.utils.prompt_resolver import PromptResolver
 from mobilerun.config_manager.config_manager import AgentConfig
 from mobilerun.config_manager.prompt_loader import PromptLoader
-from mobilerun.tools.helpers.images import resize_image_to_max_side_with_grid
-from mobilerun.tools.ui.provider import should_resize_model_screenshot
+from mobilerun.tools.ui.provider import (
+    resize_model_screenshot_with_grid,
+    should_resize_model_screenshot,
+)
 
 if TYPE_CHECKING:
     from mobilerun.agent.action_context import ActionContext
@@ -139,7 +141,9 @@ class ExecutorAgent(Workflow):
             screenshot = self.shared_state.screenshot
             if screenshot is not None:
                 if should_resize_model_screenshot(self.action_ctx.state_provider):
-                    screenshot = resize_image_to_max_side_with_grid(screenshot)
+                    screenshot = resize_model_screenshot_with_grid(
+                        self.action_ctx.state_provider, screenshot
+                    )
                 messages[0].blocks.append(ImageBlock(image=screenshot))
                 logger.debug("📸 Using screenshot for Executor")
             else:

--- a/mobilerun/agent/fast_agent/fast_agent.py
+++ b/mobilerun/agent/fast_agent/fast_agent.py
@@ -46,8 +46,10 @@ from mobilerun.agent.utils.prompt_resolver import PromptResolver
 from mobilerun.agent.utils.tracing_setup import record_langfuse_screenshot
 from mobilerun.config_manager.config_manager import AgentConfig, TracingConfig
 from mobilerun.config_manager.prompt_loader import PromptLoader
-from mobilerun.tools.helpers.images import resize_image_to_max_side_with_grid
-from mobilerun.tools.ui.provider import should_resize_model_screenshot
+from mobilerun.tools.ui.provider import (
+    resize_model_screenshot_with_grid,
+    should_resize_model_screenshot,
+)
 
 if TYPE_CHECKING:
     from mobilerun.agent.action_context import ActionContext
@@ -328,7 +330,9 @@ class FastAgent(Workflow):
             # Screenshot → last user message
             if self.vision and screenshot:
                 if should_resize_model_screenshot(self.state_provider):
-                    screenshot = resize_image_to_max_side_with_grid(screenshot)
+                    screenshot = resize_model_screenshot_with_grid(
+                        self.state_provider, screenshot
+                    )
                 messages_to_send[last_user_idx].blocks.append(
                     ImageBlock(image=screenshot)
                 )

--- a/mobilerun/agent/manager/manager_agent.py
+++ b/mobilerun/agent/manager/manager_agent.py
@@ -48,8 +48,10 @@ from mobilerun.app_cards.providers import (
     ServerAppCardProvider,
 )
 from mobilerun.config_manager.prompt_loader import PromptLoader
-from mobilerun.tools.helpers.images import resize_image_to_max_side_with_grid
-from mobilerun.tools.ui.provider import should_resize_model_screenshot
+from mobilerun.tools.ui.provider import (
+    resize_model_screenshot_with_grid,
+    should_resize_model_screenshot,
+)
 
 if TYPE_CHECKING:
     from mobilerun.agent.action_context import ActionContext
@@ -292,7 +294,9 @@ class ManagerAgent(Workflow):
             # Add screenshot if vision enabled
             if screenshot and self.vision:
                 if should_resize_model_screenshot(self.state_provider):
-                    screenshot = resize_image_to_max_side_with_grid(screenshot)
+                    screenshot = resize_model_screenshot_with_grid(
+                        self.state_provider, screenshot
+                    )
                 messages[last_user_idx].blocks.append(ImageBlock(image=screenshot))
 
             # Add previous device state to second-to-last user message

--- a/mobilerun/agent/manager/stateless_manager_agent.py
+++ b/mobilerun/agent/manager/stateless_manager_agent.py
@@ -26,8 +26,10 @@ from mobilerun.agent.utils.inference import acall_with_retries
 from mobilerun.agent.utils.prompt_resolver import PromptResolver
 from mobilerun.agent.utils.tracing_setup import record_langfuse_screenshot
 from mobilerun.config_manager.prompt_loader import PromptLoader
-from mobilerun.tools.helpers.images import resize_image_to_max_side_with_grid
-from mobilerun.tools.ui.provider import should_resize_model_screenshot
+from mobilerun.tools.ui.provider import (
+    resize_model_screenshot_with_grid,
+    should_resize_model_screenshot,
+)
 
 if TYPE_CHECKING:
     from mobilerun.agent.action_context import ActionContext
@@ -232,7 +234,9 @@ class StatelessManagerAgent(Workflow):
 
         if self.vision and screenshot:
             if should_resize_model_screenshot(self.state_provider):
-                screenshot = resize_image_to_max_side_with_grid(screenshot)
+                screenshot = resize_model_screenshot_with_grid(
+                    self.state_provider, screenshot
+                )
             messages[0]["content"].append({"image": screenshot})
 
         chat_messages = to_chat_messages(messages)

--- a/mobilerun/agent/utils/vision_sizing.py
+++ b/mobilerun/agent/utils/vision_sizing.py
@@ -1,0 +1,94 @@
+"""Resolve the exact screenshot size a vision model actually grounds on.
+
+Some providers downsize images server-side before the model sees them (e.g.
+Anthropic's 28px visual-token budget). If the coordinate contract declares a
+larger space than the model receives, the model grounds on the smaller image it
+actually sees and coordinate actions land short. This policy computes the EXACT
+dimensions the model will use, so the declared space == the sent image and
+``convert_point`` stays exact.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence
+
+from mobilerun.tools.helpers.images import (
+    MODEL_SCREENSHOT_MAX_SIDE,
+    anthropic_resized_size,
+    fit_dimensions_to_max_side,
+)
+
+# Anthropic models with the high-resolution budget (2576 px / 4784 tokens).
+# Unknown Anthropic ids fall back to the standard 1568 budget — never assume
+# high-res, since that would re-introduce the undershoot bug.
+_ANTHROPIC_HIGHRES_MODELS = {
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-fable-5",
+    "claude-mythos-5",
+}
+_ANTHROPIC_STANDARD = (1568, 1568)  # (max_edge, max_tokens)
+_ANTHROPIC_HIGHRES = (2576, 4784)
+
+
+def _model_id(llm: Any) -> str:
+    return str(getattr(llm, "model", "") or "")
+
+
+def _is_anthropic(model_id: str) -> bool:
+    return model_id.startswith("claude")
+
+
+def model_effective_dims(model_id: str, width: int, height: int) -> tuple[int, int]:
+    """Exact dims a single model grounds on for a native ``width``x``height`` screen."""
+    base_w, base_h = fit_dimensions_to_max_side(
+        width, height, MODEL_SCREENSHOT_MAX_SIDE
+    )
+    if _is_anthropic(model_id):
+        edge, tokens = (
+            _ANTHROPIC_HIGHRES
+            if model_id in _ANTHROPIC_HIGHRES_MODELS
+            else _ANTHROPIC_STANDARD
+        )
+        return anthropic_resized_size(base_w, base_h, edge, tokens)
+    # OpenAI / Gemini / Ollama / OpenAI-compatible: ground at the declared size
+    # (empirically no further server-side downsize for the supported models).
+    return base_w, base_h
+
+
+class VisionResizePolicy:
+    """Composite resize policy across all active vision models.
+
+    Resolves the screenshot dimensions the contract should declare and send so
+    the image matches what EVERY screenshot recipient grounds on. Uses the
+    smallest (most conservative) result across models, then an optional explicit
+    max-side cap (escape hatch for undocumented local/Ollama models).
+    """
+
+    def __init__(
+        self, model_ids: Sequence[str], max_side_cap: Optional[int] = None
+    ) -> None:
+        self._model_ids = [m for m in dict.fromkeys(model_ids) if m]
+        self._cap = max_side_cap if (max_side_cap and max_side_cap > 0) else None
+
+    @classmethod
+    def from_llms(
+        cls, llms: Sequence[Any], max_side_cap: Optional[int] = None
+    ) -> "VisionResizePolicy":
+        return cls(
+            [_model_id(llm) for llm in llms if llm is not None],
+            max_side_cap=max_side_cap,
+        )
+
+    def effective_dims(self, width: int, height: int) -> tuple[int, int]:
+        """Smallest effective dims across all models, after the optional cap."""
+        if width <= 0 or height <= 0:
+            return width, height
+        candidates = [
+            model_effective_dims(m, width, height) for m in self._model_ids
+        ] or [fit_dimensions_to_max_side(width, height, MODEL_SCREENSHOT_MAX_SIDE)]
+        # Aspect ratio is preserved, so smallest long-edge == smallest area.
+        w, h = min(candidates, key=max)
+        if self._cap and max(w, h) > self._cap:
+            w, h = fit_dimensions_to_max_side(w, h, self._cap)
+        return w, h

--- a/mobilerun/config_manager/config_manager.py
+++ b/mobilerun/config_manager/config_manager.py
@@ -116,6 +116,10 @@ class AgentConfig:
     after_sleep_action: float = 1.0
     wait_for_stable_ui: float = 0.3
     use_normalized_coordinates: bool = False
+    # Optional cap (px, long edge) on the model-facing screenshot size, applied
+    # on top of per-model effective-size resolution. Escape hatch for local
+    # vision models (e.g. Ollama) that downsize to an undocumented size.
+    model_screenshot_max_side: Optional[int] = None
 
     fast_agent: FastAgentConfig = field(default_factory=FastAgentConfig)
     manager: ManagerConfig = field(default_factory=ManagerConfig)
@@ -327,6 +331,7 @@ class MobileConfig:
             use_normalized_coordinates=agent_data.get(
                 "use_normalized_coordinates", False
             ),
+            model_screenshot_max_side=agent_data.get("model_screenshot_max_side"),
             fast_agent=fast_agent_config,
             manager=manager_config,
             executor=executor_config,

--- a/mobilerun/tools/helpers/images.py
+++ b/mobilerun/tools/helpers/images.py
@@ -2,12 +2,54 @@
 
 from __future__ import annotations
 
+import math
 import struct
 from io import BytesIO
 
 from PIL import Image, ImageDraw, ImageFont
 
 MODEL_SCREENSHOT_MAX_SIDE = 2048
+
+
+def anthropic_resized_size(
+    width: int, height: int, max_edge: int, max_tokens: int
+) -> tuple[int, int]:
+    """Dimensions Anthropic will resize an image to before the model sees it.
+
+    Mirrors Anthropic's documented rule: images are split into 28x28 visual
+    tokens; the image is shrunk (preserving aspect) until every edge is
+    ``<= max_edge`` AND the token count ``<= max_tokens``. ``(max_edge,
+    max_tokens)`` is ``(1568, 1568)`` for standard models and ``(2576, 4784)``
+    for high-resolution models (Opus 4.7+, etc.).
+    """
+    if width <= 0 or height <= 0:
+        raise ValueError("Image dimensions must be positive.")
+
+    def tokens(w: int, h: int) -> int:
+        return math.ceil(w / 28) * math.ceil(h / 28)
+
+    def fits(w: int, h: int) -> bool:
+        return (
+            math.ceil(w / 28) * 28 <= max_edge
+            and math.ceil(h / 28) * 28 <= max_edge
+            and tokens(w, h) <= max_tokens
+        )
+
+    if fits(width, height):
+        return width, height
+    if height > width:
+        rw, rh = anthropic_resized_size(height, width, max_edge, max_tokens)
+        return rh, rw
+
+    aspect = width / height
+    lo, hi = 1, width
+    while lo + 1 < hi:
+        mid = (lo + hi) // 2
+        if fits(mid, max(round(mid / aspect), 1)):
+            lo = mid
+        else:
+            hi = mid
+    return lo, max(round(lo / aspect), 1)
 
 
 def image_dimensions(image: bytes) -> tuple[int, int]:
@@ -60,7 +102,20 @@ def resize_image_to_max_side_with_grid(
     """Resize image and overlay a model-only coordinate grid."""
     width, height = image_dimensions(image)
     target_width, target_height = fit_dimensions_to_max_side(width, height, max_side)
+    return resize_image_to_dimensions_with_grid(
+        image, target_width, target_height, divisions=divisions
+    )
 
+
+def resize_image_to_dimensions_with_grid(
+    image: bytes, target_width: int, target_height: int, divisions: int = 10
+) -> bytes:
+    """Resize image to exact ``target_width``x``target_height`` and overlay the grid.
+
+    Used by the vision coordinate contract so the image the model receives
+    matches the declared coordinate space exactly.
+    """
+    width, height = image_dimensions(image)
     with Image.open(BytesIO(image)) as source:
         screenshot = source.convert("RGBA")
         if (target_width, target_height) != (width, height):

--- a/mobilerun/tools/ui/ios_provider.py
+++ b/mobilerun/tools/ui/ios_provider.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from mobilerun_core_cli.driver.base import DeviceDisconnectedError, DeviceDriver
 
@@ -58,10 +58,16 @@ class IOSStateProvider(StateProvider):
         driver: DeviceDriver,
         use_normalized: bool = False,
         vision_enabled: bool = False,
+        vision_resize_policy: Any = None,
     ) -> None:
         super().__init__(driver)
         self.use_normalized = use_normalized
         self.vision_enabled = vision_enabled
+        # Resolves the exact screenshot dims the active vision model grounds on
+        # (duck-typed: needs ``effective_dims(w, h)``). None → legacy 2048 cap.
+        self.vision_resize_policy = vision_resize_policy
+        self.model_screenshot_width: Optional[int] = None
+        self.model_screenshot_height: Optional[int] = None
         # iOS screenshots are physical pixels while taps/bounds are points, so
         # without the contract a vision model answers in image space and taps
         # land wrong. Normalized [0-1000] coordinates are scale-invariant and
@@ -96,6 +102,8 @@ class IOSStateProvider(StateProvider):
             # screenshot they attach alongside it.
             if self._vision_contract_intent:
                 self.resize_model_screenshot = False
+            self.model_screenshot_width = None
+            self.model_screenshot_height = None
             return UIState(
                 elements=[],
                 formatted_text="No UI elements available — device may be loading.",
@@ -134,9 +142,16 @@ class IOSStateProvider(StateProvider):
             try:
                 screenshot = await self.driver.screenshot()
                 shot_width, shot_height = image_dimensions(screenshot)
-                display_width, display_height = fit_dimensions_to_max_side(
-                    shot_width, shot_height
-                )
+                if self.vision_resize_policy is not None:
+                    display_width, display_height = (
+                        self.vision_resize_policy.effective_dims(
+                            shot_width, shot_height
+                        )
+                    )
+                else:
+                    display_width, display_height = fit_dimensions_to_max_side(
+                        shot_width, shot_height
+                    )
                 # convert_point maps model output back to POINTS, not pixels
                 coordinate_scale_x = screen_width / display_width
                 coordinate_scale_y = screen_height / display_height
@@ -153,6 +168,9 @@ class IOSStateProvider(StateProvider):
             # Keep agent-side resizing paired with the contract this state
             # actually declares.
             self.resize_model_screenshot = bool(display_width and display_height)
+        # Exact dims the model-facing screenshot must match for this state.
+        self.model_screenshot_width = display_width
+        self.model_screenshot_height = display_height
 
         if display_width and display_height:
             # Model-facing bounds in display space; "bounds" (points) keep
@@ -204,6 +222,8 @@ class IOSStateProvider(StateProvider):
             coordinate_scale_x=coordinate_scale_x,
             coordinate_scale_y=coordinate_scale_y,
             coordinate_contract_active=bool(display_width and display_height),
+            model_screenshot_width=display_width,
+            model_screenshot_height=display_height,
         )
 
 

--- a/mobilerun/tools/ui/provider.py
+++ b/mobilerun/tools/ui/provider.py
@@ -13,7 +13,11 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
 
 from mobilerun_core_cli.driver.base import DeviceDisconnectedError
 
-from mobilerun.tools.helpers.images import fit_dimensions_to_max_side
+from mobilerun.tools.helpers.images import (
+    fit_dimensions_to_max_side,
+    resize_image_to_dimensions_with_grid,
+    resize_image_to_max_side_with_grid,
+)
 from mobilerun.tools.ui.state import UIState
 from mobilerun.tools.ui.stealth_state import StealthUIState
 
@@ -166,6 +170,21 @@ def should_resize_model_screenshot(state_provider: Any) -> bool:
     )
 
 
+def resize_model_screenshot_with_grid(state_provider: Any, screenshot: bytes) -> bytes:
+    """Resize a screenshot to the exact model-facing dims the provider declared.
+
+    The provider stores ``model_screenshot_width/height`` (resolved from the
+    active vision model's effective image size) on each ``get_state``. Resizing
+    to those exact dims keeps the image the model grounds on equal to the
+    declared coordinate space. Falls back to the legacy max-side resize when no
+    dims are available (e.g. injected screenshot-only providers)."""
+    width = getattr(state_provider, "model_screenshot_width", None)
+    height = getattr(state_provider, "model_screenshot_height", None)
+    if width and height:
+        return resize_image_to_dimensions_with_grid(screenshot, width, height)
+    return resize_image_to_max_side_with_grid(screenshot)
+
+
 class AndroidStateProvider(StateProvider):
     """Fetches state from an Android device via ``driver.get_ui_tree()``.
 
@@ -185,6 +204,7 @@ class AndroidStateProvider(StateProvider):
         stealth: bool = False,
         ui_cls: "type[UIState] | None" = None,
         vision_enabled: bool = False,
+        vision_resize_policy: Any = None,
     ) -> None:
         super().__init__(driver)
         self.tree_filter = tree_filter
@@ -192,6 +212,13 @@ class AndroidStateProvider(StateProvider):
         self.use_normalized = use_normalized
         self._ui_cls = ui_cls or (StealthUIState if stealth else UIState)
         self.vision_enabled = vision_enabled
+        # Resolves the exact screenshot dims the active vision model grounds on
+        # (duck-typed: needs ``effective_dims(w, h)``). None → legacy 2048 cap.
+        self.vision_resize_policy = vision_resize_policy
+        # Exact model-facing screenshot dims for the current state (set per
+        # get_state); read by resize_model_screenshot_with_grid.
+        self.model_screenshot_width: Optional[int] = None
+        self.model_screenshot_height: Optional[int] = None
         # Android screenshots and input taps share device-pixel coordinates,
         # but only when not in normalized mode. ``use_normalized=True`` makes
         # ``UIState.convert_point`` treat inputs as [0-1000] normalized
@@ -273,15 +300,23 @@ class AndroidStateProvider(StateProvider):
         display_width = None
         display_height = None
         if self._vision_contract_intent and screen_width and screen_height:
-            display_width, display_height = fit_dimensions_to_max_side(
-                screen_width, screen_height
-            )
+            if self.vision_resize_policy is not None:
+                display_width, display_height = self.vision_resize_policy.effective_dims(
+                    screen_width, screen_height
+                )
+            else:
+                display_width, display_height = fit_dimensions_to_max_side(
+                    screen_width, screen_height
+                )
             coordinate_scale_x = screen_width / display_width
             coordinate_scale_y = screen_height / display_height
         if self._vision_contract_intent:
             # Keep agent-side resizing paired with the contract this state
             # actually declares (screen bounds can be missing for a state).
             self.resize_model_screenshot = bool(display_width and display_height)
+        # Exact dims the model-facing screenshot must match for this state.
+        self.model_screenshot_width = display_width
+        self.model_screenshot_height = display_height
 
         self.tree_formatter.screen_width = screen_width
         self.tree_formatter.screen_height = screen_height
@@ -321,4 +356,6 @@ class AndroidStateProvider(StateProvider):
             coordinate_scale_x=coordinate_scale_x,
             coordinate_scale_y=coordinate_scale_y,
             coordinate_contract_active=bool(display_width and display_height),
+            model_screenshot_width=display_width,
+            model_screenshot_height=display_height,
         )

--- a/mobilerun/tools/ui/screenshot_provider.py
+++ b/mobilerun/tools/ui/screenshot_provider.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 from mobilerun.tools.helpers.images import fit_dimensions_to_max_side, image_dimensions
 from mobilerun.tools.ui.provider import StateProvider
@@ -19,8 +19,15 @@ class ScreenshotOnlyStateProvider(StateProvider):
     requires_coordinate_tools = True
     resize_model_screenshot = True
 
-    def __init__(self, driver: "DeviceDriver") -> None:
+    def __init__(
+        self, driver: "DeviceDriver", vision_resize_policy: Any = None
+    ) -> None:
         super().__init__(driver)
+        # Resolves the exact screenshot dims the active vision model grounds on
+        # (duck-typed: needs ``effective_dims(w, h)``). None → legacy 2048 cap.
+        self.vision_resize_policy = vision_resize_policy
+        self.model_screenshot_width: Optional[int] = None
+        self.model_screenshot_height: Optional[int] = None
 
     async def get_state(self) -> UIState:
         screenshot = await self.driver.screenshot()
@@ -30,10 +37,17 @@ class ScreenshotOnlyStateProvider(StateProvider):
             input_width, input_height = native_width, native_height
         else:
             input_width, input_height = await input_size(native_width, native_height)
-        screen_width, screen_height = fit_dimensions_to_max_side(
-            native_width,
-            native_height,
-        )
+        if self.vision_resize_policy is not None:
+            screen_width, screen_height = self.vision_resize_policy.effective_dims(
+                native_width, native_height
+            )
+        else:
+            screen_width, screen_height = fit_dimensions_to_max_side(
+                native_width,
+                native_height,
+            )
+        self.model_screenshot_width = screen_width
+        self.model_screenshot_height = screen_height
         max_x = max(screen_width - 1, 0)
         max_y = max(screen_height - 1, 0)
 
@@ -69,4 +83,6 @@ class ScreenshotOnlyStateProvider(StateProvider):
             use_normalized=False,
             coordinate_scale_x=input_width / screen_width,
             coordinate_scale_y=input_height / screen_height,
+            model_screenshot_width=screen_width,
+            model_screenshot_height=screen_height,
         )

--- a/mobilerun/tools/ui/state.py
+++ b/mobilerun/tools/ui/state.py
@@ -27,6 +27,8 @@ class UIState:
         coordinate_scale_x: float = 1.0,
         coordinate_scale_y: float = 1.0,
         coordinate_contract_active: bool = False,
+        model_screenshot_width: Optional[int] = None,
+        model_screenshot_height: Optional[int] = None,
     ) -> None:
         self.elements = elements
         self.formatted_text = formatted_text
@@ -37,6 +39,11 @@ class UIState:
         self.use_normalized = use_normalized
         self.coordinate_scale_x = coordinate_scale_x
         self.coordinate_scale_y = coordinate_scale_y
+        # Exact pixel size the model-facing screenshot must be resized to so the
+        # image the model grounds on matches this snapshot's declared coordinate
+        # space (== convert_point basis). None means "no contract / native".
+        self.model_screenshot_width = model_screenshot_width
+        self.model_screenshot_height = model_screenshot_height
         # Whether the vision coordinate contract (resized+grid screenshot,
         # declared display space) is active for this snapshot. Action-time
         # coordinate guards read it from here so they match the space this

--- a/tests/eval_coordinate_grounding.py
+++ b/tests/eval_coordinate_grounding.py
@@ -27,14 +27,22 @@ from llama_index.core.base.llms.types import ChatMessage, ImageBlock, TextBlock
 
 from mobilerun.agent.utils.actions import _convert_action_point
 from mobilerun.agent.utils.llm_picker import load_llm
+from mobilerun.agent.utils.vision_sizing import VisionResizePolicy
 from mobilerun.tools.filters import ConciseFilter
 from mobilerun.tools.formatters import IndexedFormatter
-from mobilerun.tools.helpers.images import resize_image_to_max_side_with_grid
-from mobilerun.tools.ui.provider import AndroidStateProvider
+from mobilerun.tools.ui.provider import (
+    AndroidStateProvider,
+    resize_model_screenshot_with_grid,
+)
 
 PROVIDERS = [
     ("openai", "openai_oauth", "gpt-5.4-mini"),
     ("anthropic", "anthropic_oauth", "claude-opus-4-7"),
+    # claude-sonnet-4-6 uses Anthropic's standard 1568 visual-token budget, so it
+    # downsizes a 2048-declared screenshot and would undershoot ~23% without the
+    # per-model resize policy (issue #365). Keep it here so the eval covers an
+    # AFFECTED model, not just the high-res opus-4-7 that masked the bug.
+    ("anthropic", "anthropic_oauth", "claude-sonnet-4-6"),
     # gemini_oauth_code_assist quota is too tight for repeated vision calls;
     # add it back when evaluating Gemini support.
 ]
@@ -84,12 +92,9 @@ async def main(serial: str) -> None:
         tree_formatter=IndexedFormatter(),
         vision_enabled=True,
     )
-    state = await provider.get_state()
     screenshot = await driver.screenshot()
-    sent_image = resize_image_to_max_side_with_grid(screenshot)
-    ctx = SimpleNamespace(ui=state, state_provider=provider)
-
-    targets = _pick_targets(state)
+    # Device-pixel target bounds are model-independent; pick them once.
+    targets = _pick_targets(await provider.get_state())
     if not targets:
         print("No suitable targets on screen — open a list-style screen (e.g. Settings).")
         sys.exit(1)
@@ -101,7 +106,16 @@ async def main(serial: str) -> None:
         except Exception as e:
             print(f"--- {name}: SKIP ({type(e).__name__}: {e})")
             continue
-        print(f"--- {name} ({model}) ---")
+        # Declare + send this model's EFFECTIVE size, exactly like production, so
+        # the eval validates the fixed path (not the pre-fix fixed-2048 space).
+        provider.vision_resize_policy = VisionResizePolicy([model])
+        state = await provider.get_state()
+        sent_image = resize_model_screenshot_with_grid(provider, screenshot)
+        ctx = SimpleNamespace(ui=state, state_provider=provider)
+        print(
+            f"--- {name} ({model}) declared="
+            f"{provider.model_screenshot_width}x{provider.model_screenshot_height} ---"
+        )
         for text, (left, top, right, bottom) in targets:
             message = ChatMessage(
                 role="user",

--- a/tests/test_android_vision_coordinate_contract.py
+++ b/tests/test_android_vision_coordinate_contract.py
@@ -110,6 +110,47 @@ def test_vision_enabled_declares_display_space_and_scales_back():
     assert state.get_element_coords(2) == (410, 434)
 
 
+def test_policy_declares_model_effective_dims_for_anthropic_standard():
+    # issue #365: a standard-budget Anthropic model grounds at 706x1568, so the
+    # contract must declare 706x1568 (not the 2048 default) and scale back from it.
+    from mobilerun.agent.utils.vision_sizing import VisionResizePolicy
+
+    provider = _provider(
+        vision_enabled=True,
+        vision_resize_policy=VisionResizePolicy(["claude-sonnet-4-6"]),
+    )
+    state = _get_state(provider)
+
+    assert (state.model_screenshot_width, state.model_screenshot_height) == (706, 1568)
+    assert provider.model_screenshot_width == 706
+    assert state.coordinate_scale_x == NATIVE_W / 706
+    assert state.coordinate_scale_y == NATIVE_H / 1568
+    assert "706x1568 coordinate space" in state.formatted_text
+    # ~center of the 706x1568 image maps back to the native screen center.
+    x, y = state.convert_point(353, 784)
+    assert abs(x - 540) <= 4 and abs(y - 1200) <= 6
+
+
+def test_no_policy_keeps_2048_default_dims():
+    state = _get_state(_provider(vision_enabled=True))
+    assert (state.model_screenshot_width, state.model_screenshot_height) == (922, 2048)
+
+
+def test_resize_helper_resizes_to_provider_dims():
+    from mobilerun.agent.utils.vision_sizing import VisionResizePolicy
+    from mobilerun.tools.ui.provider import resize_model_screenshot_with_grid
+
+    provider = _provider(
+        vision_enabled=True,
+        vision_resize_policy=VisionResizePolicy(["claude-sonnet-4-6"]),
+    )
+    _get_state(provider)
+    buf = BytesIO()
+    Image.new("RGB", (NATIVE_W, NATIVE_H), (10, 20, 30)).save(buf, "PNG")
+    out = resize_model_screenshot_with_grid(provider, buf.getvalue())
+    assert image_dimensions(out) == (706, 1568)
+
+
 def test_small_screens_keep_scale_one_but_still_declare_space():
     state = _get_state(_provider(height=1920, vision_enabled=True))
 
@@ -146,7 +187,7 @@ def test_resize_flags_pair_providers_with_agent_gating():
     for module in (fast_agent, executor_agent, manager_agent, stateless_manager_agent):
         source = inspect.getsource(module)
         assert "should_resize_model_screenshot" in source, module.__name__
-        assert "resize_image_to_max_side_with_grid" in source, module.__name__
+        assert "resize_model_screenshot_with_grid" in source, module.__name__
 
 
 def test_missing_screen_bounds_disables_resize_for_that_state():

--- a/tests/test_vision_sizing.py
+++ b/tests/test_vision_sizing.py
@@ -1,0 +1,66 @@
+"""Tests for the per-model vision resize policy (issue #365)."""
+
+from types import SimpleNamespace
+
+from mobilerun.agent.utils.vision_sizing import (
+    VisionResizePolicy,
+    model_effective_dims,
+)
+from mobilerun.tools.helpers.images import anthropic_resized_size
+
+
+def test_anthropic_resized_size_standard_budget():
+    # Tall phone screenshot, standard 1568 budget → long edge clamped to 1568.
+    assert anthropic_resized_size(922, 2048, 1568, 1568) == (706, 1568)
+    # 16:9 case where the token budget binds tighter than the 1568 edge.
+    assert anthropic_resized_size(1080, 1920, 1568, 1568) == (819, 1456)
+
+
+def test_anthropic_resized_size_highres_budget_keeps_2048():
+    # High-res budget (Opus 4.7+): a 922x2048 image fits unchanged.
+    assert anthropic_resized_size(922, 2048, 2576, 4784) == (922, 2048)
+
+
+def test_model_effective_dims_per_provider():
+    # Standard Anthropic model downsizes; high-res Anthropic + others do not.
+    assert model_effective_dims("claude-sonnet-4-6", 1080, 2400) == (706, 1568)
+    assert model_effective_dims("claude-opus-4-7", 1080, 2400) == (922, 2048)
+    assert model_effective_dims("gpt-5.5", 1080, 2400) == (922, 2048)
+    assert model_effective_dims("gemini-3.5-flash-low", 1080, 2400) == (922, 2048)
+    # Unknown Anthropic id is treated as STANDARD (never assume high-res).
+    assert model_effective_dims("claude-future-9", 1080, 2400) == (706, 1568)
+
+
+def test_policy_single_model():
+    assert VisionResizePolicy(["claude-sonnet-4-6"]).effective_dims(1080, 2400) == (
+        706,
+        1568,
+    )
+    assert VisionResizePolicy(["gpt-5.5"]).effective_dims(1080, 2400) == (922, 2048)
+
+
+def test_policy_composite_takes_smallest():
+    # Mixed manager/executor models → declare the smallest so both are correct.
+    policy = VisionResizePolicy(["claude-opus-4-7", "claude-sonnet-4-6"])
+    assert policy.effective_dims(1080, 2400) == (706, 1568)
+    # All high-res / non-downsizing → stays at 2048.
+    assert VisionResizePolicy(["claude-opus-4-7", "gpt-5.5"]).effective_dims(
+        1080, 2400
+    ) == (922, 2048)
+
+
+def test_policy_empty_defaults_to_2048_fit():
+    assert VisionResizePolicy([]).effective_dims(1080, 2400) == (922, 2048)
+
+
+def test_policy_max_side_cap_shrinks_further():
+    policy = VisionResizePolicy(["claude-sonnet-4-6"], max_side_cap=1280)
+    w, h = policy.effective_dims(1080, 2400)
+    assert max(w, h) == 1280
+
+
+def test_policy_from_llms_reads_model_attr():
+    llms = [SimpleNamespace(model="claude-sonnet-4-6"), SimpleNamespace(model="gpt-5.5")]
+    policy = VisionResizePolicy.from_llms(llms)
+    # min across sonnet(1568) and gpt(2048) → 1568.
+    assert policy.effective_dims(1080, 2400) == (706, 1568)

--- a/tests/test_visual_remote_connection.py
+++ b/tests/test_visual_remote_connection.py
@@ -478,7 +478,7 @@ class ScreenshotOnlyStateProviderTest(unittest.TestCase):
         ]
 
         for path in agent_files:
-            self.assertIn("resize_image_to_max_side_with_grid", path.read_text())
+            self.assertIn("resize_model_screenshot_with_grid", path.read_text())
 
     def test_visual_remote_exact_app_launch_tool_needs_only_start_app(self):
         async def run():


### PR DESCRIPTION
Fixes #365.

## Problem

The vision coordinate contract resizes every screenshot to a fixed `MODEL_SCREENSHOT_MAX_SIDE=2048` and declares that space, but some providers **downsize the image server-side** before the model sees it. Anthropic's standard visual-token budget (most models, incl. **`claude-sonnet-4-6` — the api-key default**) shrinks a 2048 image to a **1568** long edge. So the model grounds on a ~706×1568 image while `convert_point` back-scales from the declared 922×2048 → `click_at`/`click_area`/`long_press_at`/`swipe` land **~23% toward top-left**, intermittently by device profile.

Verified empirically (1080×2400 emulator):

| Model | effective ÷ declared | affected? |
|---|---|---|
| `claude-sonnet-4-6` (api-key default) | 0.766 | **yes (~23% short)** |
| `claude-opus-4-7` (OAuth default) / `opus-4-8` | 1.00 (2576 high-res budget) | no |
| `gpt-5.5` | 1.00 | no |
| gemini (OAuth) | 1.00 width | no (separate grounding-quality issue) |
| ollama `gemma4` | 0.625 | yes (model-specific) |

The #350 contract was sound — it was just validated on `claude-opus-4-7`, the one Anthropic model that *isn't* downsized, so the fixed-2048 choice was a model-specific artifact.

## Fix

Make the declared space equal the exact image the model actually grounds on:

- **`VisionResizePolicy`** (new `agent/utils/vision_sizing.py`) resolves each model's effective dims — Anthropic's exact 28px-tile `resized_size` (1568 standard / 2576 high-res; unknown Anthropic ids → standard), 2048 for OpenAI/Gemini/Ollama — and takes the **smallest** across all screenshot recipients (manager + executor, or the fast agent). Optional `AgentConfig.model_screenshot_max_side` cap (escape hatch for undocumented local models).
- Built once in `MobileAgent` and injected into the **Android, iOS, and screenshot-only** providers. Each declares the exact dims on `UIState` and sets `coordinate_scale = native/effective`.
- All four resize sites (executor, manager, stateless-manager, **fast agent**) resize to those exact dims via the new `resize_model_screenshot_with_grid`, so the sent image always matches the declared space and `convert_point` is exact — independent of whether the model reads the grid or grounds raw pixels.

Backward-compatible: no-policy / non-vision / normalized-coordinate paths keep the prior 2048 behavior.

## Testing

- **199 unit tests pass** (+11: Anthropic `resized_size`, composite-min, cap, per-provider effective dims, provider declares effective space + `convert_point` round-trip, resize helper, backward-compat).
- **End-to-end probe**: `claude-sonnet-4-6` taps now land at device `center_x=540` (was ~414, ~23% short); `opus-4-8` unchanged.
- **Live emulator**: `claude-sonnet-4-6 --vision` agent run completes.
- `tests/eval_coordinate_grounding.py` now covers the affected sonnet model and applies the per-model policy (the prior eval used opus-4-7, which masked the bug).

Plan and implementation each reviewed with codex (gpt-5.5 xhigh); the Anthropic algorithm was checked against Anthropic's published reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)