### PR TITLE
chore(release): bump to 0.6.12

### DIFF
--- a/compat/pyproject.toml
+++ b/compat/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "droidrun"
-version = "0.6.11"
+version = "0.6.12"
 description = "Compatibility shim — droidrun has been renamed to mobilerun"
 requires-python = ">=3.11,<3.14"
-dependencies = ["mobilerun==0.6.11"]
+dependencies = ["mobilerun==0.6.12"]
 
 [project.optional-dependencies]
-anthropic = ["mobilerun[anthropic]==0.6.11"]
-deepseek = ["mobilerun[deepseek]==0.6.11"]
-langfuse = ["mobilerun[langfuse]==0.6.11"]
-dev = ["mobilerun[dev]==0.6.11"]
+anthropic = ["mobilerun[anthropic]==0.6.12"]
+deepseek = ["mobilerun[deepseek]==0.6.12"]
+langfuse = ["mobilerun[langfuse]==0.6.12"]
+dev = ["mobilerun[dev]==0.6.12"]
 
 [project.scripts]
 droidrun = "droidrun.cli_shim:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mobilerun"
-version = "0.6.11"
+version = "0.6.12"
 description = "A framework for controlling mobile devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels@droidrun.ai" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1793,7 +1793,7 @@ wheels = [
 
 [[package]]
 name = "mobilerun"
-version = "0.6.11"
+version = "0.6.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump `mobilerun` to `0.6.12`.
- Align the `droidrun` compatibility shim and all exact `mobilerun` pins.
- Regenerate `uv.lock`.

## Validation

- `pytest` — 275 passed
- Black — 155 files unchanged
- `uv lock --check`, diff check, version/pin assertions — passed
- Built root and shim wheels/sdists; wheel metadata and `twine check` passed
- Ruff reports the same nine pre-existing findings as `main`; this PR introduces none

After merge, tag `v0.6.12` to publish both packages through the existing TestPyPI → PyPI workflow.