### PR TITLE
Use mobilerun-core-local for local Android runtime

### DIFF
--- a/docs/sdk/base-tools.mdx
+++ b/docs/sdk/base-tools.mdx
@@ -33,9 +33,9 @@ Every method raises `NotImplementedError` by default. Concrete drivers override 
 
 The tools architecture follows a multi-layer pattern:
 
-1. **DeviceDriver**: Base class for raw device I/O (provided by `mobilerun-core-cli`). Methods raise `NotImplementedError` by default.
+1. **DeviceDriver**: Base class for raw device I/O (provided by `mobilerun-core-local`). Methods raise `NotImplementedError` by default.
 2. **Driver Implementations**: Platform-specific drivers
-   - `AndroidDriver`: Android devices via ADB + Portal app (provided by `mobilerun-core-cli`)
+   - `AndroidDriver`: Android devices via ADB + Portal app (provided by `mobilerun-core-local`)
    - `IOSDriver` (`tools/driver/ios.py`): iOS devices via HTTP REST API to Portal app
    - `StealthDriver` (`tools/driver/stealth.py`): Wraps another driver, adds human-like timing jitter
    - `RecordingDriver` (`tools/driver/recording.py`): Wraps another driver with trajectory recording

--- a/docs/sdk/configuration.mdx
+++ b/docs/sdk/configuration.mdx
@@ -125,6 +125,7 @@ DeviceConfig(
     device_id="auto",     # Device id for backends that expose multiple devices
     use_tcp=False,        # TCP vs content provider communication
     platform="android",   # "android" or "ios"
+    portal_mode="auto",   # Android: "auto", "required", or "disabled"
     auto_setup=True,      # Android only: auto-install/fix Portal APK before each run
 )
 ```
@@ -538,6 +539,7 @@ device:
   serial: null
   platform: android
   use_tcp: false
+  portal_mode: auto
   auto_setup: true  # Android only: auto-install/fix Portal APK before each run
 
 tools:

--- a/mobilerun/agent/action_context.py
+++ b/mobilerun/agent/action_context.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
-    from mobilerun_core_cli.driver.base import DeviceDriver
+    from mobilerun_core_local.driver.base import DeviceDriver
 
     from mobilerun.agent.droid.state import MobileAgentState
     from mobilerun.credential_manager import CredentialManager

--- a/mobilerun/agent/droid/droid_agent.py
+++ b/mobilerun/agent/droid/droid_agent.py
@@ -15,9 +15,9 @@ from typing import TYPE_CHECKING, Awaitable, Type, Union
 from async_adbutils import adb
 from llama_index.core.llms.llm import LLM
 from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, step
-from mobilerun_core_cli.driver.android import AndroidDriver
-from mobilerun_core_cli.driver.base import DeviceDisconnectedError
-from mobilerun_core_cli.portal import ensure_portal_ready
+from mobilerun_core_local.driver.android import AndroidDriver
+from mobilerun_core_local.driver.android.portal import ensure_portal_ready
+from mobilerun_core_local.driver.base import DeviceDisconnectedError
 from opentelemetry import trace
 from pydantic import BaseModel
 from workflows.events import Event
@@ -95,7 +95,7 @@ from mobilerun.tools.ui.provider import AndroidStateProvider
 from mobilerun.tools.ui.screenshot_provider import ScreenshotOnlyStateProvider
 
 if TYPE_CHECKING:
-    from mobilerun_core_cli.driver.base import DeviceDriver
+    from mobilerun_core_local.driver.base import DeviceDriver
 
     from mobilerun.tools.ui.provider import StateProvider
 
@@ -548,13 +548,17 @@ class MobileAgent(Workflow):
                 device_serial = devices[0].serial
 
             # Auto-setup portal if enabled
-            if self.config.device.auto_setup:
+            if (
+                self.config.device.auto_setup
+                and self.resolved_device_config.portal_mode != "disabled"
+            ):
                 device_obj = await adb.device(serial=device_serial)
                 await ensure_portal_ready(device_obj, debug=self.config.logging.debug)
 
             driver = AndroidDriver(
                 serial=device_serial,
                 use_tcp=self.resolved_device_config.use_tcp,
+                portal_mode=self.resolved_device_config.portal_mode,
             )
             await driver.connect()
 

--- a/mobilerun/agent/fast_agent/fast_agent.py
+++ b/mobilerun/agent/fast_agent/fast_agent.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Optional, Type
 from llama_index.core.base.llms.types import ChatMessage, ImageBlock, TextBlock
 from llama_index.core.llms.llm import LLM
 from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, step
-from mobilerun_core_cli.driver.base import DeviceDisconnectedError
+from mobilerun_core_local.driver.base import DeviceDisconnectedError
 from opentelemetry import trace
 from pydantic import BaseModel
 

--- a/mobilerun/agent/manager/manager_agent.py
+++ b/mobilerun/agent/manager/manager_agent.py
@@ -24,7 +24,7 @@ from llama_index.core.base.llms.types import (
 )
 from llama_index.core.llms.llm import LLM
 from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, step
-from mobilerun_core_cli.driver.base import DeviceDisconnectedError
+from mobilerun_core_local.driver.base import DeviceDisconnectedError
 from opentelemetry import trace
 from pydantic import BaseModel
 

--- a/mobilerun/agent/manager/stateless_manager_agent.py
+++ b/mobilerun/agent/manager/stateless_manager_agent.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Optional, Type
 
 from llama_index.core.llms.llm import LLM
 from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, step
-from mobilerun_core_cli.driver.base import DeviceDisconnectedError
+from mobilerun_core_local.driver.base import DeviceDisconnectedError
 from opentelemetry import trace
 from pydantic import BaseModel
 

--- a/mobilerun/agent/oneflows/app_starter_workflow.py
+++ b/mobilerun/agent/oneflows/app_starter_workflow.py
@@ -116,7 +116,7 @@ async def main():
     Example of how to use the OpenAppWorkflow.
     """
     from llama_index.llms.openai import OpenAI
-    from mobilerun_core_cli.driver.android import AndroidDriver
+    from mobilerun_core_local.driver.android import AndroidDriver
 
     # Initialize driver with device serial (None for default device)
     driver = AndroidDriver(serial=None)

--- a/mobilerun/agent/utils/oauth/gemini_oauth_code_assist_llm.py
+++ b/mobilerun/agent/utils/oauth/gemini_oauth_code_assist_llm.py
@@ -759,9 +759,7 @@ class GeminiOAuthCodeAssistLLM(CustomLLM):
         for msg in messages:
             parts = self._message_parts(msg)
             if msg.role == MessageRole.SYSTEM:
-                system_chunks.extend(
-                    part["text"] for part in parts if part.get("text")
-                )
+                system_chunks.extend(part["text"] for part in parts if part.get("text"))
                 continue
 
             role = "model" if msg.role == MessageRole.ASSISTANT else "user"

--- a/mobilerun/cli/device_commands.py
+++ b/mobilerun/cli/device_commands.py
@@ -14,8 +14,8 @@ from typing import Optional
 
 import click
 from async_adbutils import adb
-from mobilerun_core_cli.driver.android import AndroidDriver
-from mobilerun_core_cli.portal import ensure_portal_ready
+from mobilerun_core_local.driver.android import AndroidDriver
+from mobilerun_core_local.driver.android.portal import ensure_portal_ready
 from rich.console import Console
 
 from mobilerun.config_manager import ConfigLoader
@@ -132,9 +132,7 @@ async def _create_driver(
 
     if cloud:
         if ios:
-            raise click.ClickException(
-                "--cloud and --ios are mutually exclusive."
-            )
+            raise click.ClickException("--cloud and --ios are mutually exclusive.")
         cloud_device_id = device_id or device
         if not cloud_device_id:
             raise click.ClickException(
@@ -183,11 +181,15 @@ async def _create_driver(
             raise click.ClickException("No connected Android devices found.")
         serial = devices[0].serial
 
-    if config.device.auto_setup:
+    if config.device.auto_setup and config.device.portal_mode != "disabled":
         device_obj = await adb.device(serial=serial)
         await ensure_portal_ready(device_obj, debug=False)
 
-    driver = AndroidDriver(serial=serial, use_tcp=config.device.use_tcp)
+    driver = AndroidDriver(
+        serial=serial,
+        use_tcp=config.device.use_tcp,
+        portal_mode=config.device.portal_mode,
+    )
     await driver.connect()
     return driver, False
 
@@ -195,7 +197,10 @@ async def _create_driver(
 async def _teardown_android(driver):
     """Disable Mobilerun keyboard after direct command execution."""
     if isinstance(driver, AndroidDriver) and driver.device:
-        from mobilerun_core_cli.portal import PORTAL_PACKAGE_NAME, portal_ime_id
+        from mobilerun_core_local.driver.android.portal import (
+            PORTAL_PACKAGE_NAME,
+            portal_ime_id,
+        )
 
         try:
             ime = portal_ime_id(PORTAL_PACKAGE_NAME)
@@ -225,7 +230,9 @@ def device_cli():
 @coro
 async def screenshot(device, config_path, tcp, ios, cloud, device_id, base_url):
     """Take a screenshot and print the saved file path to stdout."""
-    driver, _ = await _create_driver(device, config_path, tcp, ios, cloud, device_id, base_url)
+    driver, _ = await _create_driver(
+        device, config_path, tcp, ios, cloud, device_id, base_url
+    )
     try:
         png_bytes = await driver.screenshot()
         fd, path = tempfile.mkstemp(prefix="mobilerun_", suffix=".png")
@@ -243,7 +250,9 @@ async def screenshot(device, config_path, tcp, ios, cloud, device_id, base_url):
 @coro
 async def ui(device, config_path, tcp, ios, cloud, device_id, base_url):
     """Print the UI accessibility tree with element bounds for targeting."""
-    driver, is_ios = await _create_driver(device, config_path, tcp, ios, cloud, device_id, base_url)
+    driver, is_ios = await _create_driver(
+        device, config_path, tcp, ios, cloud, device_id, base_url
+    )
     try:
         if is_ios:
             provider = IOSStateProvider(driver)
@@ -268,7 +277,9 @@ async def ui(device, config_path, tcp, ios, cloud, device_id, base_url):
 @coro
 async def tap(x, y, device, config_path, tcp, ios, cloud, device_id, base_url):
     """Tap at screen coordinates."""
-    driver, _ = await _create_driver(device, config_path, tcp, ios, cloud, device_id, base_url)
+    driver, _ = await _create_driver(
+        device, config_path, tcp, ios, cloud, device_id, base_url
+    )
     try:
         await driver.tap(x, y)
         click.echo(f"Tapped ({x}, {y})")
@@ -286,9 +297,13 @@ async def tap(x, y, device, config_path, tcp, ios, cloud, device_id, base_url):
 )
 @device_options
 @coro
-async def swipe_cmd(x1, y1, x2, y2, duration, device, config_path, tcp, ios, cloud, device_id, base_url):
+async def swipe_cmd(
+    x1, y1, x2, y2, duration, device, config_path, tcp, ios, cloud, device_id, base_url
+):
     """Swipe from (x1, y1) to (x2, y2)."""
-    driver, _ = await _create_driver(device, config_path, tcp, ios, cloud, device_id, base_url)
+    driver, _ = await _create_driver(
+        device, config_path, tcp, ios, cloud, device_id, base_url
+    )
     try:
         await driver.swipe(x1, y1, x2, y2, duration_ms=int(duration * 1000))
         click.echo(f"Swiped ({x1}, {y1}) -> ({x2}, {y2})")
@@ -305,7 +320,9 @@ async def long_press(x, y, device, config_path, tcp, ios, cloud, device_id, base
     """Long press at screen coordinates."""
     if ios:
         raise click.ClickException("long-press is not supported on iOS")
-    driver, _ = await _create_driver(device, config_path, tcp, ios, cloud, device_id, base_url)
+    driver, _ = await _create_driver(
+        device, config_path, tcp, ios, cloud, device_id, base_url
+    )
     try:
         await driver.swipe(x, y, x, y, 1000)
         click.echo(f"Long pressed ({x}, {y})")
@@ -318,9 +335,13 @@ async def long_press(x, y, device, config_path, tcp, ios, cloud, device_id, base
 @click.option("--clear", is_flag=True, default=False, help="Clear field before typing")
 @device_options
 @coro
-async def type_text(text, clear, device, config_path, tcp, ios, cloud, device_id, base_url):
+async def type_text(
+    text, clear, device, config_path, tcp, ios, cloud, device_id, base_url
+):
     """Type text into the currently focused field. Use 'tap' first to focus."""
-    driver, _ = await _create_driver(device, config_path, tcp, ios, cloud, device_id, base_url)
+    driver, _ = await _create_driver(
+        device, config_path, tcp, ios, cloud, device_id, base_url
+    )
     try:
         success = await driver.input_text(text, clear)
         if success:
@@ -339,7 +360,9 @@ async def type_text(text, clear, device, config_path, tcp, ios, cloud, device_id
 @coro
 async def press(button, device, config_path, tcp, ios, cloud, device_id, base_url):
     """Press a system button."""
-    driver, _ = await _create_driver(device, config_path, tcp, ios, cloud, device_id, base_url)
+    driver, _ = await _create_driver(
+        device, config_path, tcp, ios, cloud, device_id, base_url
+    )
     try:
         await driver.press_button(button)
         click.echo(f"Pressed {button}")
@@ -353,7 +376,9 @@ async def press(button, device, config_path, tcp, ios, cloud, device_id, base_ur
 @coro
 async def apps(system, device, config_path, tcp, ios, cloud, device_id, base_url):
     """List installed apps."""
-    driver, _ = await _create_driver(device, config_path, tcp, ios, cloud, device_id, base_url)
+    driver, _ = await _create_driver(
+        device, config_path, tcp, ios, cloud, device_id, base_url
+    )
     try:
         app_list = await driver.get_apps(include_system=system)
         for app in app_list:
@@ -378,7 +403,9 @@ async def apps(system, device, config_path, tcp, ios, cloud, device_id, base_url
 @coro
 async def start(package, device, config_path, tcp, ios, cloud, device_id, base_url):
     """Launch an app by package name."""
-    driver, _ = await _create_driver(device, config_path, tcp, ios, cloud, device_id, base_url)
+    driver, _ = await _create_driver(
+        device, config_path, tcp, ios, cloud, device_id, base_url
+    )
     try:
         result = await driver.start_app(package)
         click.echo(result)

--- a/mobilerun/cli/doctor.py
+++ b/mobilerun/cli/doctor.py
@@ -11,7 +11,7 @@ from typing import Any
 import httpx
 import requests
 from async_adbutils import AdbDevice, adb
-from mobilerun_core_cli.portal import (
+from mobilerun_core_local.driver.android.portal import (
     GITHUB_API_HOSTS,
     PORTAL_PACKAGE_NAME,
     REPO,
@@ -21,7 +21,7 @@ from mobilerun_core_cli.portal import (
     portal_content_uri,
     portal_ime_id,
 )
-from mobilerun_core_cli.transport.portal_client import PortalClient
+from mobilerun_core_local.transport.android.portal_client import PortalClient
 from rich.console import Console
 
 from mobilerun import __version__
@@ -511,7 +511,7 @@ async def check_portal_state(
     device: AdbDevice, use_tcp: bool, debug: bool
 ) -> tuple[CheckResult, Any]:
     """Fetch full state and verify a11y_tree, phone_state, device_context are present."""
-    from mobilerun_core_cli.transport.portal_client import PortalClient
+    from mobilerun_core_local.transport.android.portal_client import PortalClient
 
     try:
         portal = PortalClient(device, prefer_tcp=use_tcp)

--- a/mobilerun/cli/main.py
+++ b/mobilerun/cli/main.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import click
 from async_adbutils import adb
-from mobilerun_core_cli.portal import (
+from mobilerun_core_local.driver.android.portal import (
     DOWNLOAD_BASE,
     PORTAL_PACKAGE_NAME,
     download_portal_apk,
@@ -334,7 +334,10 @@ async def _cleanup_android_keyboard(config: MobileConfig) -> None:
     try:
         device_obj = await adb.device(config.device.serial)
         if device_obj:
-            from mobilerun_core_cli.portal import PORTAL_PACKAGE_NAME, portal_ime_id
+            from mobilerun_core_local.driver.android.portal import (
+                PORTAL_PACKAGE_NAME,
+                portal_ime_id,
+            )
 
             ime = portal_ime_id(PORTAL_PACKAGE_NAME)
             await device_obj.shell(f"ime disable {ime}")

--- a/mobilerun/config_example.yaml
+++ b/mobilerun/config_example.yaml
@@ -135,6 +135,8 @@ device:
   use_tcp: false
   # Platform: android or ios
   platform: android
+  # Android only: auto = ADB-first with optional Portal, required = fail without Portal, disabled = ADB-only.
+  portal_mode: auto
   # Android only: auto-install/update Portal APK and enable accessibility before each run.
   # iOS requires a running iOS Portal URL or discovery through iproxy.
   auto_setup: true

--- a/mobilerun/config_manager/config_manager.py
+++ b/mobilerun/config_manager/config_manager.py
@@ -148,6 +148,7 @@ class DeviceConfig:
     device_id: str = "auto"
     use_tcp: bool = False
     platform: str = "android"  # "android" or "ios"
+    portal_mode: Literal["auto", "required", "disabled"] = "auto"
     auto_setup: bool = True  # auto-install/fix portal before each run
 
 

--- a/mobilerun/macro/replay.py
+++ b/mobilerun/macro/replay.py
@@ -10,7 +10,7 @@ import logging
 import time
 from typing import Any, Dict, Optional
 
-from mobilerun_core_cli.driver.android import AndroidDriver
+from mobilerun_core_local.driver.android import AndroidDriver
 
 from mobilerun.agent.utils.trajectory import Trajectory
 from mobilerun.macro.handoff import run_agent_handoff

--- a/mobilerun/tools/driver/__init__.py
+++ b/mobilerun/tools/driver/__init__.py
@@ -1,7 +1,7 @@
 """Device driver abstractions for Mobilerun."""
 
-from mobilerun_core_cli.driver.android import AndroidDriver
-from mobilerun_core_cli.driver.base import DeviceDisconnectedError, DeviceDriver
+from mobilerun_core_local.driver.android import AndroidDriver
+from mobilerun_core_local.driver.base import DeviceDisconnectedError, DeviceDriver
 
 from mobilerun.tools.driver.cloud import CloudDriver
 from mobilerun.tools.driver.ios import IOSDriver

--- a/mobilerun/tools/driver/cloud.py
+++ b/mobilerun/tools/driver/cloud.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Awaitable, Dict, List, Optional, TypeVar
 
-from mobilerun_core_cli.driver.base import DeviceDisconnectedError, DeviceDriver
+from mobilerun_core_local.driver.base import DeviceDisconnectedError, DeviceDriver
 from mobilerun_sdk import AsyncMobilerun
 from mobilerun_sdk._exceptions import APIConnectionError, APITimeoutError, ConflictError
 

--- a/mobilerun/tools/driver/ios.py
+++ b/mobilerun/tools/driver/ios.py
@@ -1,11 +1,11 @@
 """Compatibility shim for the iOS Portal driver.
 
-The implementation lives in ``mobilerun-core-cli`` so local drivers are
+The implementation lives in ``mobilerun-core-local`` so local drivers are
 owned by one package. This module preserves the historical
 ``mobilerun.tools.driver.ios`` import path used by the framework, CLI, and docs.
 """
 
-from mobilerun_core_cli.driver.ios import (
+from mobilerun_core_local.driver.ios.http import (
     SYSTEM_APP_LABELS,
     IOSDriver,
     IOSPortalDriver,

--- a/mobilerun/tools/driver/recording.py
+++ b/mobilerun/tools/driver/recording.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from mobilerun_core_cli.driver.base import DeviceDriver
+from mobilerun_core_local.driver.base import DeviceDriver
 
 
 class RecordingDriver:

--- a/mobilerun/tools/driver/stealth.py
+++ b/mobilerun/tools/driver/stealth.py
@@ -14,7 +14,7 @@ import math
 import random
 from typing import Any, List, Tuple
 
-from mobilerun_core_cli.driver.base import DeviceDriver
+from mobilerun_core_local.driver.base import DeviceDriver
 
 # ---------------------------------------------------------------------------
 # Path generation helpers

--- a/mobilerun/tools/driver/visual_remote.py
+++ b/mobilerun/tools/driver/visual_remote.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import quote, urlparse
 
 import httpx
-from mobilerun_core_cli.driver.base import DeviceDriver
+from mobilerun_core_local.driver.base import DeviceDriver
 
 from mobilerun.tools.helpers.images import image_dimensions
 

--- a/mobilerun/tools/ui/ios_provider.py
+++ b/mobilerun/tools/ui/ios_provider.py
@@ -14,7 +14,7 @@ import logging
 import re
 from typing import Any, Dict, List, Optional
 
-from mobilerun_core_cli.driver.base import DeviceDisconnectedError, DeviceDriver
+from mobilerun_core_local.driver.base import DeviceDisconnectedError, DeviceDriver
 
 from mobilerun.tools.helpers.images import (
     fit_dimensions_to_max_side,

--- a/mobilerun/tools/ui/provider.py
+++ b/mobilerun/tools/ui/provider.py
@@ -11,7 +11,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
 
-from mobilerun_core_cli.driver.base import DeviceDisconnectedError
+from mobilerun_core_local.driver.base import DeviceDisconnectedError
 
 from mobilerun.tools.helpers.images import (
     fit_dimensions_to_max_side,
@@ -22,7 +22,7 @@ from mobilerun.tools.ui.state import UIState
 from mobilerun.tools.ui.stealth_state import StealthUIState
 
 if TYPE_CHECKING:
-    from mobilerun_core_cli.driver.base import DeviceDriver
+    from mobilerun_core_local.driver.base import DeviceDriver
 
     from mobilerun.tools.filters import TreeFilter
     from mobilerun.tools.formatters import TreeFormatter
@@ -236,7 +236,7 @@ class AndroidStateProvider(StateProvider):
 
     async def _recover_portal(self) -> None:
         """Restart Portal's accessibility service and TCP socket server."""
-        from mobilerun_core_cli.driver.android import AndroidDriver
+        from mobilerun_core_local.driver.android import AndroidDriver
 
         if not isinstance(self.driver, AndroidDriver):
             return
@@ -244,7 +244,7 @@ class AndroidStateProvider(StateProvider):
         if device is None:
             return
 
-        from mobilerun_core_cli.portal import (
+        from mobilerun_core_local.driver.android.portal import (
             PORTAL_PACKAGE_NAME,
             portal_a11y_service,
             portal_content_uri,
@@ -301,8 +301,10 @@ class AndroidStateProvider(StateProvider):
         display_height = None
         if self._vision_contract_intent and screen_width and screen_height:
             if self.vision_resize_policy is not None:
-                display_width, display_height = self.vision_resize_policy.effective_dims(
-                    screen_width, screen_height
+                display_width, display_height = (
+                    self.vision_resize_policy.effective_dims(
+                        screen_width, screen_height
+                    )
                 )
             else:
                 display_width, display_height = fit_dimensions_to_max_side(

--- a/mobilerun/tools/ui/screenshot_provider.py
+++ b/mobilerun/tools/ui/screenshot_provider.py
@@ -9,7 +9,7 @@ from mobilerun.tools.ui.provider import StateProvider
 from mobilerun.tools.ui.state import UIState
 
 if TYPE_CHECKING:
-    from mobilerun_core_cli.driver.base import DeviceDriver
+    from mobilerun_core_local.driver.base import DeviceDriver
 
 
 class ScreenshotOnlyStateProvider(StateProvider):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "llama-index-llms-ollama>=0.7.2",
     "llama-index-llms-openrouter>=0.4.2",
     "mobilerun-sdk>=3.2.0",
-    "mobilerun-core-cli>=0.2.0",
+    "mobilerun-core-local>=0.3.1",
 ]
 requires-python = ">=3.11,<3.14"
 readme = "README.md"

--- a/tests/eval_coordinate_grounding.py
+++ b/tests/eval_coordinate_grounding.py
@@ -50,7 +50,9 @@ MAX_TARGETS = 4
 
 
 def _parse_xy(text: str):
-    m = re.search(r'"x"\s*:\s*(-?\d+(?:\.\d+)?)\s*,\s*"y"\s*:\s*(-?\d+(?:\.\d+)?)', text)
+    m = re.search(
+        r'"x"\s*:\s*(-?\d+(?:\.\d+)?)\s*,\s*"y"\s*:\s*(-?\d+(?:\.\d+)?)', text
+    )
     if m:
         return float(m.group(1)), float(m.group(2))
     nums = re.findall(r"-?\d+(?:\.\d+)?", text)
@@ -82,7 +84,7 @@ def _pick_targets(state):
 
 
 async def main(serial: str) -> None:
-    from mobilerun_core_cli.driver.android import AndroidDriver
+    from mobilerun_core_local.driver.android import AndroidDriver
 
     driver = AndroidDriver(serial=serial)
     await driver.connect()
@@ -96,7 +98,9 @@ async def main(serial: str) -> None:
     # Device-pixel target bounds are model-independent; pick them once.
     targets = _pick_targets(await provider.get_state())
     if not targets:
-        print("No suitable targets on screen — open a list-style screen (e.g. Settings).")
+        print(
+            "No suitable targets on screen — open a list-style screen (e.g. Settings)."
+        )
         sys.exit(1)
     print(f"targets: {[t for t, _ in targets]}")
 
@@ -135,7 +139,9 @@ async def main(serial: str) -> None:
             response = await llm.achat([message])
             xy = _parse_xy(str(response.message.content))
             if xy is None:
-                print(f"  {text[:32]:34} UNPARSEABLE: {str(response.message.content)[:60]!r}")
+                print(
+                    f"  {text[:32]:34} UNPARSEABLE: {str(response.message.content)[:60]!r}"
+                )
                 continue
             try:
                 device_x, device_y = _convert_action_point(xy[0], xy[1], ctx=ctx)

--- a/tests/test_android_vision_coordinate_contract.py
+++ b/tests/test_android_vision_coordinate_contract.py
@@ -54,7 +54,10 @@ def _combined_data(width=NATIVE_W, height=NATIVE_H):
             ],
         },
         "device_context": {"screen_bounds": {"width": width, "height": height}},
-        "phone_state": {"currentApp": "Settings", "packageName": "com.android.settings"},
+        "phone_state": {
+            "currentApp": "Settings",
+            "packageName": "com.android.settings",
+        },
     }
 
 

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -56,8 +56,8 @@ def test_cloud_uuid_auto_routes_only_with_cloud_credential(monkeypatch):
             pass
 
     class FakeAndroidDriver:
-        def __init__(self, serial, use_tcp):
-            android_calls.append((serial, use_tcp))
+        def __init__(self, serial, use_tcp, portal_mode="auto"):
+            android_calls.append((serial, use_tcp, portal_mode))
 
         async def connect(self):
             pass
@@ -87,6 +87,7 @@ def test_cloud_uuid_auto_routes_only_with_cloud_credential(monkeypatch):
                 use_tcp=False,
                 platform="android",
                 auto_setup=False,
+                portal_mode="auto",
             )
         ),
     )
@@ -98,7 +99,7 @@ def test_cloud_uuid_auto_routes_only_with_cloud_credential(monkeypatch):
     assert isinstance(driver, FakeAndroidDriver)
     assert is_ios is False
     assert cloud_calls == []
-    assert android_calls[-1] == (uuid, False)
+    assert android_calls[-1] == (uuid, False, "auto")
 
 
 def test_devices_cloud_missing_key_exits_nonzero(monkeypatch):

--- a/tests/test_core_local_runtime.py
+++ b/tests/test_core_local_runtime.py
@@ -1,0 +1,99 @@
+import asyncio
+from types import SimpleNamespace
+
+from mobilerun.cli import device_commands
+from mobilerun.config_manager.config_manager import DeviceConfig
+
+
+def test_device_config_defaults_to_auto_portal_mode():
+    config = DeviceConfig()
+
+    assert config.portal_mode == "auto"
+
+
+def test_device_config_accepts_disabled_portal_mode():
+    config = DeviceConfig(portal_mode="disabled")
+
+    assert config.portal_mode == "disabled"
+
+
+def test_create_driver_passes_portal_mode(monkeypatch):
+    android_calls = []
+
+    class FakeAndroidDriver:
+        def __init__(self, serial, use_tcp, portal_mode):
+            android_calls.append(
+                {
+                    "serial": serial,
+                    "use_tcp": use_tcp,
+                    "portal_mode": portal_mode,
+                }
+            )
+
+        async def connect(self):
+            pass
+
+    monkeypatch.setattr(
+        device_commands.ConfigLoader,
+        "load",
+        lambda _path: SimpleNamespace(
+            device=SimpleNamespace(
+                serial="emulator-5556",
+                use_tcp=True,
+                platform="android",
+                auto_setup=False,
+                portal_mode="disabled",
+            )
+        ),
+    )
+    monkeypatch.setattr(device_commands, "AndroidDriver", FakeAndroidDriver)
+
+    driver, is_ios = asyncio.run(
+        device_commands._create_driver(None, None, None, False)
+    )
+
+    assert isinstance(driver, FakeAndroidDriver)
+    assert is_ios is False
+    assert android_calls == [
+        {
+            "serial": "emulator-5556",
+            "use_tcp": True,
+            "portal_mode": "disabled",
+        }
+    ]
+
+
+def test_create_driver_disabled_portal_mode_skips_auto_setup(monkeypatch):
+    setup_calls = []
+
+    class FakeAndroidDriver:
+        def __init__(self, serial, use_tcp, portal_mode):
+            pass
+
+        async def connect(self):
+            pass
+
+    async def fake_ensure_portal_ready(*args, **kwargs):
+        setup_calls.append((args, kwargs))
+
+    monkeypatch.setattr(
+        device_commands.ConfigLoader,
+        "load",
+        lambda _path: SimpleNamespace(
+            device=SimpleNamespace(
+                serial="emulator-5556",
+                use_tcp=False,
+                platform="android",
+                auto_setup=True,
+                portal_mode="disabled",
+            )
+        ),
+    )
+    monkeypatch.setattr(device_commands, "AndroidDriver", FakeAndroidDriver)
+    monkeypatch.setattr(
+        device_commands, "ensure_portal_ready", fake_ensure_portal_ready
+    )
+
+    asyncio.run(device_commands._create_driver(None, None, None, False))
+
+    assert setup_calls == []

--- a/tests/test_gemini_oauth_llm.py
+++ b/tests/test_gemini_oauth_llm.py
@@ -80,7 +80,11 @@ def test_image_only_message_is_sent_as_inline_data():
     from llama_index.core.base.llms.types import ImageBlock
 
     payload = _gemini_llm()._to_code_assist_request(
-        [ChatMessage(role=MessageRole.USER, blocks=[ImageBlock(image=_tiny_image("PNG"))])]
+        [
+            ChatMessage(
+                role=MessageRole.USER, blocks=[ImageBlock(image=_tiny_image("PNG"))]
+            )
+        ]
     )
 
     parts = payload["request"]["contents"][0]["parts"]
@@ -132,12 +136,14 @@ def test_system_message_text_reaches_system_instruction():
 
 def test_oauth_default_model_resolves_to_antigravity_flash():
     from mobilerun.agent.utils.llm_picker import load_llm
+
     # no model arg -> the Antigravity consumer default
     assert load_llm("gemini_oauth_code_assist").model == "gemini-3.5-flash-low"
 
 
 def test_oauth_explicit_default_model_is_honored_not_preset():
     from mobilerun.agent.utils.llm_picker import load_llm
+
     # explicit model equal to DEFAULT_MODEL must NOT fall through to a preset
     assert (
         load_llm("gemini_oauth_code_assist", model="gemini-3.5-flash-low").model
@@ -147,6 +153,7 @@ def test_oauth_explicit_default_model_is_honored_not_preset():
 
 def test_oauth_explicit_agy_models_are_honored():
     from mobilerun.agent.utils.llm_picker import load_llm
+
     for m in ("gemini-3-flash", "gemini-pro-agent", "gemini-3.1-pro-low"):
         assert load_llm("gemini_oauth_code_assist", model=m).model == m
 
@@ -155,6 +162,7 @@ def test_oauth_preset_key_still_resolves():
     from mobilerun.agent.utils.oauth.gemini_oauth_code_assist_llm import (
         GeminiOAuthCodeAssistLLM,
     )
+
     assert (
         GeminiOAuthCodeAssistLLM(model_preset="flash").model == "gemini-3.5-flash-low"
     )
@@ -164,6 +172,7 @@ def test_deprecated_models_are_rejected_with_reconfigure_error():
     import pytest
 
     from mobilerun.agent.utils.llm_picker import load_llm
+
     for m in ("gemini-2.5-pro", "gemini-2.5-flash", "gemini-3.1-pro-preview"):
         with pytest.raises(ValueError):
             load_llm("gemini_oauth_code_assist", model=m)
@@ -173,6 +182,7 @@ def test_never_sends_project_even_if_passed_as_kwarg():
     from mobilerun.agent.utils.oauth.gemini_oauth_code_assist_llm import (
         GeminiOAuthCodeAssistLLM,
     )
+
     llm = GeminiOAuthCodeAssistLLM(access_token="t", credential_path=None)
     payload = llm._to_code_assist_request(
         [ChatMessage(role=MessageRole.USER, content="hi")], project="proj-123"
@@ -185,6 +195,7 @@ def test_consumer_default_credential_slot_is_antigravity():
         DEFAULT_CREDENTIAL_SLOT,
         GeminiOAuthCodeAssistLLM,
     )
+
     llm = GeminiOAuthCodeAssistLLM(access_token="t", credential_path=None)
     assert llm.credential_slot == DEFAULT_CREDENTIAL_SLOT == "geminiAntigravityOauth"
 
@@ -194,6 +205,7 @@ def test_consumer_mode_uses_antigravity_client_and_aicode_scope():
         DEFAULT_CLIENT_ID,
         GeminiOAuthCodeAssistLLM,
     )
+
     llm = GeminiOAuthCodeAssistLLM(access_token="t", credential_path=None)
     assert llm.client_id == DEFAULT_CLIENT_ID
     assert any("aicode" in s for s in llm.scopes)
@@ -204,6 +216,7 @@ def test_flash_lite_preset_resolves_to_picker_model():
     from mobilerun.agent.utils.oauth.gemini_oauth_code_assist_llm import (
         GeminiOAuthCodeAssistLLM,
     )
+
     assert (
         GeminiOAuthCodeAssistLLM(model_preset="flash_lite").model
         == "gemini-3.5-flash-extra-low"
@@ -216,6 +229,7 @@ def test_consumer_mode_ignores_bare_credential_file(tmp_path):
     from mobilerun.agent.utils.oauth.gemini_oauth_code_assist_llm import (
         GeminiOAuthCodeAssistLLM,
     )
+
     p = tmp_path / "bare.json"
     p.write_text(json.dumps({"access_token": "raw-old", "refresh_token": "raw-r"}))
     llm = GeminiOAuthCodeAssistLLM(credential_path=str(p))  # consumer mode default
@@ -227,6 +241,7 @@ def test_wizard_oauth_detection_handles_provider_field_names(tmp_path):
     import json
 
     from mobilerun.cli.configure_wizard import _oauth_credentials_present
+
     p = tmp_path / "auth.json"
     p.write_text(
         json.dumps(

--- a/tests/test_ios_vision_coordinate_contract.py
+++ b/tests/test_ios_vision_coordinate_contract.py
@@ -36,7 +36,9 @@ def _png(width, height):
 
 
 class FakeIOSDriver:
-    def __init__(self, screenshot_bytes=None, screenshot_error=None, screenshot_plan=None):
+    def __init__(
+        self, screenshot_bytes=None, screenshot_error=None, screenshot_plan=None
+    ):
         # screenshot_plan: per-call behaviors (bytes or Exception); the last
         # entry repeats. Overrides screenshot_bytes/screenshot_error.
         self._plan = screenshot_plan or (
@@ -49,8 +51,13 @@ class FakeIOSDriver:
         if self.ui_tree_error:
             raise self.ui_tree_error
         return {
-            "phone_state": {"currentApp": "Settings", "packageName": "com.apple.Preferences"},
-            "device_context": {"screen_bounds": {"width": POINTS_W, "height": POINTS_H}},
+            "phone_state": {
+                "currentApp": "Settings",
+                "packageName": "com.apple.Preferences",
+            },
+            "device_context": {
+                "screen_bounds": {"width": POINTS_W, "height": POINTS_H}
+            },
             "a11y_tree": RAW_A11Y,
         }
 
@@ -150,15 +157,17 @@ def test_probe_failure_disables_resize_for_agent_captured_screenshot():
     """The review scenario, in the agents' real order: the agent's own
     capture succeeds, the provider's probe fails — that step must not be
     resized."""
-    driver = FakeIOSDriver(screenshot_plan=[
-        _png(PIXELS_W, PIXELS_H),          # 1: agent's capture (succeeds)
-        RuntimeError("transient hiccup"),  # 2: provider probe (fails)
-        _png(PIXELS_W, PIXELS_H),          # 3+: recovery
-    ])
+    driver = FakeIOSDriver(
+        screenshot_plan=[
+            _png(PIXELS_W, PIXELS_H),  # 1: agent's capture (succeeds)
+            RuntimeError("transient hiccup"),  # 2: provider probe (fails)
+            _png(PIXELS_W, PIXELS_H),  # 3+: recovery
+        ]
+    )
     provider = IOSStateProvider(driver, vision_enabled=True)
 
     agent_screenshot = asyncio.run(driver.screenshot())  # agents capture first
-    state = _state(provider)                             # probe fails inside
+    state = _state(provider)  # probe fails inside
 
     assert agent_screenshot is not None
     assert state.coordinate_scale_x == 1.0
@@ -250,10 +259,12 @@ def test_coordinate_actions_refused_when_contract_drops_for_a_step():
     """Registry exposes click_at under vision, but a step whose contract
     dropped (probe failure) must refuse coordinate actions rather than tap
     raw pixels at 1:1 into point space."""
-    driver = FakeIOSDriver(screenshot_plan=[
-        RuntimeError("probe failed this step"),  # contract drops
-        _png(PIXELS_W, PIXELS_H),                # recovers next step
-    ])
+    driver = FakeIOSDriver(
+        screenshot_plan=[
+            RuntimeError("probe failed this step"),  # contract drops
+            _png(PIXELS_W, PIXELS_H),  # recovers next step
+        ]
+    )
     provider = IOSStateProvider(driver, vision_enabled=True)
 
     state = _state(provider)  # fallback state, contract inactive
@@ -335,7 +346,9 @@ def test_swipe_refused_on_dropped_contract_step():
     driver = FakeIOSDriver(screenshot_error=RuntimeError("probe failed"))
     provider = IOSStateProvider(driver, vision_enabled=True)
     state = _state(provider)
-    ctx = SimpleNamespace(ui=state, state_provider=provider, driver=driver, macro_recorder=None)
+    ctx = SimpleNamespace(
+        ui=state, state_provider=provider, driver=driver, macro_recorder=None
+    )
 
     result = asyncio.run(swipe([100, 200], [100, 600], ctx=ctx))
     assert result.success is False
@@ -357,7 +370,9 @@ def test_click_at_end_to_end_refused_then_works(monkeypatch):
     state = _state(provider)
     from mobilerun.agent.utils.actions import click_at
 
-    ctx = SimpleNamespace(ui=state, state_provider=provider, driver=driver, macro_recorder=None)
+    ctx = SimpleNamespace(
+        ui=state, state_provider=provider, driver=driver, macro_recorder=None
+    )
     ok = asyncio.run(click_at(471, 1024, ctx=ctx))
     assert ok.success and taps == [(220, 478)]
 
@@ -366,7 +381,9 @@ def test_click_at_end_to_end_refused_then_works(monkeypatch):
     drop = _Driver(screenshot_error=RuntimeError("probe failed"))
     drop_provider = IOSStateProvider(drop, vision_enabled=True)
     drop_state = _state(drop_provider)
-    ctx2 = SimpleNamespace(ui=drop_state, state_provider=drop_provider, driver=drop, macro_recorder=None)
+    ctx2 = SimpleNamespace(
+        ui=drop_state, state_provider=drop_provider, driver=drop, macro_recorder=None
+    )
     refused = asyncio.run(click_at(100, 200, ctx=ctx2))
     assert refused.success is False and taps == []
 

--- a/tests/test_llm_picker.py
+++ b/tests/test_llm_picker.py
@@ -236,7 +236,9 @@ def test_ollama_invalid_max_tokens_warns_and_skips(bad, mobilerun_caplog) -> Non
 
     assert "max_tokens" not in out
     assert "num_predict" not in out.get("additional_kwargs", {})
-    assert any("Ignoring non-integer max_tokens" in r.message for r in mobilerun_caplog.records)
+    assert any(
+        "Ignoring non-integer max_tokens" in r.message for r in mobilerun_caplog.records
+    )
 
 
 def test_ollama_context_window_defaults_to_32k() -> None:
@@ -253,18 +255,14 @@ def test_ollama_explicit_context_window_is_preserved(explicit) -> None:
 
 
 def test_ollama_num_ctx_mirrors_into_context_window() -> None:
-    out = _prepare(
-        {"model": "qwen3:0.6b", "additional_kwargs": {"num_ctx": 16384}}
-    )
+    out = _prepare({"model": "qwen3:0.6b", "additional_kwargs": {"num_ctx": 16384}})
 
     assert out["context_window"] == 16384
     assert out["additional_kwargs"]["num_ctx"] == 16384
 
 
 def test_ollama_non_numeric_num_ctx_falls_back_to_default() -> None:
-    out = _prepare(
-        {"model": "qwen3:0.6b", "additional_kwargs": {"num_ctx": "max"}}
-    )
+    out = _prepare({"model": "qwen3:0.6b", "additional_kwargs": {"num_ctx": "max"}})
 
     assert out["context_window"] == 32768
 

--- a/tests/test_portal_asset_selection.py
+++ b/tests/test_portal_asset_selection.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mobilerun_core_cli import portal
+from mobilerun_core_local.driver.android import portal
 
 _get_release_assets_by_tag = portal._get_release_assets_by_tag
 _normalize_download_base = portal._normalize_download_base

--- a/tests/test_vision_sizing.py
+++ b/tests/test_vision_sizing.py
@@ -60,7 +60,10 @@ def test_policy_max_side_cap_shrinks_further():
 
 
 def test_policy_from_llms_reads_model_attr():
-    llms = [SimpleNamespace(model="claude-sonnet-4-6"), SimpleNamespace(model="gpt-5.5")]
+    llms = [
+        SimpleNamespace(model="claude-sonnet-4-6"),
+        SimpleNamespace(model="gpt-5.5"),
+    ]
     policy = VisionResizePolicy.from_llms(llms)
     # min across sonnet(1568) and gpt(2048) → 1568.
     assert policy.effective_dims(1080, 2400) == (706, 1568)

--- a/tests/test_visual_remote_connection.py
+++ b/tests/test_visual_remote_connection.py
@@ -463,9 +463,7 @@ class ScreenshotOnlyStateProviderTest(unittest.TestCase):
             self.assertNotIn("destructive controls", description)
             self.assertNotIn("Do not tap toggles", description)
 
-        self.assertIn(
-            "Click at position", registry.tools["click_at"].description
-        )
+        self.assertIn("Click at position", registry.tools["click_at"].description)
         self.assertIn("Duration is in seconds", registry.tools["swipe"].description)
 
     def test_screenshot_only_agent_sources_resize_screenshots(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1810,7 +1810,7 @@ dependencies = [
     { name = "llama-index-llms-openrouter" },
     { name = "llama-index-workflows" },
     { name = "mcp" },
-    { name = "mobilerun-core-cli" },
+    { name = "mobilerun-core-local" },
     { name = "mobilerun-sdk" },
     { name = "posthog" },
     { name = "pydantic" },
@@ -1874,7 +1874,7 @@ requires-dist = [
     { name = "llama-index-workflows", specifier = ">=2.16.0,<3.0.0" },
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "mobilerun", extras = ["langfuse"], marker = "extra == 'dev'" },
-    { name = "mobilerun-core-cli", specifier = ">=0.2.0" },
+    { name = "mobilerun-core-local", specifier = ">=0.3.1" },
     { name = "mobilerun-sdk", specifier = ">=3.2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "openinference-instrumentation-llama-index", marker = "extra == 'langfuse'", specifier = ">=3.0.0" },
@@ -1900,8 +1900,8 @@ dev = [
 ]
 
 [[package]]
-name = "mobilerun-core-cli"
-version = "0.2.0"
+name = "mobilerun-core-local"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-adbutils" },
@@ -1909,9 +1909,9 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/78/18cd91fccb2fb348a5150707245d303b6052890a9aca2c35bd391d776208/mobilerun_core_cli-0.2.0.tar.gz", hash = "sha256:dc13016c7983476cca564dd013fc281047474dc502de54f8c0bd5647b48211e2", size = 43779, upload-time = "2026-06-07T23:46:53.93Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/8b/1a2d0585b3675dec10a15f84f37938c53ecceff984122baa54d7861e4606/mobilerun_core_local-0.3.1.tar.gz", hash = "sha256:9e23ca8c98de1651ffc1de2990ff6bf658379839d9309f6b5882f5eb345eb70d", size = 49920, upload-time = "2026-06-23T16:45:15.087Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/54/2fe03bf7a98fb50b70580acef5c5bf3ea1c51ccf6ef867b5df81201934ea/mobilerun_core_cli-0.2.0-py3-none-any.whl", hash = "sha256:d94c5478d299fc10ec3f8f850dc469d65e2533db4805e0d932b15925c8e5e351", size = 30765, upload-time = "2026-06-07T23:46:52.562Z" },
+    { url = "https://files.pythonhosted.org/packages/59/c8/7844b86724598a44dc9f74d32236808b7c2f99e626ca0dbeaddd885506b4/mobilerun_core_local-0.3.1-py3-none-any.whl", hash = "sha256:5be484a5d2ebd97bca782a8685d3e3515e151e556d29eeb71439b2af8c9b2a02", size = 35910, upload-time = "2026-06-23T16:45:13.838Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Switches local runtime imports and dependency from mobilerun-core-cli to mobilerun-core-local>=0.3.1.
- Adds device.portal_mode with default auto.
- Passes portal_mode into AndroidDriver for local Android runs.
- Skips Portal auto-setup when portal_mode="disabled".
- Adds coverage for default and disabled portal mode driver construction.

## Verification
- env UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest
- env UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check mobilerun tests
- env UV_CACHE_DIR=/private/tmp/uv-cache uv run --with black==25.9.0 black --check .
- env UV_CACHE_DIR=/private/tmp/uv-cache uv lock --check

## Notes
- mobilerun-core 1.0.5 has been published and mobilerun-core-local 0.3.1 is available on PyPI.
- This PR includes black-only formatting needed for the repository-wide black check.