### PR TITLE
Fix cloud CLI auth and post-merge regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Read the full [framework documentation](https://docs.mobilerun.ai/framework/quic
 
 ## ⚙️ Features
 
-- **CLI and TUI:** Run one-off natural language tasks, inspect devices, replay macros, and debug from the terminal.
+- **CLI:** Run one-off natural language tasks, inspect devices, replay macros, and debug from the terminal.
 - **Python API:** Build custom mobile automation workflows with Python and use custom tools.
 - **Android and iOS support:** Control Android through the Portal app or target iOS through the iOS Portal flow.
 - **Portal-based control:** Use UI trees, screenshots, text input, gestures, app launching, and device state from the Portal runtime.
@@ -152,7 +152,7 @@ Read the full [framework documentation](https://docs.mobilerun.ai/framework/quic
 | --- | --- | --- |
 | Best for | Running agents locally on your own machine and devices | Ready-to-go local phone control, hosted real or virtual devices, API workflows, and managed device operations |
 | Runtime | Your machine  | Mobilerun-managed infrastructure |
-| Interface | CLI, TUI, Docker, and Python API | Dashboard, REST API, SDKs, and hosted devices |
+| Interface | CLI, Docker, and Python API | Dashboard, REST API, SDKs, and hosted devices |
 
 Use the framework when you want full local control of the agent runtime. Use [Mobilerun Cloud](https://cloud.mobilerun.ai) when you want managed devices, fleet workflows, or cloud APIs without running the agent locally. Learn more in the [framework overview](https://docs.mobilerun.ai/framework/overview) and the [cloud docs](https://docs.mobilerun.ai).
 

--- a/docs/guides/cli.mdx
+++ b/docs/guides/cli.mdx
@@ -503,6 +503,7 @@ mobilerun ping --tcp
 | `OPENAI_API_KEY` | OpenAI API key | None |
 | `ANTHROPIC_API_KEY` | Anthropic API key | None |
 | `DEEPSEEK_API_KEY` | DeepSeek API key | None |
+| `MOBILERUN_CLOUD_API_KEY` | Mobilerun Cloud API key for `devices --cloud` and cloud device actions | None |
 | `MOBILERUN_CONFIG` | Config file path | `~/.config/mobilerun/config.yaml` |
 
 **Setting variables:**

--- a/docs/guides/overview.mdx
+++ b/docs/guides/overview.mdx
@@ -11,7 +11,7 @@ Welcome to the Mobilerun Guides! This section provides step-by-step instructions
 ### Getting Started
 
 **[CLI Reference](./cli)** - Complete command-line interface guide
-- All CLI commands (`run`, `setup`, `devices`, `connect`, `disconnect`, `ping`, `device`, `macro`, `doctor`, `tui`)
+- All CLI commands (`run`, `setup`, `devices`, `connect`, `disconnect`, `ping`, `device`, `macro`, `doctor`)
 - Configuration overrides and flags
 - Environment variables and API keys
 - Common workflows and troubleshooting

--- a/mobilerun/__init__.py
+++ b/mobilerun/__init__.py
@@ -7,8 +7,8 @@ from importlib.metadata import version
 
 __version__ = version("mobilerun")
 
-# Attach a default CLILogHandler so that every consumer (CLI, TUI, SDK,
-# tools-only) gets visible output without explicit setup.  CLI and TUI
+# Attach a default CLILogHandler so that every consumer (CLI, SDK,
+# tools-only) gets visible output without explicit setup.  CLI flows can
 # replace this with their own handler via ``configure_logging()``.
 from mobilerun.log_handlers import CLILogHandler
 

--- a/mobilerun/agent/providers/registry.py
+++ b/mobilerun/agent/providers/registry.py
@@ -11,7 +11,7 @@ from mobilerun.config_manager.credential_paths import (
 )
 
 # Canonical mapping from variant ID to env-key slot name.
-# Imported by setup_service, configure_wizard, config_manager, and TUI.
+# Imported by setup_service, configure_wizard, and config_manager.
 VARIANT_ENV_KEY_SLOT: dict[str, str] = {
     "GoogleGenAI": "google",
     "OpenAIResponses": "openai",

--- a/mobilerun/cli/device_commands.py
+++ b/mobilerun/cli/device_commands.py
@@ -32,7 +32,7 @@ from mobilerun.tools.ui.provider import AndroidStateProvider
 console = Console()
 
 DEFAULT_CLOUD_BASE_URL = "https://api.mobilerun.ai/v1"
-CLOUD_API_KEY_ENV = "MOBILERUN_API_KEY"
+CLOUD_API_KEY_ENV = "MOBILERUN_CLOUD_API_KEY"
 
 # Cloud device ids are UUIDs (RFC 4122); ADB serials never are. Used to
 # auto-route `-d <id>` to the cloud driver when the user didn't pass `--cloud`.
@@ -49,7 +49,7 @@ def _looks_like_cloud_device_id(value: Optional[str]) -> bool:
 def resolve_cloud_api_key() -> Optional[str]:
     """Resolve the Mobilerun cloud API key for ``--cloud`` commands.
 
-    Order: the ``MOBILERUN_API_KEY`` env var, then the credential persisted by
+    Order: the ``MOBILERUN_CLOUD_API_KEY`` env var, then the credential persisted by
     ``mobilerun login`` (``<config dir>/credentials/mobilerun-cloud.json``).
     """
     env_key = os.environ.get(CLOUD_API_KEY_ENV)

--- a/mobilerun/cli/deviceauth.py
+++ b/mobilerun/cli/deviceauth.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -140,12 +141,32 @@ def credential_path() -> Path:
     return OAUTH_CREDENTIAL_DIR / "mobilerun-cloud.json"
 
 
+def _chmod_private(path: Path, mode: int) -> None:
+    if os.name != "nt":
+        os.chmod(path, mode)
+
+
 def save_token(token: str, auth_url: str) -> Path:
-    """Persist the session token to the credentials dir (chmod 600)."""
+    """Persist the session token to the credentials dir."""
     path = credential_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps({"access_token": token, "auth_url": auth_url}))
-    os.chmod(path, 0o600)
+    _chmod_private(path.parent, 0o700)
+
+    payload = json.dumps({"access_token": token, "auth_url": auth_url})
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            handle.write(payload)
+        _chmod_private(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+        _chmod_private(path, 0o600)
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
     return path
 
 

--- a/mobilerun/cli/event_handler.py
+++ b/mobilerun/cli/event_handler.py
@@ -1,5 +1,5 @@
 """
-Shared event handler for CLI, TUI and SDK.
+Shared event handler for CLI and SDK.
 
 Translates workflow events into ``logging`` calls with ``extra`` params
 (color, step_increment, etc.).  The actual rendering is handled by

--- a/mobilerun/cli/main.py
+++ b/mobilerun/cli/main.py
@@ -569,6 +569,8 @@ async def _list_cloud_devices(
     base_url: str | None,
     *,
     silent_if_no_key: bool = False,
+    raise_on_error: bool = False,
+    silent_errors: bool = False,
 ) -> int:
     """List Mobilerun cloud devices via the SDK.
 
@@ -580,10 +582,13 @@ async def _list_cloud_devices(
     if not api_key:
         if silent_if_no_key:
             return 0
-        console.print(
-            f"[red]No cloud API key found. Set {CLOUD_API_KEY_ENV} or run "
-            "`mobilerun login`.[/]"
+        message = (
+            f"No cloud API key found. Set {CLOUD_API_KEY_ENV} or run "
+            "`mobilerun login`."
         )
+        if raise_on_error:
+            raise click.ClickException(message)
+        console.print(f"[red]{message}[/]")
         return 0
 
     from mobilerun_sdk import AsyncMobilerun
@@ -596,6 +601,10 @@ async def _list_cloud_devices(
     try:
         resp = await client.devices.list()
     except Exception as e:
+        if silent_errors:
+            return 0
+        if raise_on_error:
+            raise click.ClickException(f"Error listing cloud devices: {e}") from e
         console.print(f"[red]Error listing cloud devices: {e}[/]")
         return 0
 
@@ -640,7 +649,7 @@ async def devices(cloud: bool, base_url: str | None):
     a Mobilerun credential is available. ``--cloud`` shows only cloud.
     """
     if cloud:
-        await _list_cloud_devices(base_url)
+        await _list_cloud_devices(base_url, raise_on_error=True)
         return
 
     # Local section
@@ -658,7 +667,11 @@ async def devices(cloud: bool, base_url: str | None):
     # Cloud section (only when authenticated — silent otherwise).
     if resolve_cloud_api_key():
         console.print()
-        await _list_cloud_devices(base_url, silent_if_no_key=True)
+        await _list_cloud_devices(
+            base_url,
+            silent_if_no_key=True,
+            silent_errors=True,
+        )
 
 
 DEFAULT_AUTH_URL = "https://cloud.mobilerun.ai/api/auth"

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -1,0 +1,176 @@
+import asyncio
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from mobilerun.cli import device_commands
+from mobilerun.cli.main import cli
+
+
+def test_resolve_cloud_api_key_prefers_cloud_env(monkeypatch, tmp_path):
+    from mobilerun.config_manager import credential_paths
+
+    monkeypatch.setattr(credential_paths, "OAUTH_CREDENTIAL_DIR", tmp_path)
+    (tmp_path / "mobilerun-cloud.json").write_text(
+        '{"access_token": "saved-token", "auth_url": "https://example.test"}'
+    )
+    monkeypatch.setenv("MOBILERUN_CLOUD_API_KEY", "env-token")
+    monkeypatch.setenv("MOBILERUN_API_KEY", "legacy-token")
+
+    assert device_commands.resolve_cloud_api_key() == "env-token"
+
+
+def test_resolve_cloud_api_key_ignores_legacy_env(monkeypatch, tmp_path):
+    from mobilerun.config_manager import credential_paths
+
+    monkeypatch.setattr(credential_paths, "OAUTH_CREDENTIAL_DIR", tmp_path)
+    monkeypatch.delenv("MOBILERUN_CLOUD_API_KEY", raising=False)
+    monkeypatch.setenv("MOBILERUN_API_KEY", "legacy-token")
+
+    assert device_commands.resolve_cloud_api_key() is None
+
+
+def test_resolve_cloud_api_key_reads_saved_credential(monkeypatch, tmp_path):
+    from mobilerun.config_manager import credential_paths
+
+    monkeypatch.setattr(credential_paths, "OAUTH_CREDENTIAL_DIR", tmp_path)
+    monkeypatch.delenv("MOBILERUN_CLOUD_API_KEY", raising=False)
+    monkeypatch.delenv("MOBILERUN_API_KEY", raising=False)
+    (tmp_path / "mobilerun-cloud.json").write_text(
+        '{"access_token": "saved-token", "auth_url": "https://example.test"}'
+    )
+
+    assert device_commands.resolve_cloud_api_key() == "saved-token"
+
+
+def test_cloud_uuid_auto_routes_only_with_cloud_credential(monkeypatch):
+    uuid = "123e4567-e89b-12d3-a456-426614174000"
+    cloud_calls = []
+    android_calls = []
+
+    class FakeCloudDriver:
+        def __init__(self, **kwargs):
+            cloud_calls.append(kwargs)
+
+        async def connect(self):
+            pass
+
+    class FakeAndroidDriver:
+        def __init__(self, serial, use_tcp):
+            android_calls.append((serial, use_tcp))
+
+        async def connect(self):
+            pass
+
+    monkeypatch.setattr(device_commands, "resolve_cloud_api_key", lambda: "cloud-token")
+    monkeypatch.setattr(
+        "mobilerun.tools.driver.cloud.CloudDriver",
+        FakeCloudDriver,
+    )
+    driver, is_ios = asyncio.run(
+        device_commands._create_driver(uuid, None, None, False)
+    )
+
+    assert isinstance(driver, FakeCloudDriver)
+    assert is_ios is False
+    assert cloud_calls[0]["device_id"] == uuid
+    assert cloud_calls[0]["api_key"] == "cloud-token"
+
+    cloud_calls.clear()
+    monkeypatch.setattr(device_commands, "resolve_cloud_api_key", lambda: None)
+    monkeypatch.setattr(
+        device_commands.ConfigLoader,
+        "load",
+        lambda _path: SimpleNamespace(
+            device=SimpleNamespace(
+                serial="local-serial",
+                use_tcp=False,
+                platform="android",
+                auto_setup=False,
+            )
+        ),
+    )
+    monkeypatch.setattr(device_commands, "AndroidDriver", FakeAndroidDriver)
+    driver, is_ios = asyncio.run(
+        device_commands._create_driver(uuid, None, None, False)
+    )
+
+    assert isinstance(driver, FakeAndroidDriver)
+    assert is_ios is False
+    assert cloud_calls == []
+    assert android_calls[-1] == (uuid, False)
+
+
+def test_devices_cloud_missing_key_exits_nonzero(monkeypatch):
+    monkeypatch.setattr("mobilerun.cli.main.resolve_cloud_api_key", lambda: None)
+
+    result = CliRunner().invoke(cli, ["devices", "--cloud"])
+
+    assert result.exit_code != 0
+    assert "MOBILERUN_CLOUD_API_KEY" in result.output
+
+
+def test_devices_cloud_sdk_error_exits_nonzero(monkeypatch):
+    class FakeDevices:
+        async def list(self):
+            raise RuntimeError("boom")
+
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            self.devices = FakeDevices()
+
+    monkeypatch.setattr("mobilerun.cli.main.resolve_cloud_api_key", lambda: "token")
+    monkeypatch.setattr("mobilerun_sdk.AsyncMobilerun", FakeClient)
+
+    result = CliRunner().invoke(cli, ["devices", "--cloud"])
+
+    assert result.exit_code != 0
+    assert "Error listing cloud devices" in result.output
+    assert "boom" in result.output
+
+
+def test_devices_cloud_empty_list_is_success(monkeypatch):
+    class FakeResponse:
+        items = []
+
+    class FakeDevices:
+        async def list(self):
+            return FakeResponse()
+
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            self.devices = FakeDevices()
+
+    monkeypatch.setattr("mobilerun.cli.main.resolve_cloud_api_key", lambda: "token")
+    monkeypatch.setattr("mobilerun_sdk.AsyncMobilerun", FakeClient)
+
+    result = CliRunner().invoke(cli, ["devices", "--cloud"])
+
+    assert result.exit_code == 0
+    assert "No cloud devices found" in result.output
+
+
+def test_devices_plain_keeps_local_listing_when_cloud_errors(monkeypatch):
+    class FakeAdbDevice:
+        serial = "emulator-5554"
+
+    class FakeDevices:
+        async def list(self):
+            raise RuntimeError("cloud broke")
+
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            self.devices = FakeDevices()
+
+    async def fake_adb_list():
+        return [FakeAdbDevice()]
+
+    monkeypatch.setattr("mobilerun.cli.main.resolve_cloud_api_key", lambda: "token")
+    monkeypatch.setattr("mobilerun.cli.main.adb.list", fake_adb_list)
+    monkeypatch.setattr("mobilerun_sdk.AsyncMobilerun", FakeClient)
+
+    result = CliRunner().invoke(cli, ["devices"])
+
+    assert result.exit_code == 0, result.output
+    assert "emulator-5554" in result.output
+    assert "cloud broke" not in result.output

--- a/tests/test_deviceauth.py
+++ b/tests/test_deviceauth.py
@@ -1,0 +1,160 @@
+import json
+import os
+import stat
+
+import pytest
+
+from mobilerun.cli import deviceauth
+
+
+def _mode(path):
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def test_save_token_writes_private_file_and_repairs_directory_permissions(
+    monkeypatch, tmp_path
+):
+    credential_dir = tmp_path / "credentials"
+    credential_dir.mkdir(mode=0o755)
+    credential_file = credential_dir / "mobilerun-cloud.json"
+    monkeypatch.setattr(deviceauth, "credential_path", lambda: credential_file)
+
+    path = deviceauth.save_token("secret-token", "https://cloud.mobilerun.ai/api/auth")
+
+    assert path == credential_file
+    assert json.loads(path.read_text()) == {
+        "access_token": "secret-token",
+        "auth_url": "https://cloud.mobilerun.ai/api/auth",
+    }
+    if os.name != "nt":
+        assert _mode(credential_dir) == 0o700
+        assert _mode(path) == 0o600
+
+
+def test_save_token_overwrites_existing_token_privately(monkeypatch, tmp_path):
+    credential_dir = tmp_path / "credentials"
+    credential_dir.mkdir()
+    credential_file = credential_dir / "mobilerun-cloud.json"
+    credential_file.write_text("old")
+    if os.name != "nt":
+        os.chmod(credential_file, 0o644)
+    monkeypatch.setattr(deviceauth, "credential_path", lambda: credential_file)
+
+    deviceauth.save_token("new-token", "https://auth.example")
+
+    assert json.loads(credential_file.read_text()) == {
+        "access_token": "new-token",
+        "auth_url": "https://auth.example",
+    }
+    if os.name != "nt":
+        assert _mode(credential_file) == 0o600
+
+
+def test_clear_credentials_removes_file_and_is_idempotent(monkeypatch, tmp_path):
+    credential_file = tmp_path / "credentials" / "mobilerun-cloud.json"
+    credential_file.parent.mkdir()
+    credential_file.write_text("{}")
+    monkeypatch.setattr(deviceauth, "credential_path", lambda: credential_file)
+
+    assert deviceauth.clear_credentials() is True
+    assert credential_file.exists() is False
+    assert deviceauth.clear_credentials() is False
+
+
+def test_poll_token_handles_pending_then_success(monkeypatch):
+    code = deviceauth.CodeResponse(
+        device_code="device-code",
+        user_code="USER",
+        verification_uri="https://example.test",
+        verification_uri_complete="https://example.test/complete",
+        expires_in=60,
+        interval=1,
+    )
+    calls = []
+
+    def fake_exchange(_auth_url, _client_id, _device_code):
+        calls.append("exchange")
+        if len(calls) == 1:
+            raise deviceauth.DeviceAuthError("authorization_pending")
+        return "token"
+
+    monkeypatch.setattr(deviceauth, "_exchange", fake_exchange)
+    monkeypatch.setattr(deviceauth.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(deviceauth.time, "monotonic", lambda: len(calls))
+
+    assert deviceauth.poll_token("https://auth.example", "client", code) == "token"
+    assert calls == ["exchange", "exchange"]
+
+
+def test_poll_token_honors_slow_down(monkeypatch):
+    code = deviceauth.CodeResponse(
+        device_code="device-code",
+        user_code="USER",
+        verification_uri="https://example.test",
+        verification_uri_complete="https://example.test/complete",
+        expires_in=60,
+        interval=1,
+    )
+    calls = []
+    sleeps = []
+
+    def fake_exchange(_auth_url, _client_id, _device_code):
+        calls.append("exchange")
+        if len(calls) == 1:
+            raise deviceauth.DeviceAuthError("slow_down")
+        return "token"
+
+    monkeypatch.setattr(deviceauth, "_exchange", fake_exchange)
+    monkeypatch.setattr(deviceauth.time, "sleep", sleeps.append)
+    monkeypatch.setattr(deviceauth.time, "monotonic", lambda: len(calls))
+
+    assert deviceauth.poll_token("https://auth.example", "client", code) == "token"
+    assert sleeps == [5.0, 10.0]
+
+
+def test_poll_token_expires_pending_authorization(monkeypatch):
+    code = deviceauth.CodeResponse(
+        device_code="device-code",
+        user_code="USER",
+        verification_uri="https://example.test",
+        verification_uri_complete="https://example.test/complete",
+        expires_in=0,
+        interval=1,
+    )
+    ticks = iter([0, 1])
+
+    monkeypatch.setattr(
+        deviceauth,
+        "_exchange",
+        lambda *_args: (_ for _ in ()).throw(
+            deviceauth.DeviceAuthError("authorization_pending")
+        ),
+    )
+    monkeypatch.setattr(deviceauth.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(deviceauth.time, "monotonic", lambda: next(ticks))
+
+    with pytest.raises(deviceauth.DeviceAuthError, match="expired_token"):
+        deviceauth.poll_token("https://auth.example", "client", code)
+
+
+def test_poll_token_raises_terminal_denial(monkeypatch):
+    code = deviceauth.CodeResponse(
+        device_code="device-code",
+        user_code="USER",
+        verification_uri="https://example.test",
+        verification_uri_complete="https://example.test/complete",
+        expires_in=60,
+        interval=1,
+    )
+
+    monkeypatch.setattr(
+        deviceauth,
+        "_exchange",
+        lambda *_args: (_ for _ in ()).throw(
+            deviceauth.DeviceAuthError("access_denied", "denied")
+        ),
+    )
+    monkeypatch.setattr(deviceauth.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(deviceauth.DeviceAuthError, match="access_denied"):
+        deviceauth.poll_token("https://auth.example", "client", code)


### PR DESCRIPTION
## Summary
- Switch cloud CLI auth to `MOBILERUN_CLOUD_API_KEY` and intentionally ignore legacy `MOBILERUN_API_KEY` for cloud commands.
- Make `mobilerun devices --cloud` fail nonzero for missing auth or SDK/API errors while keeping plain `mobilerun devices` best-effort for local listing.
- Harden saved cloud login credentials with private directory/file permissions and atomic same-directory replacement.
- Remove stale public TUI references while keeping `TUILogHandler` compatibility exports.

## Test Plan
- `UV_CACHE_DIR=/private/tmp/uv-cache uv sync --python 3.13 --group dev --locked`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check .`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest -q`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run python -m compileall -q mobilerun tests`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv lock --check`
- Wheel metadata check: no `mobilerun/cli/tui`, no `textual`, no public TUI marketing text
- Live cloud invalid-key probe exits 1 with `MOBILERUN_CLOUD_API_KEY=fake`
- Live `/device/code` endpoint returned valid device/user codes
- Android emulator `Medium_Phone_API_36.1`: `ping`, `devices`, `device ui`, `device screenshot`, `device press home`
- Anthropic API-key agent smoke on emulator passed
- Claude Code final diff review: no findings
