### PR TITLE
chore(release): bump to 0.6.11

### DIFF
--- a/compat/pyproject.toml
+++ b/compat/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "droidrun"
-version = "0.6.10"
+version = "0.6.11"
 description = "Compatibility shim — droidrun has been renamed to mobilerun"
 requires-python = ">=3.11,<3.14"
-dependencies = ["mobilerun==0.6.10"]
+dependencies = ["mobilerun==0.6.11"]
 
 [project.optional-dependencies]
-anthropic = ["mobilerun[anthropic]==0.6.10"]
-deepseek = ["mobilerun[deepseek]==0.6.10"]
-langfuse = ["mobilerun[langfuse]==0.6.10"]
-dev = ["mobilerun[dev]==0.6.10"]
+anthropic = ["mobilerun[anthropic]==0.6.11"]
+deepseek = ["mobilerun[deepseek]==0.6.11"]
+langfuse = ["mobilerun[langfuse]==0.6.11"]
+dev = ["mobilerun[dev]==0.6.11"]
 
 [project.scripts]
 droidrun = "droidrun.cli_shim:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mobilerun"
-version = "0.6.10"
+version = "0.6.11"
 description = "A framework for controlling mobile devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels@droidrun.ai" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1793,7 +1793,7 @@ wheels = [
 
 [[package]]
 name = "mobilerun"
-version = "0.6.10"
+version = "0.6.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Bump the `mobilerun` package version from 0.6.10 to 0.6.11.
- Align the `droidrun` compatibility shim and all optional dependency pins to 0.6.11.
- Regenerate `uv.lock` so the local package metadata reports 0.6.11.

## Why
Release PR #382, which moves the concrete driver implementations to `mobilerun-core-local` while preserving the historical Mobilerun compatibility import surface.

## Validation
- `uv run pytest` — 218 passed
- `uvx black==25.9.0 --check .` — 152 files unchanged
- Root/compat/tag version alignment and all five compatibility pins verified
- Built both wheels and sdists
- Wheel metadata verified: `mobilerun-core-local[cloud]>=0.5.0`; `droidrun` pins `mobilerun==0.6.11`
- Android 16 and iOS live OAuth E2E regression pass completed before release