### PR TITLE
feat(driver): CloudDriver forwards X-Owner-Id (DRO-1682)

### DIFF
--- a/mobilerun/tools/driver/cloud.py
+++ b/mobilerun/tools/driver/cloud.py
@@ -51,6 +51,7 @@ class CloudDriver(DeviceDriver):
         api_key: str | None = None,
         base_url: str = "https://api.mobilerun.com/v1",
         user_id: str | None = None,
+        owner_id: str | None = None,
         stealth: bool = False,
     ) -> None:
         self.device_id = device_id
@@ -58,12 +59,15 @@ class CloudDriver(DeviceDriver):
         self._stealth = stealth
 
         if user_id:
+            default_headers = {"X-User-ID": user_id}
+            if owner_id:
+                default_headers["X-Owner-Id"] = owner_id
             self._client = AsyncMobilerun(
                 api_key="x",
                 base_url=base_url,
                 timeout=10.0,
                 max_retries=4,
-                default_headers={"X-User-ID": user_id},
+                default_headers=default_headers,
             )
         else:
             self._client = AsyncMobilerun(

--- a/tests/test_cloud_driver_sdk.py
+++ b/tests/test_cloud_driver_sdk.py
@@ -55,6 +55,29 @@ class CloudDriverSdkTest(unittest.TestCase):
             [("device-123", {"x_device_display_id": 7})],
         )
 
+    def test_owner_id_forwarded_as_x_owner_id_header(self):
+        with patch("mobilerun.tools.driver.cloud.AsyncMobilerun", FakeClient):
+            driver = CloudDriver(
+                "d",
+                user_id="u",
+                owner_id="o",
+            )
+
+        headers = driver._client.kwargs["default_headers"]
+        self.assertEqual(headers["X-User-ID"], "u")
+        self.assertEqual(headers["X-Owner-Id"], "o")
+
+    def test_owner_id_omitted_when_not_provided(self):
+        with patch("mobilerun.tools.driver.cloud.AsyncMobilerun", FakeClient):
+            driver = CloudDriver(
+                "d",
+                user_id="u",
+            )
+
+        headers = driver._client.kwargs["default_headers"]
+        self.assertEqual(headers["X-User-ID"], "u")
+        self.assertNotIn("X-Owner-Id", headers)
+
     def test_installed_sdk_exposes_devices_state_time(self):
         self.assertGreaterEqual(_version_tuple("mobilerun-sdk"), (3, 2, 0))
 


### PR DESCRIPTION
## Summary

* `CloudDriver.__init__` gains an optional `owner_id: str | None = None` parameter.
* When `user_id` is set and `owner_id` is provided, `X-Owner-Id` is added to `default_headers` alongside the existing `X-User-ID` header. When `owner_id` is `None`, behavior is unchanged (header omitted).
* This lets the cloud device driver forward the tenancy header that devices-api now requires (devices-api [#503](<https://github.com/droidrun/mobilerun/issues/503>), merged/live on dev), fixing dev device-driving 400s for the tasks-api agent.

## Release / rollout note (action required by a human)

* This PR alone does **not** fix the live dev incident. A new mobilerun release (e.g. `0.6.0rc6`) must be cut from this change, and tasks-api's `pyproject.toml` pin (`mobilerun[langfuse]==0.6.0rc5`) must be bumped to that release, before `owner_id` can actually be passed through and take effect.
* Until that release + pin bump happens, the corresponding tasks-api change is being tracked as a comment/placeholder in PR droidrun/mobilerun#224 (lucius/dro-1682-tasks-owner-threading) — it is NOT wired up yet because the currently-pinned `0.6.0rc5` has no `owner_id` param and would `TypeError` if called with one.
* **Do not merge or release this yet** — prepared as part of the dev-incident fix, still needs review/coordination with the release + pin-bump step.

## Test plan

- [X] Added two unit tests to `tests/test_cloud_driver_sdk.py`:
  - `test_owner_id_forwarded_as_x_owner_id_header` — constructs `CloudDriver(device_id="d", user_id="u", owner_id="o")` and asserts the client's `default_headers` contains `X-Owner-Id: o` (no network call, mocked `AsyncMobilerun`).
  - `test_owner_id_omitted_when_not_provided` — asserts `X-Owner-Id` is absent when `owner_id` is not passed.
- [X] `uv run pytest` — full suite green (220 passed).

Part of [DRO-1682](https://linear.app/droidrun/issue/DRO-1682/team-accounts)