### PR TITLE
chore(release): bump to 0.6.13

### DIFF
--- a/compat/pyproject.toml
+++ b/compat/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "droidrun"
-version = "0.6.12"
+version = "0.6.13"
 description = "Compatibility shim — droidrun has been renamed to mobilerun"
 requires-python = ">=3.11,<3.14"
-dependencies = ["mobilerun==0.6.12"]
+dependencies = ["mobilerun==0.6.13"]
 
 [project.optional-dependencies]
-anthropic = ["mobilerun[anthropic]==0.6.12"]
-deepseek = ["mobilerun[deepseek]==0.6.12"]
-langfuse = ["mobilerun[langfuse]==0.6.12"]
-dev = ["mobilerun[dev]==0.6.12"]
+anthropic = ["mobilerun[anthropic]==0.6.13"]
+deepseek = ["mobilerun[deepseek]==0.6.13"]
+langfuse = ["mobilerun[langfuse]==0.6.13"]
+dev = ["mobilerun[dev]==0.6.13"]
 
 [project.scripts]
 droidrun = "droidrun.cli_shim:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mobilerun"
-version = "0.6.12"
+version = "0.6.13"
 description = "A framework for controlling mobile devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels@droidrun.ai" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1679,7 +1679,7 @@ wheels = [
 
 [[package]]
 name = "mobilerun"
-version = "0.6.12"
+version = "0.6.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- bump `mobilerun` to `0.6.13`
- bump the `droidrun` compatibility shim, its base dependency, and all four optional-extra pins to `0.6.13`
- regenerate `uv.lock`

This release includes the MiniMax configuration work from #390 and GPT-5.5/LlamaIndex compatibility from #398. Portal resolution maps Mobilerun `0.6.8-0.6.13` to public Portal `0.7.22`. The prerequisite Docker build-context fix was merged separately in #400.

## Validation

- unittest discovery: 65 passed
- full pytest: 368 passed
- Black 25.9.0: 159 files unchanged
- `uv lock --check`: passed
- full Ruff: exactly the nine pre-existing findings, byte-for-byte identical to the parent commit
- compat version/base dependency/all four extra pins: exactly `0.6.13`
- `git diff --check`: passed
- root and compatibility wheels/sdists built; `twine check` passed
- clean Python 3.11 and 3.13 direct-wheel installs: `pip check`, imports, CLI, and compatibility-shim resolution passed
- exact LlamaIndex versions verified: `0.14.23`, OpenAI adapter `0.7.10`, OpenAI-like adapter `0.7.2`
- GPT-5.5 context metadata verified at `1,050,000`; MiniMax-M3 and both regional endpoints verified
- local Docker image built from the corrected context; CLI help/version, package metadata/import, provider imports, and packaged resources passed
- Android 16 smoke with Portal v0.7.22 required: GPT-5.5 opened Settings in two steps and returned `Search Settings`; strict Portal state remained valid and Settings stayed foreground