### PR TITLE
chore(release): bump to 0.6.10

### DIFF
--- a/compat/pyproject.toml
+++ b/compat/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "droidrun"
-version = "0.6.8"
+version = "0.6.10"
 description = "Compatibility shim — droidrun has been renamed to mobilerun"
 requires-python = ">=3.11,<3.14"
-dependencies = ["mobilerun==0.6.8"]
+dependencies = ["mobilerun==0.6.10"]
 
 [project.optional-dependencies]
-anthropic = ["mobilerun[anthropic]==0.6.8"]
-deepseek = ["mobilerun[deepseek]==0.6.8"]
-langfuse = ["mobilerun[langfuse]==0.6.8"]
-dev = ["mobilerun[dev]==0.6.8"]
+anthropic = ["mobilerun[anthropic]==0.6.10"]
+deepseek = ["mobilerun[deepseek]==0.6.10"]
+langfuse = ["mobilerun[langfuse]==0.6.10"]
+dev = ["mobilerun[dev]==0.6.10"]
 
 [project.scripts]
 droidrun = "droidrun.cli_shim:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mobilerun"
-version = "0.6.8"
+version = "0.6.10"
 description = "A framework for controlling mobile devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels@droidrun.ai" }]
 dependencies = [


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` version 0.6.8 → 0.6.10.
- Bump all 5 pins in `compat/pyproject.toml` (base `mobilerun==` + the 4 optional-dependency extras) to 0.6.10.

## Why
The v0.6.9 GitHub release was tagged without a version bump, so the PyPI publish workflow failed its tag-vs-pyproject version check (`Tag v0.6.9 does not match pyproject.toml version 0.6.8`) and 0.6.9 never reached PyPI. Skipping straight to 0.6.10: after merge, tag `v0.6.10` on the merge commit to publish. First release containing #379 (CloudDriver `owner_id` / X-Owner-Id), needed by tasks-api for DRO-1682.

## Test plan
- [x] Diff is version strings only (6 lines across 2 files)
- [ ] Publish workflow version-check passes on tag `v0.6.10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)