### PR TITLE
fix: correct MiniMax configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You should see confirmation that the Portal is installed and accessible.
 mobilerun configure
 ```
 
-The wizard walks you through choosing a provider, auth method, and model. You can also use provider environment variables such as `GOOGLE_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY`.
+The wizard walks you through choosing a provider, auth method, and model. You can also use provider environment variables such as `GOOGLE_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `MINIMAX_API_KEY`. For MiniMax, choose the Global (`https://api.minimax.io/v1`) or Mainland China (`https://api.minimaxi.com/v1`) endpoint that matches the platform where the key was created. If a MiniMax key is already saved, choose **Use env key** to make `MINIMAX_API_KEY` override it.
 
 ### 4. Run your first command
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You should see confirmation that the Portal is installed and accessible.
 mobilerun configure
 ```
 
-The wizard walks you through choosing a provider, auth method, and model. You can also use provider environment variables such as `GOOGLE_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `MINIMAX_API_KEY`. For MiniMax, choose the Global (`https://api.minimax.io/v1`) or Mainland China (`https://api.minimaxi.com/v1`) endpoint that matches the platform where the key was created. If a MiniMax key is already saved, choose **Use env key** to make `MINIMAX_API_KEY` override it.
+The wizard walks you through choosing a provider, auth method, and model. You can also use provider environment variables such as `GOOGLE_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `MINIMAX_API_KEY`.
 
 ### 4. Run your first command
 

--- a/docs/guides/cli.mdx
+++ b/docs/guides/cli.mdx
@@ -108,6 +108,13 @@ mobilerun run "Reply to latest email" \
   --provider Anthropic \
   --model claude-sonnet-4-5-latest
 
+# MiniMax (global API)
+export MINIMAX_API_KEY=your-key
+mobilerun run "Open Settings" \
+  --provider MiniMax \
+  --model MiniMax-M2.7 \
+  --base_url https://api.minimax.io/v1
+
 # Local Ollama (free)
 mobilerun run "Turn on dark mode" \
   --provider Ollama \
@@ -152,6 +159,36 @@ mobilerun run "Enable 2FA" \
 | Ollama | Included by default | None (local) |
 | Anthropic | `uv pip install 'mobilerun[anthropic]'` | `ANTHROPIC_API_KEY` |
 | DeepSeek | Included by default | `DEEPSEEK_API_KEY` |
+| MiniMax | Included by default | `MINIMAX_API_KEY` |
+
+### MiniMax endpoints and credentials
+
+Run `mobilerun configure`, choose MiniMax, and then select the API region where
+the key was created:
+
+| Region | Base URL |
+|--------|----------|
+| Global | `https://api.minimax.io/v1` |
+| Mainland China | `https://api.minimaxi.com/v1` |
+
+The global endpoint is the default. For noninteractive setup, pass a regional
+override explicitly:
+
+```bash
+mobilerun configure \
+  --provider minimax \
+  --model MiniMax-M2.7 \
+  --base-url https://api.minimaxi.com/v1
+```
+
+Keys are regional; a valid key from one MiniMax platform can be rejected by the
+other endpoint. When a profile uses `api_key_source: auto`, a key saved under
+`apiKeys.minimax` takes precedence over `MINIMAX_API_KEY`. To force the shell
+key, choose **Use env key** in the wizard. You can instead replace or remove the
+saved `apiKeys.minimax` entry in `credentials/auth-profiles.json` inside
+Mobilerun's platform configuration directory. Pasting a new key in the wizard
+updates that saved entry. The top-level `credentials.enabled` setting controls
+device secrets and does not configure LLM provider authentication.
 
   </Tab>
 
@@ -503,6 +540,7 @@ mobilerun ping --tcp
 | `OPENAI_API_KEY` | OpenAI API key | None |
 | `ANTHROPIC_API_KEY` | Anthropic API key | None |
 | `DEEPSEEK_API_KEY` | DeepSeek API key | None |
+| `MINIMAX_API_KEY` | MiniMax API key | None |
 | `MOBILERUN_CLOUD_API_KEY` | Mobilerun Cloud API key for `devices --cloud` and cloud device actions | None |
 | `MOBILERUN_CONFIG` | Config file path | `~/.config/mobilerun/config.yaml` |
 

--- a/docs/guides/cli.mdx
+++ b/docs/guides/cli.mdx
@@ -112,7 +112,7 @@ mobilerun run "Reply to latest email" \
 export MINIMAX_API_KEY=your-key
 mobilerun run "Open Settings" \
   --provider MiniMax \
-  --model MiniMax-M2.7 \
+  --model MiniMax-M3 \
   --base_url https://api.minimax.io/v1
 
 # Local Ollama (free)
@@ -171,8 +171,20 @@ the key was created:
 | Global | `https://api.minimax.io/v1` |
 | Mainland China | `https://api.minimaxi.com/v1` |
 
-The global endpoint is the default. For noninteractive setup, pass a regional
+The global endpoint is the default. `MiniMax-M3` is the first wizard choice and
+the default model for either region. For noninteractive setup, pass a regional
 override explicitly:
+
+```bash
+mobilerun configure \
+  --provider minimax \
+  --model MiniMax-M3 \
+  --base-url https://api.minimaxi.com/v1
+```
+
+The Mainland China model catalog can lag behind the global platform. If
+`MiniMax-M3` is not available for your China account, explicitly select the
+still-supported `MiniMax-M2.7` model:
 
 ```bash
 mobilerun configure \

--- a/docs/sdk/configuration.mdx
+++ b/docs/sdk/configuration.mdx
@@ -642,7 +642,20 @@ export MOBILERUN_CONFIG=/path/to/config.yaml  # Custom config path
 
 MiniMax uses `https://api.minimax.io/v1` for global accounts and
 `https://api.minimaxi.com/v1` for Mainland China accounts. The configure wizard
-asks for the matching region. With `api_key_source: auto`, the saved
+asks for the matching region and selects `MiniMax-M3` by default:
+
+```bash
+mobilerun configure \
+  --provider minimax \
+  --model MiniMax-M3 \
+  --base-url https://api.minimax.io/v1
+```
+
+The Mainland China model catalog can lag behind the global platform. If
+`MiniMax-M3` is not available for a China account, explicitly use the supported
+`MiniMax-M2.7` model with `https://api.minimaxi.com/v1`.
+
+With `api_key_source: auto`, the saved
 `apiKeys.minimax` value takes precedence over `MINIMAX_API_KEY`. Select **Use env
 key** in the wizard to force the environment value, or replace/remove the saved
 entry. Keys pasted into the wizard are stored in the `apiKeys.minimax` entry of

--- a/docs/sdk/configuration.mdx
+++ b/docs/sdk/configuration.mdx
@@ -611,11 +611,11 @@ mobilerun run "Task" --config /path/to/config.yaml
 - `--config PATH` - Custom config file
 - `--device SERIAL` - Device serial/IP
 - `--agent NAME` - External agent to use. Not yet supported — reserved for future use.
-- `--provider PROVIDER` - LLM provider (OpenAI, Ollama, Anthropic, GoogleGenAI, DeepSeek)
+- `--provider PROVIDER` - LLM provider (OpenAI, Ollama, Anthropic, GoogleGenAI, DeepSeek, MiniMax)
 - `--model MODEL` - LLM model name
 - `--temperature FLOAT` - LLM temperature
 - `--steps INT` - Max steps
-- `--base_url URL` - API base URL (for Ollama/OpenRouter)
+- `--base_url URL` - API base URL (for Ollama/OpenRouter/MiniMax)
 - `--api_base URL` - API base URL (for OpenAI-like)
 - `--vision/--no-vision` - Enable/disable vision for all agents
 - `--reasoning/--no-reasoning` - Enable/disable reasoning mode
@@ -636,5 +636,16 @@ export GOOGLE_API_KEY=your-key
 export OPENAI_API_KEY=your-key
 export ANTHROPIC_API_KEY=your-key
 export DEEPSEEK_API_KEY=your-key
+export MINIMAX_API_KEY=your-key
 export MOBILERUN_CONFIG=/path/to/config.yaml  # Custom config path
 ```
+
+MiniMax uses `https://api.minimax.io/v1` for global accounts and
+`https://api.minimaxi.com/v1` for Mainland China accounts. The configure wizard
+asks for the matching region. With `api_key_source: auto`, the saved
+`apiKeys.minimax` value takes precedence over `MINIMAX_API_KEY`. Select **Use env
+key** in the wizard to force the environment value, or replace/remove the saved
+entry. Keys pasted into the wizard are stored in the `apiKeys.minimax` entry of
+`credentials/auth-profiles.json` in the platform configuration directory; this
+file is separate from the device secrets file controlled by
+`credentials.enabled`.

--- a/mobilerun/agent/providers/__init__.py
+++ b/mobilerun/agent/providers/__init__.py
@@ -1,3 +1,9 @@
+from mobilerun.agent.providers.minimax import (
+    MINIMAX_CHINA_BASE_URL,
+    MINIMAX_GLOBAL_BASE_URL,
+    MINIMAX_LEGACY_BASE_URL,
+    warn_if_legacy_minimax_endpoint,
+)
 from mobilerun.agent.providers.registry import (
     VARIANT_ENV_KEY_SLOT,
     get_provider_family,
@@ -12,6 +18,9 @@ from mobilerun.agent.providers.types import (
 )
 
 __all__ = [
+    "MINIMAX_CHINA_BASE_URL",
+    "MINIMAX_GLOBAL_BASE_URL",
+    "MINIMAX_LEGACY_BASE_URL",
     "VARIANT_ENV_KEY_SLOT",
     "ProviderFamilySpec",
     "ProviderVariantSpec",
@@ -20,4 +29,5 @@ __all__ = [
     "list_models_for_variant",
     "list_provider_families",
     "resolve_provider_variant",
+    "warn_if_legacy_minimax_endpoint",
 ]

--- a/mobilerun/agent/providers/minimax.py
+++ b/mobilerun/agent/providers/minimax.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+
+MINIMAX_GLOBAL_BASE_URL = "https://api.minimax.io/v1"
+MINIMAX_CHINA_BASE_URL = "https://api.minimaxi.com/v1"
+MINIMAX_LEGACY_BASE_URL = "https://api.minimaxi.chat/v1"
+
+logger = logging.getLogger("mobilerun")
+
+
+def _normalize_base_url(base_url: str | None) -> str:
+    return str(base_url or "").strip().rstrip("/").lower()
+
+
+@lru_cache(maxsize=1)
+def _warn_about_legacy_endpoint_once() -> None:
+    logger.warning(
+        "This MiniMax profile uses the legacy endpoint "
+        f"{MINIMAX_LEGACY_BASE_URL}. The profile was not changed. Re-run "
+        "`mobilerun configure` and choose either Global "
+        f"({MINIMAX_GLOBAL_BASE_URL}) or Mainland China "
+        f"({MINIMAX_CHINA_BASE_URL})."
+    )
+
+
+def warn_if_legacy_minimax_endpoint(base_url: str | None) -> None:
+    """Warn once per process when a profile still uses MiniMax's legacy endpoint."""
+    if _normalize_base_url(base_url) == _normalize_base_url(MINIMAX_LEGACY_BASE_URL):
+        _warn_about_legacy_endpoint_once()

--- a/mobilerun/agent/providers/registry.py
+++ b/mobilerun/agent/providers/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from mobilerun.agent.providers.minimax import MINIMAX_GLOBAL_BASE_URL
 from mobilerun.agent.providers.types import (
     ProviderFamilySpec,
     ProviderVariantSpec,
@@ -172,7 +173,7 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 ),
                 requires_api_key=True,
                 requires_base_url=True,
-                base_url="https://api.minimaxi.chat/v1",
+                base_url=MINIMAX_GLOBAL_BASE_URL,
             ),
         ),
     ),

--- a/mobilerun/agent/providers/registry.py
+++ b/mobilerun/agent/providers/registry.py
@@ -166,8 +166,9 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 runtime_provider_name="MiniMax",
                 runtime_transport_provider_name="OpenAILike",
                 auth_mode="api_key",
-                default_model="MiniMax-M2.7",
+                default_model="MiniMax-M3",
                 models=(
+                    "MiniMax-M3",
                     "MiniMax-M2.7",
                     "MiniMax-M2.5-highspeed",
                 ),

--- a/mobilerun/agent/providers/setup_service.py
+++ b/mobilerun/agent/providers/setup_service.py
@@ -25,6 +25,7 @@ DEFAULT_KWARGS_BY_VARIANT: dict[str, dict[str, int]] = {
 }
 
 HIDDEN_ROLE_FALLBACKS: tuple[str, ...] = ("app_opener", "structured_output")
+_MINIMAX_DETERMINISTIC_TEMPERATURE = 0.1
 _ZAI_GLOBAL_BASE_URL = "https://api.z.ai/api/paas/v4"
 _ZAI_CODING_GLOBAL_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
 
@@ -53,6 +54,12 @@ def auth_mode_choices(family_id: str) -> tuple[str, ...]:
 def variant_models(family_id: str, auth_mode: str) -> tuple[str, ...]:
     variant = resolve_provider_variant(family_id, auth_mode)
     return tuple(variant.models)
+
+
+def _normalize_generated_temperature(family_id: str, temperature: float) -> float:
+    if family_id == "minimax" and not 0 < temperature <= 1:
+        return _MINIMAX_DETERMINISTIC_TEMPERATURE
+    return temperature
 
 
 def _probe_zai_chat_completions(
@@ -151,6 +158,8 @@ def create_profile_for_variant(
     # OpenAI models require temperature=1
     if selection.family_id == "openai":
         temperature = 1.0
+    else:
+        temperature = _normalize_generated_temperature(selection.family_id, temperature)
 
     return LLMProfile(
         provider=runtime_provider_name,
@@ -206,7 +215,9 @@ def apply_selection_to_roles(
                 config.llm_profiles[hidden_role] = LLMProfile(
                     provider=fast_agent_profile.provider,
                     model=fast_agent_profile.model,
-                    temperature=current.temperature,
+                    temperature=_normalize_generated_temperature(
+                        selection.family_id, current.temperature
+                    ),
                     base_url=fast_agent_profile.base_url,
                     api_base=fast_agent_profile.api_base,
                     provider_family=fast_agent_profile.provider_family,

--- a/mobilerun/agent/utils/inference.py
+++ b/mobilerun/agent/utils/inference.py
@@ -14,6 +14,30 @@ logger = logging.getLogger("mobilerun")
 
 T = TypeVar("T", bound=BaseModel)
 
+_RETRYABLE_HTTP_CLIENT_STATUS_CODES = {408, 409, 425, 429}
+
+
+def _http_status_code(error: Exception) -> int | None:
+    status_code = getattr(error, "status_code", None)
+    if status_code is None:
+        status_code = getattr(getattr(error, "response", None), "status_code", None)
+    if isinstance(status_code, bool):
+        return None
+    try:
+        return int(status_code)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_permanent_http_client_error(error: Exception) -> bool:
+    """Return whether an HTTP client error should fail without another attempt."""
+    status_code = _http_status_code(error)
+    return (
+        status_code is not None
+        and 400 <= status_code < 500
+        and status_code not in _RETRYABLE_HTTP_CLIENT_STATUS_CODES
+    )
+
 
 async def acall_with_retries(
     llm,
@@ -68,6 +92,8 @@ async def acall_with_retries(
 
         except Exception as e:
             logger.warning(f"Attempt {attempt} failed with error: {e!r}")
+            if _is_permanent_http_client_error(e):
+                raise
             last_exception = e
 
         if attempt < retries:
@@ -170,6 +196,8 @@ async def acomplete_with_retries(
 
         except Exception as e:
             logger.warning(f"Attempt {attempt} failed with error: {e!r}")
+            if _is_permanent_http_client_error(e):
+                raise
             last_exception = e
 
         if attempt < retries:
@@ -266,6 +294,8 @@ async def astructured_predict_with_retries(
 
         except Exception as e:
             logger.warning(f"Attempt {attempt} failed with error: {e!r}")
+            if _is_permanent_http_client_error(e):
+                raise
             last_exception = e
 
         if attempt < retries:

--- a/mobilerun/agent/utils/inference.py
+++ b/mobilerun/agent/utils/inference.py
@@ -18,15 +18,39 @@ _RETRYABLE_HTTP_CLIENT_STATUS_CODES = {408, 409, 425, 429}
 
 
 def _http_status_code(error: Exception) -> int | None:
-    status_code = getattr(error, "status_code", None)
-    if status_code is None:
-        status_code = getattr(getattr(error, "response", None), "status_code", None)
-    if isinstance(status_code, bool):
-        return None
-    try:
-        return int(status_code)
-    except (TypeError, ValueError):
-        return None
+    def read_attribute(value: object, name: str) -> object | None:
+        try:
+            return getattr(value, name, None)
+        except Exception:
+            return None
+
+    def parse_status(value: object) -> int | None:
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            parsed = value
+        elif isinstance(value, str):
+            stripped = value.strip()
+            if not stripped.isascii() or not stripped.isdecimal():
+                return None
+            parsed = int(stripped)
+        else:
+            return None
+        return parsed if 100 <= parsed <= 599 else None
+
+    response = read_attribute(error, "response")
+    candidates = (
+        read_attribute(error, "status_code"),
+        read_attribute(response, "status_code"),
+        read_attribute(error, "code"),
+        read_attribute(error, "status"),
+        read_attribute(response, "status"),
+    )
+    for status_code in candidates:
+        parsed = parse_status(status_code)
+        if parsed is not None:
+            return parsed
+    return None
 
 
 def _is_permanent_http_client_error(error: Exception) -> bool:

--- a/mobilerun/agent/utils/llm_picker.py
+++ b/mobilerun/agent/utils/llm_picker.py
@@ -292,8 +292,17 @@ def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM
     if provider_name == "MiniMax":
         import os
 
+        api_key = kwargs.get("api_key")
+        if not isinstance(api_key, str) or not api_key.strip():
+            api_key = os.environ.get("MINIMAX_API_KEY")
+        if not isinstance(api_key, str) or not api_key.strip():
+            raise ValueError(
+                "MiniMax requires an API key. Pass api_key explicitly or set "
+                "MINIMAX_API_KEY."
+            )
+
         provider_name = "OpenAILike"
-        kwargs.setdefault("api_key", os.environ.get("MINIMAX_API_KEY"))
+        kwargs["api_key"] = api_key
         kwargs.setdefault("is_chat_model", True)
         base_url = kwargs.pop("base_url", None)
         if not kwargs.get("api_base"):

--- a/mobilerun/agent/utils/llm_picker.py
+++ b/mobilerun/agent/utils/llm_picker.py
@@ -3,6 +3,10 @@ from typing import TYPE_CHECKING, Any
 
 from llama_index.core.llms.llm import LLM
 
+from mobilerun.agent.providers.minimax import (
+    MINIMAX_GLOBAL_BASE_URL,
+    warn_if_legacy_minimax_endpoint,
+)
 from mobilerun.agent.usage import track_usage
 
 if TYPE_CHECKING:
@@ -288,9 +292,10 @@ def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM
     if provider_name == "MiniMax":
         provider_name = "OpenAILike"
         kwargs.setdefault("is_chat_model", True)
-        kwargs.setdefault("api_base", "https://api.minimaxi.chat/v1")
-        if "base_url" in kwargs and "api_base" not in kwargs:
-            kwargs["api_base"] = kwargs.pop("base_url")
+        base_url = kwargs.pop("base_url", None)
+        if not kwargs.get("api_base"):
+            kwargs["api_base"] = base_url or MINIMAX_GLOBAL_BASE_URL
+        warn_if_legacy_minimax_endpoint(kwargs.get("api_base"))
 
     if provider_name == "ZAI":
         provider_name = "OpenAILike"

--- a/mobilerun/agent/utils/llm_picker.py
+++ b/mobilerun/agent/utils/llm_picker.py
@@ -290,7 +290,10 @@ def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM
 
     # Legacy aliases: MiniMax and DeepSeek route through OpenAILike.
     if provider_name == "MiniMax":
+        import os
+
         provider_name = "OpenAILike"
+        kwargs.setdefault("api_key", os.environ.get("MINIMAX_API_KEY"))
         kwargs.setdefault("is_chat_model", True)
         base_url = kwargs.pop("base_url", None)
         if not kwargs.get("api_base"):

--- a/mobilerun/cli/configure_wizard.py
+++ b/mobilerun/cli/configure_wizard.py
@@ -340,6 +340,13 @@ def _any_ollama_profile(config) -> bool:
     )
 
 
+def _any_minimax_profile(config) -> bool:
+    return any(
+        getattr(profile, "provider_family", "") == "minimax"
+        for profile in config.llm_profiles.values()
+    )
+
+
 def _toggle_label(enabled: bool) -> str:
     """Return a toggle indicator: ON/OFF."""
     return "[ON]" if enabled else "[OFF]"
@@ -420,7 +427,14 @@ def _configure_advanced_settings(
             )
         elif selected == "temperature":
             default_temp = config.llm_profiles[_ALL_CONFIG_ROLES[0]].temperature
-            value = _prompt_float(console, "Temperature", default=default_temp)
+            while True:
+                value = _prompt_float(console, "Temperature", default=default_temp)
+                if not _any_minimax_profile(config) or 0 < value <= 1:
+                    break
+                console.print(
+                    "[red]MiniMax temperature must be greater than 0 and no "
+                    "more than 1.[/red]"
+                )
             for role in _ALL_CONFIG_ROLES:
                 if role in config.llm_profiles:
                     config.llm_profiles[role].temperature = value

--- a/mobilerun/cli/configure_wizard.py
+++ b/mobilerun/cli/configure_wizard.py
@@ -9,6 +9,10 @@ import click
 from rich.console import Console
 from rich.panel import Panel
 
+from mobilerun.agent.providers.minimax import (
+    MINIMAX_CHINA_BASE_URL,
+    MINIMAX_GLOBAL_BASE_URL,
+)
 from mobilerun.agent.providers.registry import (
     VARIANT_ENV_KEY_SLOT,
     resolve_provider_variant,
@@ -29,6 +33,7 @@ from mobilerun.config_manager import ConfigLoader
 from mobilerun.config_manager.env_keys import load_env_key_sources, resolve_env_key
 
 _BACK = "__back__"
+_CUSTOM_MINIMAX_BASE_URL = "__custom_minimax_base_url__"
 
 _ALL_CONFIG_ROLES = (
     "manager",
@@ -198,6 +203,35 @@ def _prompt_api_key_for_variant(variant: Any) -> tuple[str, str]:
     if source == "file":
         return resolve_env_key(env_slot, "file"), "file"
     return text_prompt("API key", secret=True), "file"
+
+
+def _prompt_base_url_for_variant(variant: Any) -> str:
+    if variant.id != "MiniMax":
+        return text_prompt("Base URL", default=variant.base_url or "", secret=False)
+
+    selected = select_prompt(
+        "Choose MiniMax API region",
+        [
+            SelectChoice(
+                value=MINIMAX_GLOBAL_BASE_URL,
+                label="Global",
+                hint=MINIMAX_GLOBAL_BASE_URL,
+            ),
+            SelectChoice(
+                value=MINIMAX_CHINA_BASE_URL,
+                label="Mainland China",
+                hint=MINIMAX_CHINA_BASE_URL,
+            ),
+            SelectChoice(
+                value=_CUSTOM_MINIMAX_BASE_URL,
+                label="Custom endpoint",
+            ),
+        ],
+        default=MINIMAX_GLOBAL_BASE_URL,
+    )
+    if selected == _CUSTOM_MINIMAX_BASE_URL:
+        return text_prompt("Custom MiniMax base URL", secret=False)
+    return selected
 
 
 # OAuth variants share one auth-profiles.json file but store tokens under
@@ -556,9 +590,7 @@ def _configure_provider_model(
             if non_interactive and variant.base_url:
                 state.selected_base_url = variant.base_url
             else:
-                state.selected_base_url = text_prompt(
-                    "Base URL", default=variant.base_url or "", secret=False
-                )
+                state.selected_base_url = _prompt_base_url_for_variant(variant)
         if (
             credential_path
             and variant.auth_mode == "oauth"

--- a/mobilerun/config_manager/config_manager.py
+++ b/mobilerun/config_manager/config_manager.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 import yaml
 
+from mobilerun.agent.providers.minimax import warn_if_legacy_minimax_endpoint
 from mobilerun.agent.providers.registry import VARIANT_ENV_KEY_SLOT
 from mobilerun.config_manager.env_keys import API_KEY_ENV_VARS, load_env_key_sources
 from mobilerun.config_manager.path_resolver import PathResolver
@@ -32,6 +33,9 @@ class LLMProfile:
 
     def to_load_llm_kwargs(self) -> Dict[str, Any]:
         """Convert profile to kwargs for load_llm function."""
+        if self.provider_family == "minimax":
+            warn_if_legacy_minimax_endpoint(self.api_base or self.base_url)
+
         result = {
             "model": self.model,
             "temperature": self.temperature,

--- a/tests/test_inference_retries.py
+++ b/tests/test_inference_retries.py
@@ -1,0 +1,108 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from llama_index.core.prompts import PromptTemplate
+from pydantic import BaseModel
+
+from mobilerun.agent.utils.inference import (
+    _http_status_code,
+    acall_with_retries,
+    acomplete_with_retries,
+    astructured_predict_with_retries,
+)
+
+
+class StatusError(Exception):
+    def __init__(self, status_code: int):
+        super().__init__(f"HTTP {status_code}")
+        self.status_code = status_code
+
+
+class StructuredResult(BaseModel):
+    value: str
+
+
+class FailingLLM:
+    def __init__(self, status_code: int):
+        self.error = StatusError(status_code)
+        self.calls = 0
+
+    async def achat(self, *, messages):
+        self.calls += 1
+        raise self.error
+
+    async def acomplete(self, prompt):
+        self.calls += 1
+        raise self.error
+
+    async def astructured_predict(self, output_cls, prompt, **prompt_args):
+        self.calls += 1
+        raise self.error
+
+
+def _run_failing_helper(helper_name: str, status_code: int) -> int:
+    llm = FailingLLM(status_code)
+
+    with pytest.raises(StatusError):
+        if helper_name == "chat":
+            asyncio.run(
+                acall_with_retries(
+                    llm,
+                    [{"role": "user", "content": "hello"}],
+                    retries=3,
+                    delay=0,
+                )
+            )
+        elif helper_name == "completion":
+            asyncio.run(
+                acomplete_with_retries(
+                    llm,
+                    "hello",
+                    retries=3,
+                    delay=0,
+                )
+            )
+        else:
+            asyncio.run(
+                astructured_predict_with_retries(
+                    llm,
+                    StructuredResult,
+                    PromptTemplate("Return a value for {value}"),
+                    retries=3,
+                    delay=0,
+                    value="hello",
+                )
+            )
+
+    return llm.calls
+
+
+@pytest.mark.parametrize("helper_name", ["chat", "completion", "structured"])
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 422])
+def test_permanent_http_client_errors_are_not_retried(
+    helper_name: str, status_code: int
+) -> None:
+    assert _run_failing_helper(helper_name, status_code) == 1
+
+
+@pytest.mark.parametrize("helper_name", ["chat", "completion", "structured"])
+@pytest.mark.parametrize("status_code", [408, 409, 425, 429, 500])
+def test_transient_http_errors_are_retried(helper_name: str, status_code: int) -> None:
+    assert _run_failing_helper(helper_name, status_code) == 3
+
+
+def test_http_status_code_falls_back_to_exception_response() -> None:
+    error = Exception("request failed")
+    error.response = SimpleNamespace(status_code=401)
+
+    assert _http_status_code(error) == 401
+
+
+def test_authentication_error_does_not_sleep_before_failing(monkeypatch) -> None:
+    async def fail_if_called(delay):
+        pytest.fail("permanent 401 errors must not enter retry backoff")
+
+    monkeypatch.setattr(asyncio, "sleep", fail_if_called)
+
+    assert _run_failing_helper("chat", 401) == 1

--- a/tests/test_inference_retries.py
+++ b/tests/test_inference_retries.py
@@ -19,13 +19,25 @@ class StatusError(Exception):
         self.status_code = status_code
 
 
+class CodeError(Exception):
+    def __init__(self, status_code: int):
+        super().__init__(f"HTTP {status_code}")
+        self.code = status_code
+
+
+class ResponseStatusError(Exception):
+    def __init__(self, status_code: int):
+        super().__init__(f"HTTP {status_code}")
+        self.response = SimpleNamespace(status=status_code)
+
+
 class StructuredResult(BaseModel):
     value: str
 
 
 class FailingLLM:
-    def __init__(self, status_code: int):
-        self.error = StatusError(status_code)
+    def __init__(self, error: Exception):
+        self.error = error
         self.calls = 0
 
     async def achat(self, *, messages):
@@ -41,10 +53,14 @@ class FailingLLM:
         raise self.error
 
 
-def _run_failing_helper(helper_name: str, status_code: int) -> int:
-    llm = FailingLLM(status_code)
+def _run_failing_helper(
+    helper_name: str,
+    status_code: int,
+    error_type: type[Exception] = StatusError,
+) -> int:
+    llm = FailingLLM(error_type(status_code))
 
-    with pytest.raises(StatusError):
+    with pytest.raises(error_type):
         if helper_name == "chat":
             asyncio.run(
                 acall_with_retries(
@@ -97,6 +113,55 @@ def test_http_status_code_falls_back_to_exception_response() -> None:
     error.response = SimpleNamespace(status_code=401)
 
     assert _http_status_code(error) == 401
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (CodeError(403), 403),
+        (ResponseStatusError(429), 429),
+    ],
+)
+def test_http_status_code_supports_provider_specific_shapes(
+    error: Exception, expected: int
+) -> None:
+    assert _http_status_code(error) == expected
+
+
+def test_http_status_code_skips_malformed_candidates() -> None:
+    error = Exception("request failed")
+    error.status_code = False
+    error.code = lambda: 403
+    error.response = SimpleNamespace(status_code="not-a-status", status="401")
+
+    assert _http_status_code(error) == 401
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, False, 401.5, "401.0", "", "not-a-status", object(), 99, 600],
+)
+def test_http_status_code_rejects_invalid_values(value: object) -> None:
+    error = Exception("request failed")
+    error.code = value
+
+    assert _http_status_code(error) is None
+
+
+@pytest.mark.parametrize("helper_name", ["chat", "completion", "structured"])
+@pytest.mark.parametrize("error_type", [CodeError, ResponseStatusError])
+def test_provider_specific_permanent_http_errors_are_not_retried(
+    helper_name: str, error_type: type[Exception]
+) -> None:
+    assert _run_failing_helper(helper_name, 403, error_type) == 1
+
+
+@pytest.mark.parametrize("helper_name", ["chat", "completion", "structured"])
+@pytest.mark.parametrize("error_type", [CodeError, ResponseStatusError])
+def test_provider_specific_transient_http_errors_are_retried(
+    helper_name: str, error_type: type[Exception]
+) -> None:
+    assert _run_failing_helper(helper_name, 429, error_type) == 3
 
 
 def test_authentication_error_does_not_sleep_before_failing(monkeypatch) -> None:

--- a/tests/test_minimax_configuration.py
+++ b/tests/test_minimax_configuration.py
@@ -32,6 +32,12 @@ def test_minimax_registry_uses_current_global_endpoint() -> None:
     variant = resolve_provider_variant("minimax", "api_key")
 
     assert variant.base_url == MINIMAX_GLOBAL_BASE_URL
+    assert variant.default_model == "MiniMax-M3"
+    assert variant.models == (
+        "MiniMax-M3",
+        "MiniMax-M2.7",
+        "MiniMax-M2.5-highspeed",
+    )
     assert MINIMAX_CHINA_BASE_URL == "https://api.minimaxi.com/v1"
     assert MINIMAX_LEGACY_BASE_URL == "https://api.minimaxi.chat/v1"
 
@@ -188,6 +194,29 @@ def test_legacy_minimax_alias_prefers_explicit_api_key(monkeypatch) -> None:
     assert llm.api_key == "explicit-minimax-key"
 
 
+def test_legacy_minimax_alias_empty_explicit_key_uses_environment(monkeypatch) -> None:
+    monkeypatch.setenv("MINIMAX_API_KEY", "minimax-env-key")
+
+    llm = load_llm(
+        "MiniMax",
+        model="MiniMax-M2.7",
+        api_key="",
+    )
+
+    assert llm.api_key == "minimax-env-key"
+
+
+def test_legacy_minimax_alias_never_falls_back_to_openai_key(monkeypatch) -> None:
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "wrong-openai-key")
+
+    with pytest.raises(
+        ValueError,
+        match="Pass api_key explicitly or set MINIMAX_API_KEY",
+    ):
+        load_llm("MiniMax", model="MiniMax-M2.7")
+
+
 def test_legacy_minimax_alias_honors_base_url_override() -> None:
     llm = load_llm(
         "MiniMax",
@@ -259,6 +288,152 @@ def test_minimax_interactive_custom_endpoint(monkeypatch) -> None:
         )
         == custom_base_url
     )
+
+
+@pytest.mark.parametrize(
+    "selected_endpoint",
+    [MINIMAX_GLOBAL_BASE_URL, MINIMAX_CHINA_BASE_URL],
+)
+def test_minimax_wizard_defaults_to_m3_for_each_region(
+    monkeypatch, selected_endpoint: str
+) -> None:
+    config = MobileConfig()
+    state = ConfigureWizardState(family_id="minimax")
+    captured = {}
+
+    def choose_default_model(models, *, default_model, allow_back=True):
+        captured["models"] = models
+        captured["default_model"] = default_model
+        captured["allow_back"] = allow_back
+        return default_model
+
+    monkeypatch.setattr(
+        configure_wizard,
+        "_prompt_model_choice",
+        choose_default_model,
+    )
+    monkeypatch.setattr(
+        configure_wizard,
+        "_prompt_api_key_for_variant",
+        lambda variant: ("stub", "env"),
+    )
+    monkeypatch.setattr(
+        configure_wizard,
+        "_prompt_base_url_for_variant",
+        lambda variant: selected_endpoint,
+    )
+    callbacks = ConfigureWizardCallbacks(
+        run_openai_oauth_login=lambda **kwargs: None,
+        run_anthropic_oauth_login=lambda **kwargs: None,
+        run_gemini_oauth_login=lambda **kwargs: None,
+    )
+
+    configured = configure_wizard._configure_provider_model(
+        Console(file=StringIO(), force_terminal=False),
+        config,
+        callbacks,
+        state,
+        family_choices(),
+        {family.id: family.display_name for family in family_choices()},
+        provider_is_fixed=True,
+        auth_mode_is_fixed=False,
+        model_is_fixed=False,
+        api_key=None,
+        base_url=None,
+    )
+
+    assert configured is True
+    assert captured["models"][0] == "MiniMax-M3"
+    assert captured["default_model"] == "MiniMax-M3"
+    assert state.selected_model == "MiniMax-M3"
+    for profile in config.llm_profiles.values():
+        assert profile.model == "MiniMax-M3"
+        assert profile.base_url == selected_endpoint
+        assert profile.api_base == selected_endpoint
+
+
+@pytest.mark.parametrize(
+    "selected_endpoint",
+    [MINIMAX_GLOBAL_BASE_URL, MINIMAX_CHINA_BASE_URL],
+)
+def test_minimax_explicit_m27_remains_supported(
+    selected_endpoint: str,
+) -> None:
+    variant = resolve_provider_variant("minimax", "api_key")
+    profile = create_profile_for_variant(
+        variant,
+        SetupSelection(
+            family_id="minimax",
+            variant_id=variant.id,
+            auth_mode="api_key",
+            model="MiniMax-M2.7",
+            api_key_source="env",
+            base_url=selected_endpoint,
+        ),
+    )
+
+    assert "MiniMax-M2.7" in variant.models
+    assert profile.model == "MiniMax-M2.7"
+    assert profile.base_url == selected_endpoint
+    assert profile.api_base == selected_endpoint
+
+
+def _run_advanced_temperature_configuration(
+    monkeypatch,
+    config: MobileConfig,
+    temperatures: list[float],
+) -> str:
+    selections = iter(("temperature", "done"))
+    prompted_temperatures = iter(temperatures)
+    monkeypatch.setattr(
+        configure_wizard,
+        "_select_with_back",
+        lambda *args, **kwargs: next(selections),
+    )
+    monkeypatch.setattr(
+        configure_wizard,
+        "_prompt_float",
+        lambda *args, **kwargs: next(prompted_temperatures),
+    )
+    output = StringIO()
+    configure_wizard._configure_advanced_settings(
+        Console(file=output, force_terminal=False),
+        config,
+    )
+    return output.getvalue()
+
+
+def test_minimax_advanced_temperature_reprompts_until_valid(monkeypatch) -> None:
+    config = MobileConfig()
+    for profile in config.llm_profiles.values():
+        profile.provider_family = "minimax"
+
+    output = _run_advanced_temperature_configuration(
+        monkeypatch,
+        config,
+        [-0.1, 0.0, 1.1, 0.1],
+    )
+
+    assert output.count("MiniMax temperature must be greater than 0") == 3
+    assert all(profile.temperature == 0.1 for profile in config.llm_profiles.values())
+
+
+def test_minimax_advanced_temperature_accepts_one(monkeypatch) -> None:
+    config = MobileConfig()
+    for profile in config.llm_profiles.values():
+        profile.provider_family = "minimax"
+
+    _run_advanced_temperature_configuration(monkeypatch, config, [1.0])
+
+    assert all(profile.temperature == 1.0 for profile in config.llm_profiles.values())
+
+
+def test_non_minimax_advanced_temperature_preserves_zero(monkeypatch) -> None:
+    config = MobileConfig()
+
+    _run_advanced_temperature_configuration(monkeypatch, config, [0.0])
+
+    assert all(profile.temperature == 0.0 for profile in config.llm_profiles.values())
 
 
 def test_noninteractive_minimax_preserves_explicit_base_url(monkeypatch) -> None:

--- a/tests/test_minimax_configuration.py
+++ b/tests/test_minimax_configuration.py
@@ -1,0 +1,318 @@
+import logging
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+import mobilerun.agent.providers.minimax as minimax_provider
+import mobilerun.cli.configure_wizard as configure_wizard
+import mobilerun.config_manager.config_manager as config_manager_module
+from mobilerun.agent.providers.minimax import (
+    MINIMAX_CHINA_BASE_URL,
+    MINIMAX_GLOBAL_BASE_URL,
+    MINIMAX_LEGACY_BASE_URL,
+)
+from mobilerun.agent.providers.registry import resolve_provider_variant
+from mobilerun.agent.providers.setup_service import (
+    SetupSelection,
+    apply_selection_to_roles,
+    create_profile_for_variant,
+    family_choices,
+)
+from mobilerun.agent.utils.llm_picker import load_llm
+from mobilerun.cli.configure_wizard import (
+    ConfigureWizardCallbacks,
+    ConfigureWizardState,
+)
+from mobilerun.config_manager.config_manager import LLMProfile, MobileConfig
+from mobilerun.config_manager.env_keys import ApiKeySources
+
+
+def test_minimax_registry_uses_current_global_endpoint() -> None:
+    variant = resolve_provider_variant("minimax", "api_key")
+
+    assert variant.base_url == MINIMAX_GLOBAL_BASE_URL
+    assert MINIMAX_CHINA_BASE_URL == "https://api.minimaxi.com/v1"
+    assert MINIMAX_LEGACY_BASE_URL == "https://api.minimaxi.chat/v1"
+
+
+def test_minimax_setup_profile_uses_openai_like_transport() -> None:
+    variant = resolve_provider_variant("minimax", "api_key")
+    profile = create_profile_for_variant(
+        variant,
+        SetupSelection(
+            family_id="minimax",
+            variant_id=variant.id,
+            auth_mode="api_key",
+            model="MiniMax-M2.7",
+            api_key_source="env",
+        ),
+    )
+
+    assert profile.provider == "OpenAILike"
+    assert profile.provider_family == "minimax"
+    assert profile.base_url == MINIMAX_GLOBAL_BASE_URL
+    assert profile.api_base == MINIMAX_GLOBAL_BASE_URL
+    assert profile.kwargs == {}
+
+
+def test_minimax_issue_style_generation_normalizes_every_role_temperature() -> None:
+    config = MobileConfig()
+    roles = tuple(config.llm_profiles)
+    selection = SetupSelection(
+        family_id="minimax",
+        variant_id="MiniMax",
+        auth_mode="api_key",
+        model="MiniMax-M2.7",
+        api_key="env-test-key",
+        api_key_source="env",
+    )
+
+    apply_selection_to_roles(config, selection, roles)
+
+    assert set(config.llm_profiles) == {
+        "manager",
+        "executor",
+        "fast_agent",
+        "app_opener",
+        "structured_output",
+    }
+    for role, profile in config.llm_profiles.items():
+        assert profile.provider == "OpenAILike", role
+        assert profile.provider_family == "minimax", role
+        assert profile.model == "MiniMax-M2.7", role
+        assert profile.base_url == MINIMAX_GLOBAL_BASE_URL, role
+        assert profile.api_base == MINIMAX_GLOBAL_BASE_URL, role
+        assert 0 < profile.temperature <= 1, role
+
+    assert config.llm_profiles["manager"].temperature == 0.2
+    assert config.llm_profiles["executor"].temperature == 0.1
+    assert config.llm_profiles["fast_agent"].temperature == 0.2
+    assert config.llm_profiles["app_opener"].temperature == 0.1
+    assert config.llm_profiles["structured_output"].temperature == 0.1
+
+
+def test_minimax_fast_agent_fallback_normalizes_hidden_role_temperatures() -> None:
+    config = MobileConfig()
+    selection = SetupSelection(
+        family_id="minimax",
+        variant_id="MiniMax",
+        auth_mode="api_key",
+        model="MiniMax-M2.7",
+        api_key="env-test-key",
+        api_key_source="env",
+    )
+
+    apply_selection_to_roles(config, selection, ("fast_agent",))
+
+    assert config.llm_profiles["app_opener"].temperature == 0.1
+    assert config.llm_profiles["structured_output"].temperature == 0.1
+
+
+def test_non_minimax_generated_profile_preserves_zero_temperature() -> None:
+    variant = resolve_provider_variant("gemini", "api_key")
+    profile = create_profile_for_variant(
+        variant,
+        SetupSelection(
+            family_id="gemini",
+            variant_id=variant.id,
+            auth_mode="api_key",
+            model=variant.default_model or "",
+            api_key_source="env",
+        ),
+        temperature=0.0,
+    )
+
+    assert profile.temperature == 0.0
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("env", "env-test-key"),
+        ("file", "saved-test-key"),
+        ("auto", "saved-test-key"),
+    ],
+)
+def test_openai_like_minimax_profile_resolves_configured_key_source(
+    monkeypatch, source: str, expected: str
+) -> None:
+    monkeypatch.setattr(
+        config_manager_module,
+        "load_env_key_sources",
+        lambda: {
+            "minimax": ApiKeySources(
+                shell="env-test-key",
+                saved="saved-test-key",
+            )
+        },
+    )
+    profile = LLMProfile(
+        provider="OpenAILike",
+        provider_family="minimax",
+        auth_mode="api_key",
+        model="MiniMax-M2.7",
+        api_key_source=source,
+        base_url=MINIMAX_GLOBAL_BASE_URL,
+        api_base=MINIMAX_GLOBAL_BASE_URL,
+    )
+
+    assert profile.to_load_llm_kwargs()["api_key"] == expected
+
+
+def test_legacy_minimax_alias_defaults_to_global_endpoint() -> None:
+    llm = load_llm("MiniMax", model="MiniMax-M2.7", api_key="stub")
+
+    assert type(llm).__name__ == "OpenAILike"
+    assert llm.api_base == MINIMAX_GLOBAL_BASE_URL
+
+
+def test_legacy_minimax_alias_honors_base_url_override() -> None:
+    llm = load_llm(
+        "MiniMax",
+        model="MiniMax-M2.7",
+        api_key="stub",
+        base_url=MINIMAX_CHINA_BASE_URL,
+    )
+
+    assert llm.api_base == MINIMAX_CHINA_BASE_URL
+
+
+def test_legacy_minimax_alias_prefers_explicit_api_base() -> None:
+    custom_api_base = "https://gateway.example/v1"
+    llm = load_llm(
+        "MiniMax",
+        model="MiniMax-M2.7",
+        api_key="stub",
+        base_url=MINIMAX_CHINA_BASE_URL,
+        api_base=custom_api_base,
+    )
+
+    assert llm.api_base == custom_api_base
+
+
+@pytest.mark.parametrize(
+    "selected_endpoint",
+    [MINIMAX_GLOBAL_BASE_URL, MINIMAX_CHINA_BASE_URL],
+)
+def test_minimax_interactive_endpoint_choices(
+    monkeypatch, selected_endpoint: str
+) -> None:
+    captured = {}
+
+    def fake_select(message, choices, *, default=None):
+        captured["message"] = message
+        captured["choices"] = choices
+        captured["default"] = default
+        return selected_endpoint
+
+    monkeypatch.setattr(configure_wizard, "select_prompt", fake_select)
+    variant = resolve_provider_variant("minimax", "api_key")
+
+    assert configure_wizard._prompt_base_url_for_variant(variant) == selected_endpoint
+    assert captured["message"] == "Choose MiniMax API region"
+    assert captured["default"] == MINIMAX_GLOBAL_BASE_URL
+    assert [choice.value for choice in captured["choices"]] == [
+        MINIMAX_GLOBAL_BASE_URL,
+        MINIMAX_CHINA_BASE_URL,
+        configure_wizard._CUSTOM_MINIMAX_BASE_URL,
+    ]
+
+
+def test_minimax_interactive_custom_endpoint(monkeypatch) -> None:
+    custom_base_url = "https://minimax-gateway.example/v1"
+    monkeypatch.setattr(
+        configure_wizard,
+        "select_prompt",
+        lambda *args, **kwargs: configure_wizard._CUSTOM_MINIMAX_BASE_URL,
+    )
+    monkeypatch.setattr(
+        configure_wizard,
+        "text_prompt",
+        lambda message, **kwargs: custom_base_url,
+    )
+
+    assert (
+        configure_wizard._prompt_base_url_for_variant(
+            resolve_provider_variant("minimax", "api_key")
+        )
+        == custom_base_url
+    )
+
+
+def test_noninteractive_minimax_preserves_explicit_base_url(monkeypatch) -> None:
+    custom_base_url = "https://minimax-gateway.example/v1"
+    state = ConfigureWizardState(
+        family_id="minimax",
+        selected_auth_mode="api_key",
+        selected_model="MiniMax-M2.7",
+        selected_api_key="stub",
+        selected_api_key_source="file",
+        selected_base_url=custom_base_url,
+    )
+    captured = {}
+
+    def capture_selection(config, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(configure_wizard, "_apply_model_selection", capture_selection)
+    monkeypatch.setattr(
+        configure_wizard,
+        "_prompt_base_url_for_variant",
+        lambda variant: pytest.fail("noninteractive explicit base URL must not prompt"),
+    )
+    callbacks = ConfigureWizardCallbacks(
+        run_openai_oauth_login=lambda **kwargs: None,
+        run_anthropic_oauth_login=lambda **kwargs: None,
+        run_gemini_oauth_login=lambda **kwargs: None,
+    )
+
+    configured = configure_wizard._configure_provider_model(
+        Console(file=StringIO(), force_terminal=False),
+        MobileConfig(),
+        callbacks,
+        state,
+        family_choices(),
+        {family.id: family.display_name for family in family_choices()},
+        provider_is_fixed=True,
+        auth_mode_is_fixed=True,
+        model_is_fixed=True,
+        api_key="stub",
+        base_url=custom_base_url,
+    )
+
+    assert configured is True
+    assert captured["selected_base_url"] == custom_base_url
+
+
+def test_legacy_minimax_profile_warns_once_without_migration(caplog) -> None:
+    minimax_provider._warn_about_legacy_endpoint_once.cache_clear()
+    logger = logging.getLogger("mobilerun")
+    previous_propagate = logger.propagate
+    logger.propagate = True
+    caplog.set_level(logging.WARNING, logger="mobilerun")
+    profile = LLMProfile(
+        provider="OpenAILike",
+        provider_family="minimax",
+        auth_mode="api_key",
+        model="MiniMax-M2.7",
+        base_url=MINIMAX_LEGACY_BASE_URL,
+        api_base=MINIMAX_LEGACY_BASE_URL,
+        kwargs={"api_key": "stub"},
+    )
+
+    try:
+        profile.to_load_llm_kwargs()
+        profile.to_load_llm_kwargs()
+    finally:
+        logger.propagate = previous_propagate
+        minimax_provider._warn_about_legacy_endpoint_once.cache_clear()
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "MiniMax profile uses the legacy endpoint" in record.message
+    ]
+    assert len(warnings) == 1
+    assert profile.base_url == MINIMAX_LEGACY_BASE_URL
+    assert profile.api_base == MINIMAX_LEGACY_BASE_URL

--- a/tests/test_minimax_configuration.py
+++ b/tests/test_minimax_configuration.py
@@ -167,6 +167,27 @@ def test_legacy_minimax_alias_defaults_to_global_endpoint() -> None:
     assert llm.api_base == MINIMAX_GLOBAL_BASE_URL
 
 
+def test_legacy_minimax_alias_uses_minimax_environment_key(monkeypatch) -> None:
+    monkeypatch.setenv("MINIMAX_API_KEY", "minimax-env-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "wrong-openai-key")
+
+    llm = load_llm("MiniMax", model="MiniMax-M2.7")
+
+    assert llm.api_key == "minimax-env-key"
+
+
+def test_legacy_minimax_alias_prefers_explicit_api_key(monkeypatch) -> None:
+    monkeypatch.setenv("MINIMAX_API_KEY", "minimax-env-key")
+
+    llm = load_llm(
+        "MiniMax",
+        model="MiniMax-M2.7",
+        api_key="explicit-minimax-key",
+    )
+
+    assert llm.api_key == "explicit-minimax-key"
+
+
 def test_legacy_minimax_alias_honors_base_url_override() -> None:
     llm = load_llm(
         "MiniMax",


### PR DESCRIPTION
## Summary

Fix MiniMax configuration so new profiles use the correct regional API endpoint, default to MiniMax-M3, and fail safely when credentials or requests are permanently invalid.

## Root cause

MiniMax defaulted to the legacy `.chat` endpoint, the configure wizard did not distinguish Global and Mainland China accounts, and the legacy loader could ignore an explicit endpoint override. Generated profiles could also contain MiniMax-invalid temperatures. In addition, a missing MiniMax key could fall through to OpenAI-compatible client defaults and send `OPENAI_API_KEY` to the MiniMax endpoint, while provider-specific HTTP status fields were not always recognized as permanent failures.

## Changes

- Make `https://api.minimax.io/v1` the default and offer Global, Mainland China, and Custom endpoint choices.
- Make `MiniMax-M3` the registry and wizard default while preserving explicit M2.7 and older selections.
- Preserve noninteractive `--base-url` and explicit `api_base` precedence.
- Leave existing legacy profiles unchanged while emitting one actionable reconfiguration warning.
- Resolve direct-alias credentials from an explicit key or `MINIMAX_API_KEY`, and fail before client construction when neither exists.
- Normalize generated MiniMax temperatures and reject advanced values outside `(0, 1]` without affecting other providers.
- Recognize `status_code`, `code`, and response status fields so permanent HTTP 4xx failures stop immediately while transient failures retain retries.
- Document both regional endpoints, `MINIMAX_API_KEY`, credential precedence, the M3 default, the China M2.7 fallback, and `credentials/auth-profiles.json`.

## User impact

New MiniMax configurations select the endpoint matching the account region and default to M3. Explicit overrides continue to work, credentials cannot accidentally cross provider boundaries, legacy users receive actionable guidance, and permanent authentication/configuration errors fail promptly instead of waiting through retries.

## Validation

- Focused MiniMax, picker, wizard, and retry tests: 128 passed
- Full `pytest`: 358 passed
- Black check: all 158 Python files passed
- Ruff on changed Python files: passed
- `git diff --check`: passed
- Codex review of `5470e1c`: no issues
- MiniMax Global `/v1/models/MiniMax-M3` authenticated probe: HTTP 200
- Public Portal v0.7.20 on Android 16/API 36:
  - Exact APK SHA-256 and versionCode 503 verified
  - HTTP and ADB `portal_mode: required` state/action paths passed
  - Strict pre/post `state_full` JSON passed without `Infinity` or `NaN`
  - Setup-generated environment-key profile passed in two steps and reported `Search Settings`
  - Direct alias authenticated and opened Settings, but exhausted six steps because the executor repeatedly received the stale completed subgoal; no endpoint, credential, Portal, or serialization error occurred

Fixes #336.
