### PR TITLE
Feat/add litellm provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 </p>
 
 - 🤖 Control Android and iOS devices with natural language commands
-- 🔀 Use OpenAI, Anthropic, Gemini, Ollama, DeepSeek, OpenRouter, and OpenAI-compatible models
+- 🔀 Use OpenAI, Anthropic, Gemini, Ollama, DeepSeek, OpenRouter, LiteLLM, and OpenAI-compatible models
 - 🧠 Run direct tasks or enable reasoning mode for complex multi-step automation
 - 💻 Automate from the CLI, a terminal UI, Docker, or Python code
 - 🐍 Extend agents with custom tools, structured output, app cards, and credentials
@@ -76,6 +76,12 @@ Most LLM providers are included by default. For Anthropic support, install the o
 
 ```bash
 uv tool install "mobilerun[anthropic]"
+```
+
+For LiteLLM support (access to 100+ providers via a unified interface):
+
+```bash
+uv tool install "mobilerun[litellm]"
 ```
 
 ## 🚀 Quickstart

--- a/mobilerun/agent/providers/registry.py
+++ b/mobilerun/agent/providers/registry.py
@@ -19,6 +19,7 @@ VARIANT_ENV_KEY_SLOT: dict[str, str] = {
     "ZAI": "zai",
     "ZAI_Coding": "zai",
     "MiniMax": "minimax",
+    "LiteLLM": "litellm",
 }
 
 
@@ -210,6 +211,25 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
         notes=(
             "ZAI is exposed as a first-class provider family while reusing the OpenAI-compatible transport.",
             "Use auth mode `coding_api` for the GLM Coding Plan endpoint.",
+        ),
+    ),
+    ProviderFamilySpec(
+        id="litellm",
+        display_name="LiteLLM",
+        variants=(
+            ProviderVariantSpec(
+                id="LiteLLM",
+                runtime_provider_name="LiteLLM",
+                auth_mode="api_key",
+                default_model=None,
+                models=(),
+                requires_api_key=True,
+            ),
+        ),
+        notes=(
+            "LiteLLM is an AI gateway that provides access to 100+ LLM providers "
+            "(OpenAI, Anthropic, Azure, Bedrock, Vertex, etc.) via a unified interface.",
+            "Use any model in `provider/model` format (e.g. anthropic/claude-sonnet-4-6).",
         ),
     ),
 )

--- a/mobilerun/agent/usage.py
+++ b/mobilerun/agent/usage.py
@@ -22,11 +22,13 @@ SUPPORTED_PROVIDERS = [
     "Anthropic_LLM",
     "AnthropicOAuthLLM",
     "Ollama",
+    "LiteLLM",
 ]
 
 PROVIDER_ALIASES = {
     "MobilerunAnthropic": "Anthropic",
     "MobilerunOpenAIResponses": "OpenAIResponses",
+    "MobilerunLiteLLM": "LiteLLM",
     "openai_responses_llm": "OpenAIResponses",
     "Ollama_llm": "Ollama",
 }
@@ -129,6 +131,21 @@ def get_usage_from_response(provider: str, chat_rsp: ChatResponse) -> UsageResul
             request_tokens=prompt_eval_count,
             response_tokens=eval_count,
             total_tokens=prompt_eval_count + eval_count,
+            requests=1,
+        )
+    elif provider == "LiteLLM":
+        usage = getattr(rsp, "usage", None) or (rsp.get("usage") if isinstance(rsp, dict) else None)
+        if usage is None:
+            return UsageResult(
+                request_tokens=0, response_tokens=0, total_tokens=0, requests=1
+            )
+        prompt_tokens = _usage_field(usage, "prompt_tokens")
+        completion_tokens = _usage_field(usage, "completion_tokens")
+        total_tokens = _usage_field(usage, "total_tokens")
+        return UsageResult(
+            request_tokens=prompt_tokens,
+            response_tokens=completion_tokens,
+            total_tokens=total_tokens or (prompt_tokens + completion_tokens),
             requests=1,
         )
     raise ValueError(f"Unsupported provider: {provider}")

--- a/mobilerun/agent/utils/llm_picker.py
+++ b/mobilerun/agent/utils/llm_picker.py
@@ -21,6 +21,7 @@ SUPPORTED_PROVIDERS = [
     "DeepSeek",
     "OpenRouter",
     "MiniMax",
+    "LiteLLM",
 ]
 
 PROVIDER_ALIASES = {
@@ -36,6 +37,9 @@ PROVIDER_ALIASES = {
     "openai_like": "OpenAILike",
     "zai": "ZAI",
     "z.ai": "ZAI",
+    "litellm": "LiteLLM",
+    "lite_llm": "LiteLLM",
+    "lite-llm": "LiteLLM",
 }
 
 ZAI_GLOBAL_API_BASE = "https://api.z.ai/api/paas/v4"
@@ -231,6 +235,126 @@ def _load_anthropic(**kwargs: Any) -> LLM:
     return MobilerunAnthropic(**filtered_kwargs)
 
 
+def _load_litellm(**kwargs: Any) -> LLM:
+    from llama_index.core.base.llms.types import ChatMessage, ChatResponse, LLMMetadata
+    from llama_index.core.llms import CustomLLM
+    from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
+
+    class MobilerunLiteLLM(CustomLLM):
+        model: str = ""
+        temperature: float = 0.1
+        max_tokens: int | None = None
+        api_key: str | None = None
+        api_base: str | None = None
+
+        @property
+        def metadata(self) -> LLMMetadata:
+            return LLMMetadata(
+                model_name=self.model,
+                is_chat_model=True,
+            )
+
+        def _get_litellm_kwargs(self) -> dict[str, Any]:
+            kw: dict[str, Any] = {
+                "model": self.model,
+                "temperature": self.temperature,
+                "drop_params": True,
+            }
+            if self.max_tokens is not None:
+                kw["max_tokens"] = self.max_tokens
+            if self.api_key:
+                kw["api_key"] = self.api_key
+            if self.api_base:
+                kw["api_base"] = self.api_base
+            return kw
+
+        @llm_completion_callback()
+        def complete(self, prompt: str, formatted: bool = False, **kw: Any) -> Any:
+            import litellm
+            from llama_index.core.base.llms.types import CompletionResponse
+
+            resp = litellm.completion(
+                messages=[{"role": "user", "content": prompt}],
+                **{**self._get_litellm_kwargs(), **kw},
+            )
+            return CompletionResponse(
+                text=resp.choices[0].message.content or "",
+                raw=resp,
+            )
+
+        @llm_completion_callback()
+        def stream_complete(self, prompt: str, formatted: bool = False, **kw: Any) -> Any:
+            import litellm
+            from llama_index.core.base.llms.types import CompletionResponse
+
+            stream = litellm.completion(
+                messages=[{"role": "user", "content": prompt}],
+                stream=True,
+                **{**self._get_litellm_kwargs(), **kw},
+            )
+            for chunk in stream:
+                delta = chunk.choices[0].delta.content or ""
+                yield CompletionResponse(text=delta, delta=delta, raw=chunk)
+
+        @llm_chat_callback()
+        def chat(self, messages: list, **kw: Any) -> ChatResponse:
+            import litellm
+
+            msgs = [{"role": m.role.value, "content": m.content} for m in messages]
+            resp = litellm.completion(
+                messages=msgs,
+                **{**self._get_litellm_kwargs(), **kw},
+            )
+            return ChatResponse(
+                message=ChatMessage(
+                    role="assistant",
+                    content=resp.choices[0].message.content or "",
+                ),
+                raw=resp,
+            )
+
+        async def achat(self, messages: list, **kw: Any) -> ChatResponse:
+            import litellm
+
+            msgs = [{"role": m.role.value, "content": m.content} for m in messages]
+            resp = await litellm.acompletion(
+                messages=msgs,
+                **{**self._get_litellm_kwargs(), **kw},
+            )
+            return ChatResponse(
+                message=ChatMessage(
+                    role="assistant",
+                    content=resp.choices[0].message.content or "",
+                ),
+                raw=resp,
+            )
+
+        async def astream_chat(self, messages: list, **kw: Any) -> Any:
+            import litellm
+
+            msgs = [{"role": m.role.value, "content": m.content} for m in messages]
+            stream = await litellm.acompletion(
+                messages=msgs,
+                stream=True,
+                **{**self._get_litellm_kwargs(), **kw},
+            )
+            async for chunk in stream:
+                delta = chunk.choices[0].delta.content or ""
+                yield ChatResponse(
+                    message=ChatMessage(role="assistant", content=delta),
+                    delta=delta,
+                    raw=chunk,
+                )
+
+    if "base_url" in kwargs and "api_base" not in kwargs:
+        kwargs["api_base"] = kwargs.pop("base_url")
+    filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    logger.debug(
+        f"Initializing MobilerunLiteLLM with kwargs: {list(filtered_kwargs.keys())}"
+    )
+    return MobilerunLiteLLM(**filtered_kwargs)
+
+
 def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM:
     """Load and initialize a configured LLM backend.
 
@@ -330,6 +454,8 @@ def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM
         from llama_index.llms.openrouter import OpenRouter
 
         llm_class = OpenRouter
+    elif provider_name == "LiteLLM":
+        return _load_litellm(**kwargs)
     else:
         raise ValueError(
             f"Unsupported provider '{provider_name}'. "

--- a/mobilerun/cli/main.py
+++ b/mobilerun/cli/main.py
@@ -447,7 +447,7 @@ except Exception:
 @click.option(
     "--provider",
     "-p",
-    help="LLM provider (OpenAI, openai_oauth, Ollama, Anthropic, anthropic_oauth, GoogleGenAI, gemini_oauth_code_assist, DeepSeek)",
+    help="LLM provider (OpenAI, openai_oauth, Ollama, Anthropic, anthropic_oauth, GoogleGenAI, gemini_oauth_code_assist, DeepSeek, LiteLLM)",
     default=None,
 )
 @click.option(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ dev = [
     "safety>=3.2.11",
     "mobilerun[langfuse]",
 ]
+litellm = [
+    "litellm>=1.83.0,<2.0.0",
+]
 langfuse = [
     "langfuse==3.12.1",
     "openinference-instrumentation-llama-index>=3.0.0",

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,242 @@
+"""Edge-case tests for the LiteLLM provider in mobilerun."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+
+from mobilerun.agent.utils.llm_picker import load_llm, normalize_provider_name
+
+
+# --- Provider alias resolution ---
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected"),
+    [
+        ("litellm", "LiteLLM"),
+        ("LiteLLM", "LiteLLM"),
+        ("lite_llm", "LiteLLM"),
+        ("lite-llm", "LiteLLM"),
+    ],
+)
+def test_litellm_alias_resolution(alias: str, expected: str) -> None:
+    assert normalize_provider_name(alias) == expected
+
+
+# --- Constructor and kwargs ---
+
+
+def test_litellm_loads_with_model_and_api_key() -> None:
+    llm = load_llm("LiteLLM", model="anthropic/claude-sonnet-4-6", api_key="sk-test")
+    assert llm.model == "anthropic/claude-sonnet-4-6"
+    assert llm.api_key == "sk-test"
+
+
+def test_litellm_loads_with_api_base() -> None:
+    llm = load_llm(
+        "LiteLLM",
+        model="openai/gpt-4o",
+        api_key="sk-test",
+        api_base="http://myproxy:4000",
+    )
+    assert llm.api_base == "http://myproxy:4000"
+
+
+def test_litellm_base_url_mapped_to_api_base() -> None:
+    llm = load_llm(
+        "LiteLLM",
+        model="openai/gpt-4o",
+        api_key="sk-test",
+        base_url="http://myproxy:4000",
+    )
+    assert llm.api_base == "http://myproxy:4000"
+
+
+def test_litellm_drop_params_always_true() -> None:
+    llm = load_llm("LiteLLM", model="test/model", api_key="sk-test")
+    kw = llm._get_litellm_kwargs()
+    assert kw["drop_params"] is True
+
+
+def test_litellm_kwargs_forwarding() -> None:
+    llm = load_llm(
+        "LiteLLM",
+        model="anthropic/claude-sonnet-4-6",
+        api_key="sk-key",
+        api_base="http://localhost:4000",
+        temperature=0.5,
+        max_tokens=1024,
+    )
+    kw = llm._get_litellm_kwargs()
+    assert kw["model"] == "anthropic/claude-sonnet-4-6"
+    assert kw["temperature"] == 0.5
+    assert kw["max_tokens"] == 1024
+    assert kw["api_key"] == "sk-key"
+    assert kw["api_base"] == "http://localhost:4000"
+    assert kw["drop_params"] is True
+
+
+def test_litellm_omits_none_api_key() -> None:
+    llm = load_llm("LiteLLM", model="test/model")
+    kw = llm._get_litellm_kwargs()
+    assert "api_key" not in kw
+
+
+def test_litellm_omits_none_api_base() -> None:
+    llm = load_llm("LiteLLM", model="test/model", api_key="sk-test")
+    kw = llm._get_litellm_kwargs()
+    assert "api_base" not in kw
+
+
+# --- Model string format ---
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "anthropic/claude-sonnet-4-6",
+        "openai/gpt-4o",
+        "bedrock/anthropic.claude-sonnet-4-6-v1",
+        "vertex_ai/gemini-2.5-flash",
+        "groq/llama-4-scout-17b-16e-instruct",
+        "mistral/mistral-large-latest",
+        "deepseek/deepseek-chat",
+    ],
+)
+def test_litellm_model_string_preserved(model: str) -> None:
+    llm = load_llm("LiteLLM", model=model, api_key="sk-test")
+    kw = llm._get_litellm_kwargs()
+    assert kw["model"] == model
+
+
+# --- Completion (mocked) ---
+
+
+@patch("litellm.completion")
+def test_litellm_complete(mock_completion: MagicMock) -> None:
+    mock_completion.return_value = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="4"),
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=10, completion_tokens=1, total_tokens=11
+        ),
+    )
+
+    llm = load_llm("LiteLLM", model="anthropic/claude-sonnet-4-6", api_key="sk-test")
+    resp = llm.complete("What is 2+2?")
+
+    assert resp.text == "4"
+    mock_completion.assert_called_once()
+    call_kwargs = mock_completion.call_args
+    assert call_kwargs.kwargs["model"] == "anthropic/claude-sonnet-4-6"
+    assert call_kwargs.kwargs["drop_params"] is True
+
+
+@patch("litellm.completion")
+def test_litellm_complete_empty_content(mock_completion: MagicMock) -> None:
+    mock_completion.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=None))],
+    )
+
+    llm = load_llm("LiteLLM", model="test/model", api_key="sk-test")
+    resp = llm.complete("test")
+    assert resp.text == ""
+
+
+@patch("litellm.completion")
+def test_litellm_complete_auth_error(mock_completion: MagicMock) -> None:
+    mock_completion.side_effect = Exception("AuthenticationError: Invalid API key")
+
+    llm = load_llm("LiteLLM", model="test/model", api_key="sk-bad")
+    with pytest.raises(Exception, match="AuthenticationError"):
+        llm.complete("test")
+
+
+# --- Chat (mocked) ---
+
+
+@patch("litellm.completion")
+def test_litellm_chat(mock_completion: MagicMock) -> None:
+    mock_completion.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Hello!"))],
+    )
+
+    llm = load_llm("LiteLLM", model="openai/gpt-4o", api_key="sk-test")
+    messages = [ChatMessage(role=MessageRole.USER, content="Hi")]
+    resp = llm.chat(messages)
+
+    assert resp.message.content == "Hello!"
+    call_kwargs = mock_completion.call_args
+    assert call_kwargs.kwargs["messages"][0]["role"] == "user"
+    assert call_kwargs.kwargs["messages"][0]["content"] == "Hi"
+
+
+# --- Streaming (mocked) ---
+
+
+@patch("litellm.completion")
+def test_litellm_stream_complete(mock_completion: MagicMock) -> None:
+    chunks = [
+        SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content="Hel"))]),
+        SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content="lo"))]),
+        SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content=None))]),
+    ]
+    mock_completion.return_value = iter(chunks)
+
+    llm = load_llm("LiteLLM", model="test/model", api_key="sk-test")
+    result = list(llm.stream_complete("test"))
+
+    assert len(result) == 3
+    assert result[0].text == "Hel"
+    assert result[1].text == "lo"
+    assert result[2].text == ""
+    call_kwargs = mock_completion.call_args
+    assert call_kwargs.kwargs["stream"] is True
+
+
+# --- Async chat (mocked) ---
+
+
+def test_litellm_achat() -> None:
+    import asyncio
+
+    mock_resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="async ok"))],
+    )
+    with patch("litellm.acompletion", new_callable=AsyncMock) as mock_acompletion:
+        mock_acompletion.return_value = mock_resp
+
+        llm = load_llm("LiteLLM", model="openai/gpt-4o", api_key="sk-test")
+        messages = [ChatMessage(role=MessageRole.USER, content="test")]
+        resp = asyncio.get_event_loop().run_until_complete(llm.achat(messages))
+
+        assert resp.message.content == "async ok"
+        mock_acompletion.assert_called_once()
+
+
+# --- Metadata ---
+
+
+def test_litellm_metadata() -> None:
+    llm = load_llm(
+        "LiteLLM", model="anthropic/claude-sonnet-4-6", api_key="sk-test"
+    )
+    meta = llm.metadata
+    assert meta.model_name == "anthropic/claude-sonnet-4-6"
+    assert meta.is_chat_model is True
+
+
+# --- Usage tracking ---
+
+
+def test_litellm_usage_tracking() -> None:
+    from mobilerun.agent.usage import create_tracker
+
+    llm = load_llm("LiteLLM", model="anthropic/claude-sonnet-4-6", api_key="sk-test")
+    tracker = create_tracker(llm)
+    assert tracker.provider == "LiteLLM"

--- a/tests/test_llm_picker.py
+++ b/tests/test_llm_picker.py
@@ -18,6 +18,9 @@ from mobilerun.agent.utils.llm_picker import load_llm, normalize_provider_name
         ("OpenAI-like", "OpenAILike"),
         ("ZAI", "ZAI"),
         ("Z.AI", "ZAI"),
+        ("litellm", "LiteLLM"),
+        ("lite_llm", "LiteLLM"),
+        ("lite-llm", "LiteLLM"),
     ],
 )
 def test_normalize_provider_name_accepts_user_facing_aliases(
@@ -302,3 +305,74 @@ def test_ollama_wizard_default_includes_context_window() -> None:
     from mobilerun.agent.providers.setup_service import DEFAULT_KWARGS_BY_VARIANT
 
     assert DEFAULT_KWARGS_BY_VARIANT["Ollama"] == {"context_window": 32768}
+
+
+def test_litellm_loads_correct_class() -> None:
+    llm = load_llm(
+        "LiteLLM",
+        model="anthropic/claude-haiku-4-5",
+        api_key="stub",
+    )
+
+    assert type(llm).__name__ == "MobilerunLiteLLM"
+
+
+def test_litellm_alias_resolves() -> None:
+    llm = load_llm(
+        "litellm",
+        model="openai/gpt-4o-mini",
+        api_key="stub",
+    )
+
+    assert type(llm).__name__ == "MobilerunLiteLLM"
+
+
+def test_litellm_base_url_translates_to_api_base() -> None:
+    llm = load_llm(
+        "LiteLLM",
+        model="openai/gpt-4o-mini",
+        api_key="stub",
+        base_url="http://localhost:4000",
+    )
+
+    assert type(llm).__name__ == "MobilerunLiteLLM"
+    assert llm.api_base == "http://localhost:4000"
+
+
+def test_litellm_provider_slash_model_format() -> None:
+    llm = load_llm("LiteLLM", model="anthropic/claude-sonnet-4-6", api_key="stub")
+
+    assert llm.model == "anthropic/claude-sonnet-4-6"
+
+
+def test_litellm_bare_model_name_preserved() -> None:
+    llm = load_llm("LiteLLM", model="gpt-4o-mini", api_key="stub")
+
+    assert llm.model == "gpt-4o-mini"
+
+
+def test_litellm_api_key_forwarded() -> None:
+    llm = load_llm("LiteLLM", model="openai/gpt-4o-mini", api_key="sk-test-key-123")
+
+    assert llm.api_key == "sk-test-key-123"
+
+
+def test_litellm_temperature_forwarded() -> None:
+    llm = load_llm(
+        "LiteLLM", model="openai/gpt-4o-mini", api_key="stub", temperature=0.7
+    )
+
+    assert llm.temperature == 0.7
+
+
+def test_litellm_max_tokens_forwarded() -> None:
+    llm = load_llm(
+        "LiteLLM", model="openai/gpt-4o-mini", api_key="stub", max_tokens=512
+    )
+
+    assert llm.max_tokens == 512
+
+
+def test_litellm_unsupported_provider_raises() -> None:
+    with pytest.raises(ValueError, match="Unsupported provider"):
+        load_llm("NotARealProvider", model="some-model", api_key="stub")

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -79,6 +79,16 @@ def test_openai_api_key_catalog_uses_current_default_model() -> None:
     assert models == ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano")
 
 
+def test_litellm_family_resolves_api_key_variant() -> None:
+    variant = resolve_provider_variant("litellm", "api_key")
+
+    assert variant.id == "LiteLLM"
+    assert variant.runtime_provider_name == "LiteLLM"
+    assert variant.requires_api_key is True
+    assert variant.default_model is None
+    assert variant.models == ()
+
+
 def test_default_profiles_use_stable_gemini_flash_lite() -> None:
     config = MobileConfig()
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -64,6 +64,97 @@ def test_openai_responses_class_name_extracts_usage_from_response() -> None:
     assert usage.requests == 1
 
 
+def _litellm_chat_response() -> ChatResponse:
+    return ChatResponse(
+        message=ChatMessage(role=MessageRole.ASSISTANT, content="ok"),
+        raw=SimpleNamespace(
+            usage=SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+            )
+        ),
+    )
+
+
+def test_litellm_extracts_usage_from_response() -> None:
+    usage = get_usage_from_response("LiteLLM", _litellm_chat_response())
+
+    assert usage.request_tokens == 10
+    assert usage.response_tokens == 5
+    assert usage.total_tokens == 15
+    assert usage.requests == 1
+
+
+def test_track_usage_supports_litellm() -> None:
+    llm = load_llm("LiteLLM", model="openai/gpt-4o-mini", api_key="stub")
+
+    tracker = track_usage(llm)
+
+    assert isinstance(tracker, TokenCountingHandler)
+    assert tracker.provider == "LiteLLM"
+
+
+def test_litellm_usage_with_null_usage_returns_zeros() -> None:
+    rsp = ChatResponse(
+        message=ChatMessage(role=MessageRole.ASSISTANT, content="ok"),
+        raw=SimpleNamespace(),
+    )
+
+    usage = get_usage_from_response("LiteLLM", rsp)
+
+    assert usage.request_tokens == 0
+    assert usage.response_tokens == 0
+    assert usage.total_tokens == 0
+    assert usage.requests == 1
+
+
+def test_litellm_usage_with_dict_raw_response() -> None:
+    rsp = ChatResponse(
+        message=ChatMessage(role=MessageRole.ASSISTANT, content="ok"),
+        raw={
+            "usage": {
+                "prompt_tokens": 15,
+                "completion_tokens": 8,
+                "total_tokens": 23,
+            }
+        },
+    )
+
+    usage = get_usage_from_response("LiteLLM", rsp)
+
+    assert usage.request_tokens == 15
+    assert usage.response_tokens == 8
+    assert usage.total_tokens == 23
+
+
+def test_litellm_usage_computes_total_when_missing() -> None:
+    rsp = ChatResponse(
+        message=ChatMessage(role=MessageRole.ASSISTANT, content="ok"),
+        raw=SimpleNamespace(
+            usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+        ),
+    )
+
+    usage = get_usage_from_response("LiteLLM", rsp)
+
+    assert usage.request_tokens == 10
+    assert usage.response_tokens == 5
+    assert usage.total_tokens == 15
+
+
+def test_litellm_no_raw_response_raises() -> None:
+    rsp = ChatResponse(
+        message=ChatMessage(role=MessageRole.ASSISTANT, content="ok"),
+        raw=None,
+    )
+
+    import pytest
+
+    with pytest.raises(ValueError, match="No raw response"):
+        get_usage_from_response("LiteLLM", rsp)
+
+
 def test_track_usage_supports_mobilerun_anthropic_wrapper() -> None:
     llm = load_llm("Anthropic", model="claude-opus-4-8", api_key="stub")
 


### PR DESCRIPTION
## Summary

- Adds [LiteLLM](https://github.com/BerriAI/litellm) as a first-class AI gateway provider, giving Mobilerun users access to 100+ LLM providers (OpenAI, Anthropic, Azure, AWS Bedrock, Google Vertex, Groq, Mistral, etc.) through a single unified interface.
- LiteLLM is installed as an optional extra (`pip install mobilerun[litellm]`), keeping the base install unaffected.
- Uses litellm SDK directly (`import litellm` / `litellm.completion()`) with a custom `MobilerunLiteLLM` wrapper extending llama-index's `CustomLLM`.


## Changes

- `pyproject.toml` - Added `litellm` optional dependency group with `litellm>=1.83.0,<2.0.0`
- `mobilerun/agent/providers/registry.py` - Added LiteLLM provider family with API key auth mode and env key slot
- `mobilerun/agent/utils/llm_picker.py` - Added `MobilerunLiteLLM` class (extends `CustomLLM`, calls `litellm.completion()` / `litellm.acompletion()` directly with `drop_params=True`), registered in `SUPPORTED_PROVIDERS`, `PROVIDER_ALIASES`, and `load_llm()` dispatch
- `mobilerun/agent/usage.py` - Added LiteLLM to supported providers list, alias map, and usage extraction (prompt_tokens, completion_tokens, total_tokens)
- `mobilerun/cli/main.py` - Updated CLI `--provider` help text to include LiteLLM
- `README.md` - Added LiteLLM to feature list and installation instructions
- `tests/test_llm_picker.py` - 9 tests: alias resolution, class loading, base_url translation, provider/model format, bare model name, API key forwarding, temperature forwarding, max_tokens forwarding, unsupported provider error
- `tests/test_provider_registry.py` - 1 test: provider family variant resolution
- `tests/test_usage.py` - 6 tests: usage extraction, tracker support, null usage fallback, dict raw response, total computation from parts, no-raw-response error

## Tests

**1. Unit tests (71/71 passing):**

```
tests/test_llm_picker.py::test_litellm_loads_correct_class PASSED
tests/test_llm_picker.py::test_litellm_alias_resolves PASSED
tests/test_llm_picker.py::test_litellm_base_url_translates_to_api_base PASSED
tests/test_llm_picker.py::test_litellm_provider_slash_model_format PASSED
tests/test_llm_picker.py::test_litellm_bare_model_name_preserved PASSED
tests/test_llm_picker.py::test_litellm_api_key_forwarded PASSED
tests/test_llm_picker.py::test_litellm_temperature_forwarded PASSED
tests/test_llm_picker.py::test_litellm_max_tokens_forwarded PASSED
tests/test_llm_picker.py::test_litellm_unsupported_provider_raises PASSED
tests/test_provider_registry.py::test_litellm_family_resolves_api_key_variant PASSED
tests/test_usage.py::test_litellm_extracts_usage_from_response PASSED
tests/test_usage.py::test_track_usage_supports_litellm PASSED
tests/test_usage.py::test_litellm_usage_with_null_usage_returns_zeros PASSED
tests/test_usage.py::test_litellm_usage_with_dict_raw_response PASSED
tests/test_usage.py::test_litellm_usage_computes_total_when_missing PASSED
tests/test_usage.py::test_litellm_no_raw_response_raises PASSED
============================== 71 passed in 1.08s ==============================
```

**2. Lint:** `ruff check mobilerun/ tests/` -> All checks passed.

**3. Live E2E against Anthropic (via Azure Foundry):**

```python
from mobilerun.agent.utils.llm_picker import load_llm
from mobilerun.agent.usage import get_usage_from_response
from llama_index.core.base.llms.types import ChatMessage

llm = load_llm('LiteLLM', model='anthropic/claude-sonnet-4-6',
               api_base='https://amanrai-test-resource.services.ai.azure.com/anthropic')
messages = [ChatMessage(role='user', content='What is 2+2? Reply with just the number.')]
response = llm.chat(messages)
usage = get_usage_from_response('LiteLLM', response)
```

```
Provider class: MobilerunLiteLLM
Model: anthropic/claude-sonnet-4-6
Response: 4
Usage: prompt_tokens=20, completion_tokens=5, total_tokens=25
```

**4. Pin resolution verified:** `pip install -e '.[litellm]'` resolves cleanly against `litellm>=1.83.0,<2.0.0`.

## Risk / Compatibility

- Additive only. No existing providers touched.
- `litellm` is an optional extra - base install and all existing providers remain unaffected.
- Uses litellm SDK directly (`import litellm`) - no additional wrapper packages needed.
- LiteLLM appears in `mobilerun configure` wizard automatically via the provider family registry.

## Example usage

**CLI:**
```bash
# Install with LiteLLM support
pip install "mobilerun[litellm]"

# Use with any LiteLLM-supported provider
mobilerun "Open Settings" --provider LiteLLM --model anthropic/claude-sonnet-4-6

# Or with Azure OpenAI
AZURE_API_KEY=... AZURE_API_BASE=... \
mobilerun "Take a screenshot" --provider LiteLLM --model azure/gpt-4o

# Or with AWS Bedrock
AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... \
mobilerun "Open Chrome" --provider LiteLLM --model bedrock/anthropic.claude-v2
```

**Python SDK:**
```python
from mobilerun.agent.utils.llm_picker import load_llm

llm = load_llm("LiteLLM", model="anthropic/claude-sonnet-4-6")
# Use with MobileAgent as usual
```
