### PR TITLE
fix: include Mobilerun source in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 *
 
-!droidrun
+!mobilerun
 !pyproject.toml
 !README.md


### PR DESCRIPTION
## Summary

- update `.dockerignore` to include the current `mobilerun/` package directory
- remove the stale `droidrun/` allowlist left behind by the package-directory rename

## Root cause

The Docker build context still allowed only `droidrun/`, while the Python source moved to `mobilerun/` in `fac01f9`. The image therefore contained package metadata but not the importable package, so its entrypoint failed with `ModuleNotFoundError: No module named 'mobilerun'`.

## Validation

- reproduced the broken image: 15.42 kB context; `mobilerun --help` and `import mobilerun` failed
- rebuilt with this fix: 886.89 kB context
- `docker run --rm mobilerun:docker-context-fix --help` passes
- `docker run --rm mobilerun:docker-context-fix --version` reports `v0.6.12`
- offline container probe imports `mobilerun` from `/mobilerun/mobilerun/__init__.py` and resolves distribution version `0.6.12`
- `git diff --check` passes