### PR TITLE
docs(agent-test-flows): brief for agent-run regression testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ frontend/
 reddit_python_posts.json
 
 test/
+# agent-test-flows generated run reports
+agent-test-flows/reports/

--- a/agent-test-flows/README.md
+++ b/agent-test-flows/README.md
@@ -1,0 +1,35 @@
+# agent-test-flows
+
+Briefs that tell an AI agent (Claude / Codex / Gemini) how to regression-test mobilerun before a
+release or PR. The agent reads this, decides the concrete tasks itself, runs them on real devices,
+and reports the results. Keep these short — the agent works out the details.
+
+## How to use
+Point an agent at this folder and ask for a **smoke** pass (quick, ~10–15 min) or a **full** pass
+(thorough, can take hours). The agent plans the tasks, picks models, runs them via `mobilerun run …`
+(and `mobilerun device` / `mobilerun macro` / `mobilerun <provider> login` as needed), and writes a
+comparison table with screenshots. Smoke = one cheap model + a few core checks; full = sweep the
+areas below.
+
+## What to cover
+- **Modes:** vision and non-vision; reasoning and non-reasoning.
+- **Platforms:** Android (emulator/device) and iOS (simulator/physical via ios-portal).
+- **UI actions:** open apps, tap, type, scroll, swipe, multi-step navigation, back/home.
+- **Models & providers:** a representative set across Anthropic, OpenAI, Gemini, and the others in
+  the registry — api-key and OAuth.
+- **OAuth:** login and token refresh per provider.
+- **Macros:** record a sequence (`mobilerun run … --save-trajectory`) and replay it.
+- **Cloud:** the cloud device backend.
+- Any other mobilerun functionality worth a check.
+
+The agent uses its judgment on the exact tasks and depth; there is no fixed script.
+
+## Guidance
+- **Verify independently** — don't trust the agent's own "done"; re-read the screen or check the
+  value (e.g. `mobilerun device ui`/screenshot).
+- **Capture evidence** — screenshots (and trajectories), summarized in a results table under
+  `reports/`.
+- **Set up the device first** — install the Portal if it's missing; on physical devices keep tasks
+  read-only and never destructive/paid.
+- **Treat known limits as expected**, not failures (e.g. Gemini OAuth short-window rate limits).
+- Optionally compare the run against a known-good ("ground-truth") release.


### PR DESCRIPTION
Adds `agent-test-flows/README.md` — a **short brief** that tells an AI agent (Claude / Codex / Gemini) how to regression-test mobilerun before a release or PR. The agent reads it, decides the concrete tasks itself, runs them on real devices, and reports results. No fixed script, no heavy harness — the agent works out the details.

**What to cover** (the brief): vision/non-vision · reasoning/non-reasoning · Android & iOS · UI actions (tap/type/scroll/swipe/navigation) · models across providers (api-key + OAuth) · OAuth login/refresh · macros (record via `--save-trajectory`, then replay) · cloud backend · anything else worth a check.

**Guidance**: verify results independently (don't trust the agent's own "done"), capture screenshots/trajectories into a results table, set up the Portal first / keep physical-device tasks read-only, and treat known limits (e.g. Gemini OAuth rate-limits) as expected rather than failures.

Also gitignores `agent-test-flows/reports/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)