### PR TITLE
Verify text input before reporting success

### DIFF
--- a/mobilerun/agent/utils/actions.py
+++ b/mobilerun/agent/utils/actions.py
@@ -187,6 +187,80 @@ async def _macro_pre_ui_after_focus_tap(ctx: "ActionContext"):
     return await _macro_pre_ui(ctx)
 
 
+def _normalize_input_text(value: object) -> str:
+    return str(value or "").replace("\u200b", "").replace("\ufeff", "")
+
+
+async def _verify_text_input(
+    text: str, clear: bool, *, ctx: "ActionContext"
+) -> bool | None:
+    """Return True/False for observable fields, or None when readback is unavailable."""
+    state_provider = getattr(ctx, "state_provider", None)
+    if state_provider is None or not hasattr(state_provider, "get_state"):
+        return None
+
+    try:
+        post_ui = await state_provider.get_state()
+    except Exception as exc:
+        logger.debug("Text input verification unavailable: %s", exc)
+        return None
+
+    phone_state = getattr(post_ui, "phone_state", None)
+    if not isinstance(phone_state, dict):
+        return None
+    focused = phone_state.get("focusedElement")
+    if not isinstance(focused, dict) or "text" not in focused:
+        return None
+    if focused.get("isPassword") is True:
+        return None
+    if phone_state.get("isEditable") is False:
+        return None
+
+    actual = "" if focused.get("isShowingHintText") is True else focused.get("text")
+    normalized_actual = _normalize_input_text(actual)
+    normalized_expected = _normalize_input_text(text)
+    if clear:
+        return normalized_actual == normalized_expected
+    return normalized_expected in normalized_actual
+
+
+async def _input_text_with_verification(
+    text: str,
+    clear: bool,
+    *,
+    ctx: "ActionContext",
+    pre_ui=None,
+) -> ActionResult:
+    accepted = await ctx.driver.input_text(text, clear)
+    if not accepted:
+        return ActionResult(success=False, summary="Failed to type text: input failed")
+
+    verified = await _verify_text_input(text, clear, ctx=ctx)
+    if verified is False:
+        return ActionResult(
+            success=False,
+            summary=(
+                "Failed to type text: input was accepted but the focused field "
+                "did not contain the expected text"
+            ),
+        )
+
+    _record_macro_action(
+        ctx,
+        {"action_type": "input_text", "text": text, "clear": clear},
+        pre_ui=pre_ui,
+    )
+    if verified is None:
+        return ActionResult(
+            success=True,
+            summary=f"Text input accepted; verification unavailable (clear={clear})",
+        )
+    return ActionResult(
+        success=True,
+        summary=f"Text typed and verified (clear={clear})",
+    )
+
+
 def _driver_log_length(ctx: "ActionContext") -> int | None:
     log = getattr(getattr(ctx, "driver", None), "log", None)
     if isinstance(log, list):
@@ -344,20 +418,12 @@ async def type_text(
             )
             pre_ui = await _macro_pre_ui_after_focus_tap(ctx)
 
-        success = await ctx.driver.input_text(text, clear)
-        if success:
-            _record_macro_action(
-                ctx,
-                {"action_type": "input_text", "text": text, "clear": clear},
-                pre_ui=pre_ui,
-            )
-            return ActionResult(
-                success=True, summary=f"Text typed successfully (clear={clear})"
-            )
-        else:
-            return ActionResult(
-                success=False, summary="Failed to type text: input failed"
-            )
+        return await _input_text_with_verification(
+            text,
+            clear,
+            ctx=ctx,
+            pre_ui=pre_ui,
+        )
     except Exception as e:
         return ActionResult(success=False, summary=f"Failed to type text: {e}")
 
@@ -368,17 +434,12 @@ async def type_text_direct(
     """Type text into the currently focused input."""
     try:
         pre_ui = await _macro_pre_ui(ctx)
-        success = await ctx.driver.input_text(text, clear)
-        if success:
-            _record_macro_action(
-                ctx,
-                {"action_type": "input_text", "text": text, "clear": clear},
-                pre_ui=pre_ui,
-            )
-            return ActionResult(
-                success=True, summary=f"Text typed successfully (clear={clear})"
-            )
-        return ActionResult(success=False, summary="Failed to type text: input failed")
+        return await _input_text_with_verification(
+            text,
+            clear,
+            ctx=ctx,
+            pre_ui=pre_ui,
+        )
     except Exception as e:
         return ActionResult(success=False, summary=f"Failed to type text: {e}")
 

--- a/tests/test_macro_recording_actions.py
+++ b/tests/test_macro_recording_actions.py
@@ -107,6 +107,15 @@ def test_type_text_with_index_records_input_with_refreshed_pre_state():
             "bounds": "10,20,110,60",
         }
     ]
+    post_ui = FakeUI()
+    post_ui.phone_state = {
+        "isEditable": True,
+        "focusedElement": {
+            "text": "hello",
+            "isPassword": False,
+            "isShowingHintText": False,
+        },
+    }
 
     recorder = MacroRecorder()
     driver = FakeDriver()
@@ -114,7 +123,7 @@ def test_type_text_with_index_records_input_with_refreshed_pre_state():
         driver=driver,
         ui=first_ui,
         macro_recorder=recorder,
-        state_provider=SequencedStateProvider([first_ui, focused_ui]),
+        state_provider=SequencedStateProvider([first_ui, focused_ui, post_ui]),
     )
 
     result = asyncio.run(type_text("hello", index=7, clear=True, ctx=ctx))
@@ -128,6 +137,31 @@ def test_type_text_with_index_records_input_with_refreshed_pre_state():
     assert "target_hint" not in recorder.actions[0]
     assert recorder.actions[1]["pre_state"]["nodes"][0]["focused"] is True
     assert "target_hint" not in recorder.actions[1]
+
+
+def test_type_text_mismatch_does_not_record_input_macro():
+    pre_ui = FakeUI()
+    post_ui = FakeUI()
+    post_ui.phone_state = {
+        "isEditable": True,
+        "focusedElement": {
+            "text": "",
+            "isPassword": False,
+            "isShowingHintText": True,
+        },
+    }
+    recorder = MacroRecorder()
+    ctx = SimpleNamespace(
+        driver=FakeDriver(),
+        ui=pre_ui,
+        macro_recorder=recorder,
+        state_provider=SequencedStateProvider([pre_ui, post_ui]),
+    )
+
+    result = asyncio.run(type_text("hello", clear=True, ctx=ctx))
+
+    assert not result.success
+    assert recorder.actions == []
 
 
 def test_type_secret_records_replayable_secret_action_not_placeholder():

--- a/tests/test_type_action.py
+++ b/tests/test_type_action.py
@@ -2,21 +2,22 @@ import asyncio
 import unittest
 from types import SimpleNamespace
 
-from mobilerun.agent.utils.actions import type_text
+from mobilerun.agent.utils.actions import type_text, type_text_direct
 from mobilerun.agent.utils.signatures import build_tool_registry
 
 
 class FakeDriver:
-    def __init__(self):
+    def __init__(self, accepted=True):
         self.taps = []
         self.inputs = []
+        self.accepted = accepted
 
     async def tap(self, x, y):
         self.taps.append((x, y))
 
     async def input_text(self, text, clear=False):
         self.inputs.append((text, clear))
-        return True
+        return self.accepted
 
 
 class FakeUI:
@@ -26,6 +27,27 @@ class FakeUI:
     def get_element_coords(self, index):
         self.requested_indices.append(index)
         return (123, 456)
+
+
+class FakeStateProvider:
+    def __init__(self, state):
+        self.state = state
+
+    async def get_state(self):
+        return self.state
+
+
+def observable_state(text, *, is_password=False, is_hint=False, is_editable=True):
+    return SimpleNamespace(
+        phone_state={
+            "isEditable": is_editable,
+            "focusedElement": {
+                "text": text,
+                "isPassword": is_password,
+                "isShowingHintText": is_hint,
+            },
+        }
+    )
 
 
 class TypeActionTest(unittest.TestCase):
@@ -64,6 +86,95 @@ class TypeActionTest(unittest.TestCase):
         self.assertEqual(driver.inputs, [("usb c cable", True)])
         self.assertEqual(driver.taps, [])
         self.assertEqual(ui.requested_indices, [])
+
+    def test_clear_requires_exact_focused_text(self):
+        driver = FakeDriver()
+        ui = FakeUI()
+        ctx = SimpleNamespace(
+            driver=driver,
+            ui=ui,
+            state_provider=FakeStateProvider(observable_state("different")),
+        )
+
+        result = asyncio.run(type_text("expected", clear=True, ctx=ctx))
+
+        self.assertFalse(result.success)
+        self.assertIn("did not contain the expected text", result.summary)
+
+    def test_clear_ignores_whatsapp_zero_width_sentinel(self):
+        driver = FakeDriver()
+        ctx = SimpleNamespace(
+            driver=driver,
+            ui=FakeUI(),
+            state_provider=FakeStateProvider(observable_state("\u200b9911656022")),
+        )
+
+        result = asyncio.run(type_text("9911656022", clear=True, ctx=ctx))
+
+        self.assertTrue(result.success)
+        self.assertIn("verified", result.summary)
+
+    def test_append_requires_requested_text_to_appear(self):
+        driver = FakeDriver()
+        ctx = SimpleNamespace(
+            driver=driver,
+            ui=FakeUI(),
+            state_provider=FakeStateProvider(observable_state("before and after")),
+        )
+
+        result = asyncio.run(type_text("after", clear=False, ctx=ctx))
+
+        self.assertTrue(result.success)
+
+    def test_hint_text_counts_as_empty(self):
+        driver = FakeDriver()
+        ctx = SimpleNamespace(
+            driver=driver,
+            ui=FakeUI(),
+            state_provider=FakeStateProvider(
+                observable_state("Search...", is_hint=True)
+            ),
+        )
+
+        result = asyncio.run(type_text("query", clear=True, ctx=ctx))
+
+        self.assertFalse(result.success)
+
+    def test_password_field_preserves_transport_success_without_readback(self):
+        driver = FakeDriver()
+        ctx = SimpleNamespace(
+            driver=driver,
+            ui=FakeUI(),
+            state_provider=FakeStateProvider(
+                observable_state("••••", is_password=True)
+            ),
+        )
+
+        result = asyncio.run(type_text("secret", clear=True, ctx=ctx))
+
+        self.assertTrue(result.success)
+        self.assertIn("verification unavailable", result.summary)
+
+    def test_driver_rejection_fails_without_readback(self):
+        driver = FakeDriver(accepted=False)
+        provider = FakeStateProvider(observable_state("expected"))
+        ctx = SimpleNamespace(driver=driver, ui=FakeUI(), state_provider=provider)
+
+        result = asyncio.run(type_text("expected", clear=True, ctx=ctx))
+
+        self.assertFalse(result.success)
+
+    def test_direct_typing_uses_same_verification(self):
+        driver = FakeDriver()
+        ctx = SimpleNamespace(
+            driver=driver,
+            ui=FakeUI(),
+            state_provider=FakeStateProvider(observable_state("wrong")),
+        )
+
+        result = asyncio.run(type_text_direct("expected", clear=True, ctx=ctx))
+
+        self.assertFalse(result.success)
 
     def test_type_schema_makes_index_optional_and_explains_focused_input(self):
         async def run():


### PR DESCRIPTION
## Summary

- add one shared postcondition for `type_text` and `type_text_direct`
- refresh UI state after transport acceptance and verify exact replacement or append containment
- treat hint-only fields as empty and ignore only U+200B/U+FEFF sentinels
- fail observable mismatches and skip the input macro
- preserve password/unreadable compatibility while reporting verification as unavailable

## Reproduction matrix

| Path | Before | After |
| --- | --- | --- |
| Generic Android replacement | Clear and commit were separate and transport acceptance could be reported as success | A single selection replacement is verified from fresh state |
| Gemma agent on Android 16 Settings search | No agent-side postcondition | Tool returned `Text typed and verified`; fresh state was exactly `MRTEST7319` |
| Physical WhatsApp search | Reporter observed an empty field despite a success response | Not rerun in this pass because the Samsung device was not connected |

No search result was selected and no message was sent.

## Tests

- PASS: `.venv/bin/pytest -q` (226 tests)
- PASS: Ruff on changed Python files
- PASS: Black check on changed Python files
- PASS on Android 16 `emulator-5554` with Ollama `gemma4:latest`: the agent replaced Settings search with `MRTEST7319`, returned `Text typed and verified`, and fresh Portal state contained the exact value.
- Test text was cleared and Gboard was restored afterward.
- The physical Samsung/WhatsApp matrix was not rerun because `R5CW41WF6WD` was not connected.

## Companion PRs

- [Mobilerun #387](https://github.com/droidrun/mobilerun/pull/387)
- [Public Portal #149](https://github.com/droidrun/mobilerun-portal/pull/149)
- [Internal Portal #72](https://github.com/droidrun/mobilerun-portal-internal/pull/72)