### PR TITLE
Add MCP registry server.json (remote HTTP endpoint)

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.droidrun/mobilerun",
+  "description": "Control real Android and iOS devices with LLM agents — inspect UI, tap, swipe, type, and automate app-only flows via natural language.",
+  "repository": {
+    "url": "https://github.com/droidrun/mobilerun",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.mobilerun.ai/v1/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer token — your Mobilerun API key (format: dr_sk_...). Get it in the Mobilerun app under AI & Agents.",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Prepares registration of Mobilerun in the official [MCP registry](https://github.com/modelcontextprotocol/registry) as `io.github.droidrun/mobilerun`.

This adds a root-level `server.json` describing the **hosted remote MCP endpoint** (`streamable-http`) at `https://api.mobilerun.ai/v1/mcp`. The endpoint uses Bearer authentication with a Mobilerun API key (`dr_sk_...`); the key is declared as a required, secret `Authorization` header — no real token is committed.

Notes:
- Server name namespace: `io.github.droidrun/mobilerun` (GitHub-based namespace verification).
- `version` is set to `1.0.0` for this first registry entry, aligned with the `/v1` API endpoint. Adjust if the hosted server uses a different versioning scheme.
- This is the MCP **server** entry only; the `mobile-harness` agent skill is intentionally not included here.