### PR TITLE
feat: refresh provider model catalogs

### DIFF
--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -79,7 +79,7 @@ llm_profiles:
     model: gpt-4o
   fast_agent:
     provider: GoogleGenAI
-    model: gemini-3.1-flash-lite
+    model: gemini-3.5-flash-lite
 agent:
   reasoning: true       # Enable Manager/Executor workflow
   max_steps: 15         # Maximum execution steps (global)

--- a/docs/features/structured-output.mdx
+++ b/docs/features/structured-output.mdx
@@ -124,7 +124,7 @@ By default, extraction uses the `structured_output` LLM profile. If not configur
 llm_profiles:
   fast_agent:
     provider: GoogleGenAI
-    model: gemini-3.1-flash-lite
+    model: gemini-3.5-flash-lite
     temperature: 0.3
 
   structured_output:
@@ -140,7 +140,7 @@ from mobilerun import load_llm
 config = MobileConfig()
 
 llms = {
-    "fast_agent": load_llm("GoogleGenAI", "gemini-3.1-flash-lite"),
+    "fast_agent": load_llm("GoogleGenAI", "gemini-3.5-flash-lite"),
     "structured_output": load_llm("OpenAI", "gpt-4o-mini"),
 }
 

--- a/docs/guides/cli.mdx
+++ b/docs/guides/cli.mdx
@@ -94,7 +94,7 @@ In screenshot-only mode, Mobilerun does not read an accessibility tree. The agen
 export GOOGLE_API_KEY=your-key
 mobilerun run "Archive old emails" \
   --provider GoogleGenAI \
-  --model gemini-3.1-flash-lite
+  --model gemini-3.5-flash-lite
 
 # OpenAI
 export OPENAI_API_KEY=your-key
@@ -433,7 +433,7 @@ trajectories/2025-10-16_14-30-45/
 ```bash Quick Test
 mobilerun run "Turn on dark mode" \
   --provider GoogleGenAI \
-  --model gemini-3.1-flash-lite
+  --model gemini-3.5-flash-lite
 ```
 
 ```bash Debug Task
@@ -454,7 +454,7 @@ mobilerun run "Check Wi-Fi" \
 ```bash Cost Optimization
 mobilerun run "Set alarm" \
   --provider GoogleGenAI \
-  --model gemini-3.1-flash-lite \
+  --model gemini-3.5-flash-lite \
   --no-vision
 ```
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -126,7 +126,7 @@ mobilerun run "Find a contact named John and send him an email" --reasoning
 
 **Common CLI flags:**
 - `--provider` - LLM provider (GoogleGenAI, OpenAI, Anthropic, etc.)
-- `--model` - Model name (gemini-3.1-flash-lite, gpt-4o, etc.)
+- `--model` - Model name (gemini-3.5-flash-lite, gpt-5.5, etc.)
 - `--vision` - Enable screenshot processing
 - `--reasoning` - Enable multi-agent planning mode
 - `--steps N` - Maximum execution steps (default: 15)

--- a/docs/sdk/configuration.mdx
+++ b/docs/sdk/configuration.mdx
@@ -238,26 +238,26 @@ CredentialsConfig(
 ### Single LLM (All Agents)
 
 ```python
-from llama_index.llms.google_genai import GoogleGenAI
+from mobilerun import MobileAgent, load_llm
 
-llm = GoogleGenAI(model="gemini-3.1-flash-lite", temperature=0.2)
+llm = load_llm("GoogleGenAI", model="gemini-3.5-flash-lite")
 agent = MobileAgent(goal="...", llms=llm)
 ```
 
 ### Per-Agent LLMs
 
 ```python
+from mobilerun import load_llm
 from llama_index.llms.openai import OpenAI
-from llama_index.llms.google_genai import GoogleGenAI
 
 agent = MobileAgent(
     goal="...",
     llms={
         "manager": OpenAI(model="gpt-4o"),                    # Planning
-        "executor": GoogleGenAI(model="gemini-3.1-flash-lite"),  # Action selection
-        "fast_agent": GoogleGenAI(model="gemini-3.1-flash-lite"),   # Fast Agent: Direct execution (XML tool-calling)
+        "executor": load_llm("GoogleGenAI", model="gemini-3.5-flash-lite"),  # Action selection
+        "fast_agent": load_llm("GoogleGenAI", model="gemini-3.5-flash-lite"),   # Fast Agent: Direct execution (XML tool-calling)
         "app_opener": OpenAI(model="gpt-4o-mini"),            # App launching
-        "structured_output": GoogleGenAI(model="gemini-3.1-flash-lite"),  # Output extraction
+        "structured_output": load_llm("GoogleGenAI", model="gemini-3.5-flash-lite"),  # Output extraction
     }
 )
 ```
@@ -397,10 +397,10 @@ agent = MobileAgent(
 ```python
 from mobilerun import (
     MobileAgent, MobileConfig,
-    AgentConfig, FastAgentConfig, DeviceConfig, LoggingConfig, TracingConfig
+    AgentConfig, FastAgentConfig, DeviceConfig, LoggingConfig, TracingConfig,
+    load_llm,
 )
 from llama_index.llms.openai import OpenAI
-from llama_index.llms.google_genai import GoogleGenAI
 from pydantic import BaseModel
 
 # Structured output
@@ -441,10 +441,10 @@ agent = MobileAgent(
     # LLMs
     llms={
         "manager": OpenAI(model="gpt-4o"),                    # Planning
-        "executor": GoogleGenAI(model="gemini-3.1-flash-lite"),  # Action selection
-        "fast_agent": GoogleGenAI(model="gemini-3.1-flash-lite"),   # Fast Agent: Direct execution (XML tool-calling)
+        "executor": load_llm("GoogleGenAI", model="gemini-3.5-flash-lite"),  # Action selection
+        "fast_agent": load_llm("GoogleGenAI", model="gemini-3.5-flash-lite"),   # Fast Agent: Direct execution (XML tool-calling)
         "app_opener": OpenAI(model="gpt-4o-mini"),            # App launching
-        "structured_output": GoogleGenAI(model="gemini-3.1-flash-lite"),  # Output extraction
+        "structured_output": load_llm("GoogleGenAI", model="gemini-3.5-flash-lite"),  # Output extraction
     },
 
     # Custom tools
@@ -517,21 +517,21 @@ agent:
 llm_profiles:
   manager:
     provider: GoogleGenAI
-    model: gemini-3.1-flash-lite
+    model: gemini-3.5-flash-lite
     temperature: 0.2
     kwargs:
       max_tokens: 8192
 
   executor:
     provider: GoogleGenAI
-    model: gemini-3.1-flash-lite
+    model: gemini-3.5-flash-lite
     temperature: 0.1
     kwargs:
       max_tokens: 4096
 
   fast_agent:  # Fast Agent: Direct execution (XML tool-calling)
     provider: GoogleGenAI
-    model: gemini-3.1-flash-lite
+    model: gemini-3.5-flash-lite
     temperature: 0.2
     kwargs:
       max_tokens: 8192
@@ -543,7 +543,7 @@ llm_profiles:
 
   structured_output:
     provider: GoogleGenAI
-    model: gemini-3.1-flash-lite
+    model: gemini-3.5-flash-lite
     temperature: 0.0
 
 device:
@@ -598,7 +598,7 @@ mobilerun run "Task" --steps 30 --reasoning --vision
 mobilerun run "Task" --device emulator-5554 --tcp
 
 # Override LLM (applies to ALL agents)
-mobilerun run "Task" --provider GoogleGenAI --model gemini-3.1-flash-lite
+mobilerun run "Task" --provider GoogleGenAI --model gemini-3.5-flash-lite
 
 # Override logging
 mobilerun run "Task" --debug --save-trajectory action --tracing

--- a/mobilerun/agent/providers/__init__.py
+++ b/mobilerun/agent/providers/__init__.py
@@ -10,6 +10,7 @@ from mobilerun.agent.providers.registry import (
     list_auth_modes,
     list_models_for_variant,
     list_provider_families,
+    normalize_model_id_for_variant,
     resolve_provider_variant,
 )
 from mobilerun.agent.providers.types import (
@@ -28,6 +29,7 @@ __all__ = [
     "list_auth_modes",
     "list_models_for_variant",
     "list_provider_families",
+    "normalize_model_id_for_variant",
     "resolve_provider_variant",
     "warn_if_legacy_minimax_endpoint",
 ]

--- a/mobilerun/agent/providers/anthropic.py
+++ b/mobilerun/agent/providers/anthropic.py
@@ -1,0 +1,93 @@
+"""Shared Anthropic model catalog and capability metadata."""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Any
+
+ANTHROPIC_API_DEFAULT_MODEL = "claude-sonnet-4-6"
+ANTHROPIC_OAUTH_DEFAULT_MODEL = "claude-opus-4-7"
+
+ANTHROPIC_API_MODELS = (
+    ANTHROPIC_API_DEFAULT_MODEL,
+    "claude-opus-5",
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "claude-opus-4-8",
+    "claude-opus-4-6",
+    "claude-haiku-4-5",
+)
+
+ANTHROPIC_OAUTH_MODELS = (
+    ANTHROPIC_OAUTH_DEFAULT_MODEL,
+    "claude-opus-5",
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "claude-opus-4-8",
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
+    "claude-haiku-4-5",
+)
+
+ANTHROPIC_MODEL_CONTEXT_WINDOWS = {
+    "claude-opus-5": 1_000_000,
+    "claude-sonnet-5": 1_000_000,
+    "claude-fable-5": 1_000_000,
+    "claude-opus-4-8": 1_000_000,
+    "claude-opus-4-7": 1_000_000,
+    "claude-opus-4-6": 1_000_000,
+    "claude-sonnet-4-6": 1_000_000,
+    "claude-haiku-4-5": 200_000,
+}
+
+# These models reject sampling controls. Filter them after all provider,
+# profile, and per-request kwargs have been merged so an explicit override
+# cannot accidentally restore an unsupported field.
+ANTHROPIC_MODELS_WITHOUT_SAMPLING_PARAMS = frozenset(
+    {
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+    }
+)
+ANTHROPIC_UNSUPPORTED_SAMPLING_PARAMS = frozenset({"temperature", "top_p", "top_k"})
+
+# Anthropic models with the high-resolution visual-token budget
+# (2576 px / 4784 tokens). Unknown ids remain on the conservative standard
+# budget rather than assuming capabilities that have not been verified.
+ANTHROPIC_HIGHRES_MODELS = frozenset(
+    {
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-mythos-5",
+    }
+)
+
+
+def anthropic_model_context_window(model: object) -> int | None:
+    """Return the verified context window for a known Anthropic model."""
+
+    return ANTHROPIC_MODEL_CONTEXT_WINDOWS.get(str(model or "").strip())
+
+
+def anthropic_model_omits_sampling_params(model: object) -> bool:
+    """Whether the model rejects Anthropic sampling controls."""
+
+    return str(model or "").strip() in ANTHROPIC_MODELS_WITHOUT_SAMPLING_PARAMS
+
+
+def strip_anthropic_sampling_params(
+    payload: MutableMapping[str, Any],
+) -> MutableMapping[str, Any]:
+    """Remove unsupported sampling fields from a final Anthropic payload."""
+
+    model = payload.get("model")
+    if anthropic_model_omits_sampling_params(model):
+        for param in ANTHROPIC_UNSUPPORTED_SAMPLING_PARAMS:
+            payload.pop(param, None)
+    return payload

--- a/mobilerun/agent/providers/registry.py
+++ b/mobilerun/agent/providers/registry.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+from mobilerun.agent.providers.anthropic import (
+    ANTHROPIC_API_DEFAULT_MODEL,
+    ANTHROPIC_API_MODELS,
+    ANTHROPIC_OAUTH_DEFAULT_MODEL,
+    ANTHROPIC_OAUTH_MODELS,
+)
 from mobilerun.agent.providers.minimax import MINIMAX_GLOBAL_BASE_URL
 from mobilerun.agent.providers.types import (
     ProviderFamilySpec,
@@ -22,6 +28,10 @@ VARIANT_ENV_KEY_SLOT: dict[str, str] = {
     "MiniMax": "minimax",
 }
 
+OPENAI_MODEL_ALIASES: dict[str, str] = {
+    "gpt-5.6": "gpt-5.6-sol",
+}
+
 
 PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
     ProviderFamilySpec(
@@ -35,9 +45,10 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 default_model="gemini-3.1-pro-preview",
                 models=(
                     "gemini-3.5-flash",
+                    "gemini-3.6-flash",
+                    "gemini-3.5-flash-lite",
                     "gemini-3-flash-preview",
                     "gemini-3.1-pro-preview",
-                    "gemini-3.1-flash-lite",
                 ),
                 requires_api_key=True,
             ),
@@ -54,6 +65,9 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                     "gemini-3-flash",
                     "gemini-pro-agent",
                     "gemini-3.1-pro-low",
+                    "gemini-3.6-flash-low",
+                    "gemini-3.6-flash-medium",
+                    "gemini-3.6-flash-high",
                 ),
                 credential_path=str(GEMINI_OAUTH_CREDENTIAL_PATH),
             ),
@@ -70,6 +84,9 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 default_model="gpt-5.5",
                 models=(
                     "gpt-5.5",
+                    "gpt-5.6-sol",
+                    "gpt-5.6-terra",
+                    "gpt-5.6-luna",
                     "gpt-5.4",
                     "gpt-5.4-mini",
                     "gpt-5.4-nano",
@@ -83,6 +100,9 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 default_model="gpt-5.5",
                 models=(
                     "gpt-5.5",
+                    "gpt-5.6-sol",
+                    "gpt-5.6-terra",
+                    "gpt-5.6-luna",
                     "gpt-5.4",
                     "gpt-5.4-mini",
                 ),
@@ -99,27 +119,16 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 id="Anthropic",
                 runtime_provider_name="Anthropic",
                 auth_mode="api_key",
-                default_model="claude-sonnet-4-6",
-                models=(
-                    "claude-sonnet-4-6",
-                    "claude-opus-4-8",
-                    "claude-opus-4-6",
-                    "claude-haiku-4-5",
-                ),
+                default_model=ANTHROPIC_API_DEFAULT_MODEL,
+                models=ANTHROPIC_API_MODELS,
                 requires_api_key=True,
             ),
             ProviderVariantSpec(
                 id="anthropic_oauth",
                 runtime_provider_name="anthropic_oauth",
                 auth_mode="oauth",
-                default_model="claude-opus-4-7",
-                models=(
-                    "claude-opus-4-7",
-                    "claude-opus-4-8",
-                    "claude-sonnet-4-6",
-                    "claude-opus-4-6",
-                    "claude-haiku-4-5",
-                ),
+                default_model=ANTHROPIC_OAUTH_DEFAULT_MODEL,
+                models=ANTHROPIC_OAUTH_MODELS,
                 credential_path=str(ANTHROPIC_OAUTH_CREDENTIAL_PATH),
             ),
         ),
@@ -261,8 +270,6 @@ def normalize_model_id_for_variant(
     """Normalize accepted model aliases to the canonical model id for a variant."""
     variant = resolve_provider_variant(family_id, auth_mode)
     allowed_model_ids = set(variant.models)
-    if model_id in allowed_model_ids:
-        return model_id
 
     alias_prefixes: tuple[str, ...] = ()
     if family_id == "openai" and auth_mode == "api_key":
@@ -270,10 +277,16 @@ def normalize_model_id_for_variant(
     elif family_id == "openai" and auth_mode == "oauth":
         alias_prefixes = ("openai-codex/", "openai/")
 
+    candidate = model_id
     for prefix in alias_prefixes:
-        if model_id.startswith(prefix):
-            normalized = model_id[len(prefix) :]
-            if normalized in allowed_model_ids:
-                return normalized
+        if candidate.startswith(prefix):
+            candidate = candidate[len(prefix) :]
+            break
+
+    if family_id == "openai":
+        candidate = OPENAI_MODEL_ALIASES.get(candidate, candidate)
+
+    if candidate in allowed_model_ids:
+        return candidate
 
     return model_id

--- a/mobilerun/agent/providers/setup_service.py
+++ b/mobilerun/agent/providers/setup_service.py
@@ -12,6 +12,7 @@ from mobilerun.agent.providers import (
     list_provider_families,
     resolve_provider_variant,
 )
+from mobilerun.agent.providers.registry import normalize_model_id_for_variant
 from mobilerun.config_manager.config_manager import LLMProfile, MobileConfig
 from mobilerun.config_manager.env_keys import load_env_keys, save_env_keys
 
@@ -143,6 +144,11 @@ def create_profile_for_variant(
 ) -> LLMProfile:
     base_url = selection.base_url or variant.base_url
     base_url, resolved_model = _resolve_zai_selection(selection, base_url)
+    resolved_model = normalize_model_id_for_variant(
+        selection.family_id,
+        selection.auth_mode,
+        resolved_model,
+    )
     kwargs: dict[str, str | int] = dict(DEFAULT_KWARGS_BY_VARIANT.get(variant.id, {}))
     env_slot = VARIANT_ENV_KEY_SLOT.get(variant.id)
     runtime_provider_name = (

--- a/mobilerun/agent/utils/llm_picker.py
+++ b/mobilerun/agent/utils/llm_picker.py
@@ -3,9 +3,18 @@ from typing import TYPE_CHECKING, Any
 
 from llama_index.core.llms.llm import LLM
 
+from mobilerun.agent.providers.anthropic import (
+    ANTHROPIC_UNSUPPORTED_SAMPLING_PARAMS,
+    anthropic_model_context_window,
+    anthropic_model_omits_sampling_params,
+)
 from mobilerun.agent.providers.minimax import (
     MINIMAX_GLOBAL_BASE_URL,
     warn_if_legacy_minimax_endpoint,
+)
+from mobilerun.agent.providers.registry import (
+    list_models_for_variant,
+    normalize_model_id_for_variant,
 )
 from mobilerun.agent.usage import track_usage
 
@@ -43,26 +52,32 @@ PROVIDER_ALIASES = {
 }
 
 ZAI_GLOBAL_API_BASE = "https://api.z.ai/api/paas/v4"
-# Models from the deprecated gemini-cli / Code-Assist-for-individuals path that
-# no longer apply to the Antigravity consumer entitlement. Caught early so we
-# never silently send a removed model and fail remotely.
+# Public Gemini Developer API ids that are not valid on the private
+# Antigravity OAuth catalog. Catch these locally so users get the applicable
+# OAuth choices instead of a remote model-not-found response.
 GEMINI_OAUTH_UNSUPPORTED_MODELS = {
+    "gemini-3.6-flash",
+    "gemini-3.5-flash-lite",
     "gemini-3.5-flash",
-    "gemini-2.5-pro",
-    "gemini-2.5-flash",
-    "gemini-2.5-flash-lite",
     "gemini-3-flash-preview",
     "gemini-3.1-pro-preview",
 }
 OPENAI_OAUTH_UNSUPPORTED_MODELS = {"gpt-5.3-codex"}
-OPENAI_RESPONSES_MODELS_WITHOUT_SAMPLING_PARAMS = {"gpt-5.5"}
-OPENAI_RESPONSES_UNSUPPORTED_SAMPLING_PARAMS = {"temperature", "top_p"}
-ANTHROPIC_CURRENT_MODEL_CONTEXT_WINDOWS = {
-    "claude-opus-4-8": 200_000,
-    "claude-sonnet-4-6": 200_000,
-    "claude-opus-4-6": 200_000,
-    "claude-haiku-4-5": 200_000,
+OPENAI_RESPONSES_MODELS_WITHOUT_SAMPLING_PARAMS = {
+    "gpt-5.5",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.4-nano",
 }
+OPENAI_RESPONSES_UNSUPPORTED_SAMPLING_PARAMS = {"temperature", "top_p"}
+GOOGLE_GENAI_MODELS_WITHOUT_SAMPLING_PARAMS = {
+    "gemini-3.6-flash",
+    "gemini-3.5-flash-lite",
+}
+GOOGLE_GENAI_UNSUPPORTED_SAMPLING_PARAMS = {"temperature", "top_p", "top_k"}
 
 
 def normalize_provider_name(provider_name: str) -> str:
@@ -76,14 +91,10 @@ def _openai_responses_model_omits_sampling_params(model: object) -> bool:
     return str(model or "").strip() in OPENAI_RESPONSES_MODELS_WITHOUT_SAMPLING_PARAMS
 
 
-def _anthropic_model_omits_temperature(model: object) -> bool:
-    return str(model or "").strip().startswith("claude-opus-4")
-
-
 def _validate_openai_oauth_model(model: object) -> None:
     model_id = str(model or "").strip()
     if model_id in OPENAI_OAUTH_UNSUPPORTED_MODELS:
-        supported = "gpt-5.5, gpt-5.4, or gpt-5.4-mini"
+        supported = ", ".join(list_models_for_variant("openai", "oauth"))
         raise ValueError(
             f"Model '{model_id}' is not supported with OpenAI OAuth "
             f"ChatGPT-account credentials. Use {supported}."
@@ -93,15 +104,11 @@ def _validate_openai_oauth_model(model: object) -> None:
 def _validate_gemini_oauth_model(model: object) -> None:
     model_id = str(model or "").strip()
     if model_id in GEMINI_OAUTH_UNSUPPORTED_MODELS:
-        supported = (
-            "gemini-3.5-flash-low, gemini-3.5-flash-extra-low, gemini-3-flash-agent, "
-            "gemini-3-flash, gemini-pro-agent, or gemini-3.1-pro-low"
-        )
+        supported = ", ".join(list_models_for_variant("gemini", "oauth"))
         raise ValueError(
-            f"Model '{model_id}' is from the deprecated gemini-cli Code Assist "
-            f"path, which stops serving Google One / individual tiers on "
-            f"2026-06-18. Re-run `mobilerun configure gemini` and pick one of: "
-            f"{supported}."
+            f"Model '{model_id}' is a Gemini Developer API id and is not valid "
+            f"for the Antigravity OAuth catalog. Re-run "
+            f"`mobilerun configure gemini` and pick one of: {supported}."
         )
 
 
@@ -181,14 +188,44 @@ def _load_openai_responses(**kwargs: Any) -> LLM:
     from llama_index.llms.openai.responses import OpenAIResponses
 
     class MobilerunOpenAIResponses(OpenAIResponses):
-        def _get_model_kwargs(self, **kwargs: Any) -> dict[str, Any]:
-            model_kwargs = super()._get_model_kwargs(**kwargs)
-            if _openai_responses_model_omits_sampling_params(
-                model_kwargs.get("model", self.model)
-            ):
+        def _sanitize_call_kwargs(self, call_kwargs: dict[str, Any]) -> dict[str, Any]:
+            sanitized = dict(call_kwargs)
+            effective_model = sanitized.get("model", self.model)
+            if _openai_responses_model_omits_sampling_params(effective_model):
                 for param in OPENAI_RESPONSES_UNSUPPORTED_SAMPLING_PARAMS:
-                    model_kwargs.pop(param, None)
-            return model_kwargs
+                    sanitized.pop(param, None)
+            return sanitized
+
+        def _get_model_kwargs(self, **kwargs: Any) -> dict[str, Any]:
+            return self._sanitize_call_kwargs(super()._get_model_kwargs(**kwargs))
+
+        def structured_predict(
+            self,
+            output_cls: Any,
+            prompt: Any,
+            llm_kwargs: dict[str, Any] | None = None,
+            **prompt_args: Any,
+        ) -> Any:
+            return super().structured_predict(
+                output_cls,
+                prompt,
+                llm_kwargs=self._sanitize_call_kwargs(dict(llm_kwargs or {})),
+                **prompt_args,
+            )
+
+        async def astructured_predict(
+            self,
+            output_cls: Any,
+            prompt: Any,
+            llm_kwargs: dict[str, Any] | None = None,
+            **prompt_args: Any,
+        ) -> Any:
+            return await super().astructured_predict(
+                output_cls,
+                prompt,
+                llm_kwargs=self._sanitize_call_kwargs(dict(llm_kwargs or {})),
+                **prompt_args,
+            )
 
     filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
     logger.debug(
@@ -196,6 +233,133 @@ def _load_openai_responses(**kwargs: Any) -> LLM:
         f"{list(filtered_kwargs.keys())}"
     )
     return MobilerunOpenAIResponses(**filtered_kwargs)
+
+
+def _load_google_genai(**kwargs: Any) -> LLM:
+    from llama_index.llms.google_genai import GoogleGenAI
+
+    class MobilerunGoogleGenAI(GoogleGenAI):
+        def __init__(self, **init_kwargs: Any) -> None:
+            super().__init__(**init_kwargs)
+            if self.model in GOOGLE_GENAI_MODELS_WITHOUT_SAMPLING_PARAMS:
+                for param in GOOGLE_GENAI_UNSUPPORTED_SAMPLING_PARAMS:
+                    self._generation_config.pop(param, None)
+
+        def _sanitize_call_kwargs(self, call_kwargs: dict[str, Any]) -> dict[str, Any]:
+            if self.model not in GOOGLE_GENAI_MODELS_WITHOUT_SAMPLING_PARAMS:
+                return call_kwargs
+
+            sanitized = dict(call_kwargs)
+            for param in GOOGLE_GENAI_UNSUPPORTED_SAMPLING_PARAMS:
+                sanitized.pop(param, None)
+
+            generation_config = sanitized.get("generation_config")
+            if generation_config is not None:
+                if hasattr(generation_config, "model_dump"):
+                    generation_config = generation_config.model_dump()
+                elif isinstance(generation_config, dict):
+                    generation_config = dict(generation_config)
+                else:
+                    return sanitized
+                for param in GOOGLE_GENAI_UNSUPPORTED_SAMPLING_PARAMS:
+                    generation_config.pop(param, None)
+                sanitized["generation_config"] = generation_config
+            return sanitized
+
+        def _chat(self, messages: Any, **kwargs: Any) -> Any:
+            return super()._chat(messages, **self._sanitize_call_kwargs(dict(kwargs)))
+
+        async def _achat(self, messages: Any, **kwargs: Any) -> Any:
+            return await super()._achat(
+                messages, **self._sanitize_call_kwargs(dict(kwargs))
+            )
+
+        def _stream_chat(self, messages: Any, **kwargs: Any) -> Any:
+            return super()._stream_chat(
+                messages, **self._sanitize_call_kwargs(dict(kwargs))
+            )
+
+        async def _astream_chat(self, messages: Any, **kwargs: Any) -> Any:
+            return await super()._astream_chat(
+                messages, **self._sanitize_call_kwargs(dict(kwargs))
+            )
+
+        def structured_predict_without_function_calling(
+            self,
+            output_cls: Any,
+            prompt: Any,
+            llm_kwargs: dict[str, Any] | None = None,
+            **prompt_args: Any,
+        ) -> Any:
+            return super().structured_predict_without_function_calling(
+                output_cls,
+                prompt,
+                llm_kwargs=self._sanitize_call_kwargs(dict(llm_kwargs or {})),
+                **prompt_args,
+            )
+
+        def structured_predict(
+            self,
+            output_cls: Any,
+            prompt: Any,
+            llm_kwargs: dict[str, Any] | None = None,
+            **prompt_args: Any,
+        ) -> Any:
+            return super().structured_predict(
+                output_cls,
+                prompt,
+                llm_kwargs=self._sanitize_call_kwargs(dict(llm_kwargs or {})),
+                **prompt_args,
+            )
+
+        async def astructured_predict(
+            self,
+            output_cls: Any,
+            prompt: Any,
+            llm_kwargs: dict[str, Any] | None = None,
+            **prompt_args: Any,
+        ) -> Any:
+            return await super().astructured_predict(
+                output_cls,
+                prompt,
+                llm_kwargs=self._sanitize_call_kwargs(dict(llm_kwargs or {})),
+                **prompt_args,
+            )
+
+        def stream_structured_predict(
+            self,
+            output_cls: Any,
+            prompt: Any,
+            llm_kwargs: dict[str, Any] | None = None,
+            **prompt_args: Any,
+        ) -> Any:
+            return super().stream_structured_predict(
+                output_cls,
+                prompt,
+                llm_kwargs=self._sanitize_call_kwargs(dict(llm_kwargs or {})),
+                **prompt_args,
+            )
+
+        async def astream_structured_predict(
+            self,
+            output_cls: Any,
+            prompt: Any,
+            llm_kwargs: dict[str, Any] | None = None,
+            **prompt_args: Any,
+        ) -> Any:
+            return await super().astream_structured_predict(
+                output_cls,
+                prompt,
+                llm_kwargs=self._sanitize_call_kwargs(dict(llm_kwargs or {})),
+                **prompt_args,
+            )
+
+    filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    logger.debug(
+        "Initializing MobilerunGoogleGenAI with kwargs: "
+        f"{list(filtered_kwargs.keys())}"
+    )
+    return MobilerunGoogleGenAI(**filtered_kwargs)
 
 
 def _load_anthropic(**kwargs: Any) -> LLM:
@@ -206,27 +370,32 @@ def _load_anthropic(**kwargs: Any) -> LLM:
         @property
         def _model_kwargs(self) -> dict[str, Any]:
             model_kwargs = super()._model_kwargs
-            if _anthropic_model_omits_temperature(
+            if anthropic_model_omits_sampling_params(
                 model_kwargs.get("model", self.model)
             ) and "temperature" not in (self.additional_kwargs or {}):
                 model_kwargs.pop("temperature", None)
             return model_kwargs
 
+        def _get_all_kwargs(self, **kwargs: Any) -> dict[str, Any]:
+            model_kwargs = super()._get_all_kwargs(**kwargs)
+            effective_model = model_kwargs.get("model", self.model)
+            if anthropic_model_omits_sampling_params(effective_model):
+                for param in ANTHROPIC_UNSUPPORTED_SAMPLING_PARAMS:
+                    model_kwargs.pop(param, None)
+            return model_kwargs
+
         @property
         def metadata(self) -> LLMMetadata:
-            try:
+            context_window = anthropic_model_context_window(self.model)
+            if context_window is None:
                 return super().metadata
-            except ValueError:
-                context_window = ANTHROPIC_CURRENT_MODEL_CONTEXT_WINDOWS.get(self.model)
-                if context_window is None:
-                    raise
-                return LLMMetadata(
-                    context_window=context_window,
-                    num_output=self.max_tokens,
-                    is_chat_model=True,
-                    model_name=self.model,
-                    is_function_calling_model=True,
-                )
+            return LLMMetadata(
+                context_window=context_window,
+                num_output=self.max_tokens,
+                is_chat_model=True,
+                model_name=self.model,
+                is_function_calling_model=True,
+            )
 
     # The upstream adapter defaults to 512 output tokens, which is too small
     # for a manager response that includes a complete control result plus
@@ -248,7 +417,7 @@ def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM
 
     Args:
         provider_name: Case-sensitive provider name (e.g. "OpenAIResponses", "Ollama").
-        model: Model name (e.g. "gpt-4", "gemini-3.1-flash-lite").
+        model: Model name (e.g. "gpt-5.5", "gemini-3.5-flash-lite").
         **kwargs: Keyword arguments for the LLM class constructor.
 
     Returns:
@@ -260,6 +429,10 @@ def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM
     provider_name = normalize_provider_name(provider_name)
 
     if model is not None:
+        if provider_name == "OpenAIResponses":
+            model = normalize_model_id_for_variant("openai", "api_key", model)
+        elif provider_name == "openai_oauth":
+            model = normalize_model_id_for_variant("openai", "oauth", model)
         kwargs["model"] = model
 
     # --- OAuth providers ---
@@ -341,9 +514,7 @@ def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM
         if "base_url" in kwargs and "api_base" not in kwargs:
             kwargs["api_base"] = kwargs.pop("base_url")
     elif provider_name == "GoogleGenAI":
-        from llama_index.llms.google_genai import GoogleGenAI
-
-        llm_class = GoogleGenAI
+        return _load_google_genai(**kwargs)
     elif provider_name == "Ollama":
         from llama_index.llms.ollama import Ollama
 
@@ -452,7 +623,7 @@ if __name__ == "__main__":
         },
         {
             "name": "GoogleGenAI",
-            "model": "gemini-3.1-flash-lite",
+            "model": "gemini-3.5-flash-lite",
         },
         {
             "name": "OpenAIResponses",

--- a/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/anthropic_oauth_llm.py
@@ -31,9 +31,15 @@ from llama_index.core.constants import DEFAULT_TEMPERATURE
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
 from llama_index.core.llms.custom import CustomLLM
 
+from mobilerun.agent.providers.anthropic import (
+    ANTHROPIC_OAUTH_DEFAULT_MODEL,
+    anthropic_model_context_window,
+    anthropic_model_omits_sampling_params,
+    strip_anthropic_sampling_params,
+)
 from mobilerun.config_manager.credential_paths import ANTHROPIC_OAUTH_CREDENTIAL_PATH
 
-DEFAULT_MODEL = "claude-opus-4-7"
+DEFAULT_MODEL = ANTHROPIC_OAUTH_DEFAULT_MODEL
 DEFAULT_MAX_TOKENS = 8192
 DEFAULT_API_BASE = "https://api.anthropic.com"
 DEFAULT_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
@@ -223,7 +229,7 @@ class AnthropicOAuthLLM(CustomLLM):
     @property
     def metadata(self) -> LLMMetadata:
         return LLMMetadata(
-            context_window=200_000,
+            context_window=anthropic_model_context_window(self.model) or 200_000,
             num_output=self.max_tokens or -1,
             model_name=self.model,
             is_chat_model=True,
@@ -742,13 +748,9 @@ class AnthropicOAuthLLM(CustomLLM):
 
     @staticmethod
     def _supports_temperature(model_id: str) -> bool:
-        """Anthropic deprecated `temperature` on the Claude 4 Opus family.
+        """Whether the model accepts Anthropic sampling controls."""
 
-        Sending it returns 400 "`temperature` is deprecated for this model."
-        Callers that explicitly want to override this can still pass
-        `temperature` via `additional_kwargs` or per-call kwargs.
-        """
-        return not model_id.startswith("claude-opus-4")
+        return not anthropic_model_omits_sampling_params(model_id)
 
     def _system_blocks(
         self, user_system_lines: Sequence[str], model_id: str
@@ -792,6 +794,7 @@ class AnthropicOAuthLLM(CustomLLM):
 
         payload.update(self.additional_kwargs)
         payload.update(request_kwargs)
+        strip_anthropic_sampling_params(payload)
 
         headers = {
             "Authorization": f"Bearer {token}",

--- a/mobilerun/agent/utils/oauth/openai_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/openai_oauth_llm.py
@@ -40,6 +40,7 @@ from llama_index.llms.openai import OpenAI
 from llama_index.llms.openai.base import llm_retry_decorator
 from llama_index.llms.openai.utils import to_openai_message_dicts
 
+from mobilerun.agent.providers.registry import normalize_model_id_for_variant
 from mobilerun.config_manager.credential_paths import OPENAI_OAUTH_CREDENTIAL_PATH
 
 DEFAULT_OPENAI_OAUTH_ISSUER = "https://auth.openai.com"
@@ -543,17 +544,30 @@ class OpenAIOAuth(OpenAI):
         model: Optional[str],
     ) -> str:
         if custom_model and custom_model.strip():
-            return custom_model.strip()
-        if model and model.strip():
-            return model.strip()
+            selected_model = custom_model.strip()
+        elif model and model.strip():
+            selected_model = model.strip()
+        else:
+            selected_model = auth_model.strip() or "gpt-5.4"
 
-        alias = auth_model.strip()
-        if "/" in alias:
-            return alias.split("/", 1)[1].strip()
-        if alias:
-            return alias
+        normalized_model = normalize_model_id_for_variant(
+            "openai",
+            "oauth",
+            selected_model,
+        )
+        if normalized_model != selected_model:
+            return normalized_model
 
-        return "gpt-5.4"
+        # Preserve the historical auth_model behavior for custom Codex aliases
+        # that are not part of the advertised catalog. Explicit model and
+        # custom_model values remain untouched.
+        if not (custom_model and custom_model.strip()) and not (
+            model and model.strip()
+        ):
+            if "/" in selected_model:
+                return selected_model.split("/", 1)[1].strip()
+
+        return selected_model
 
     @staticmethod
     def _build_auth_url(

--- a/mobilerun/agent/utils/vision_sizing.py
+++ b/mobilerun/agent/utils/vision_sizing.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from typing import Any, Optional, Sequence
 
+from mobilerun.agent.providers.anthropic import ANTHROPIC_HIGHRES_MODELS
 from mobilerun.tools.helpers.images import (
     MODEL_SCREENSHOT_MAX_SIDE,
     anthropic_resized_size,
@@ -21,12 +22,6 @@ from mobilerun.tools.helpers.images import (
 # Anthropic models with the high-resolution budget (2576 px / 4784 tokens).
 # Unknown Anthropic ids fall back to the standard 1568 budget — never assume
 # high-res, since that would re-introduce the undershoot bug.
-_ANTHROPIC_HIGHRES_MODELS = {
-    "claude-opus-4-7",
-    "claude-opus-4-8",
-    "claude-fable-5",
-    "claude-mythos-5",
-}
 _ANTHROPIC_STANDARD = (1568, 1568)  # (max_edge, max_tokens)
 _ANTHROPIC_HIGHRES = (2576, 4784)
 
@@ -47,7 +42,7 @@ def model_effective_dims(model_id: str, width: int, height: int) -> tuple[int, i
     if _is_anthropic(model_id):
         edge, tokens = (
             _ANTHROPIC_HIGHRES
-            if model_id in _ANTHROPIC_HIGHRES_MODELS
+            if model_id in ANTHROPIC_HIGHRES_MODELS
             else _ANTHROPIC_STANDARD
         )
         return anthropic_resized_size(base_w, base_h, edge, tokens)

--- a/mobilerun/config_example.yaml
+++ b/mobilerun/config_example.yaml
@@ -72,7 +72,7 @@ llm_profiles:
   # Manager: Plans and reasons about task progress
   manager:
     provider: GoogleGenAI
-    model: gemini-3.1-flash-lite
+    model: gemini-3.5-flash-lite
     temperature: 0.2
     # api_key_source: auto  # auto = saved env file first, then shell env; env = shell only; file = saved env file
     # kwargs: # optional kwargs, add api_key in kwargs if not already in .env
@@ -91,7 +91,7 @@ llm_profiles:
   # Executor: Selects and executes atomic actions
   executor:
     provider: GoogleGenAI
-    model: gemini-3.1-flash-lite
+    model: gemini-3.5-flash-lite
     temperature: 0.1
     # api_key_source: auto
     # kwargs:
@@ -100,7 +100,7 @@ llm_profiles:
   # Fast Agent: Direct execution agent (XML tool-calling or code generation)
   fast_agent:
     provider: GoogleGenAI
-    model: gemini-3.1-flash-lite
+    model: gemini-3.5-flash-lite
     temperature: 0.2
     # api_key_source: auto
     # kwargs:
@@ -109,7 +109,7 @@ llm_profiles:
   # App Opener: Opens apps by name/description
   app_opener:
     provider: GoogleGenAI
-    model: gemini-3.1-flash-lite
+    model: gemini-3.5-flash-lite
     temperature: 0.0
     # api_key_source: auto
     # kwargs:
@@ -118,7 +118,7 @@ llm_profiles:
   # Structured Output: Extracts structured data from final answers
   structured_output:
     provider: GoogleGenAI
-    model: gemini-3.1-flash-lite
+    model: gemini-3.5-flash-lite
     temperature: 0.0
     # api_key_source: auto
     # kwargs:

--- a/mobilerun/config_manager/config_manager.py
+++ b/mobilerun/config_manager/config_manager.py
@@ -21,7 +21,7 @@ class LLMProfile:
     """LLM profile configuration."""
 
     provider: str = "GoogleGenAI"
-    model: str = "gemini-3.1-flash-lite"
+    model: str = "gemini-3.5-flash-lite"
     temperature: float = 0.2
     api_key_source: Literal["auto", "env", "file"] = "auto"
     base_url: Optional[str] = None
@@ -256,31 +256,31 @@ class MobileConfig:
         return {
             "manager": LLMProfile(
                 provider="GoogleGenAI",
-                model="gemini-3.1-flash-lite",
+                model="gemini-3.5-flash-lite",
                 temperature=0.2,
                 kwargs={},
             ),
             "executor": LLMProfile(
                 provider="GoogleGenAI",
-                model="gemini-3.1-flash-lite",
+                model="gemini-3.5-flash-lite",
                 temperature=0.1,
                 kwargs={},
             ),
             "fast_agent": LLMProfile(
                 provider="GoogleGenAI",
-                model="gemini-3.1-flash-lite",
+                model="gemini-3.5-flash-lite",
                 temperature=0.2,
                 kwargs={},
             ),
             "app_opener": LLMProfile(
                 provider="GoogleGenAI",
-                model="gemini-3.1-flash-lite",
+                model="gemini-3.5-flash-lite",
                 temperature=0.0,
                 kwargs={},
             ),
             "structured_output": LLMProfile(
                 provider="GoogleGenAI",
-                model="gemini-3.1-flash-lite",
+                model="gemini-3.5-flash-lite",
                 temperature=0.0,
                 kwargs={},
             ),

--- a/tests/test_anthropic_oauth_llm.py
+++ b/tests/test_anthropic_oauth_llm.py
@@ -1,3 +1,4 @@
+import pytest
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 
 from mobilerun.agent.utils.oauth.anthropic_oauth_llm import (
@@ -59,6 +60,71 @@ def test_opus_4_8_payload_sends_max_tokens_without_temperature():
     assert payload["model"] == "claude-opus-4-8"
     assert payload["max_tokens"] == 8192
     assert "temperature" not in payload
+
+
+@pytest.mark.parametrize(
+    ("model", "context_window"),
+    [
+        ("claude-opus-5", 1_000_000),
+        ("claude-sonnet-5", 1_000_000),
+        ("claude-fable-5", 1_000_000),
+        ("claude-opus-4-8", 1_000_000),
+        ("claude-opus-4-7", 1_000_000),
+        ("claude-opus-4-6", 1_000_000),
+        ("claude-sonnet-4-6", 1_000_000),
+        ("claude-haiku-4-5", 200_000),
+    ],
+)
+def test_current_model_metadata_has_verified_context_window(model, context_window):
+    metadata = AnthropicOAuthLLM(model=model, credential_path=None).metadata
+
+    assert metadata.model_name == model
+    assert metadata.context_window == context_window
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+    ],
+)
+def test_models_without_sampling_strip_all_final_payload_overrides(model):
+    llm = AnthropicOAuthLLM(
+        model=model,
+        access_token="test-token",
+        credential_path=None,
+        temperature=0.7,
+        additional_kwargs={"temperature": 0.6, "top_p": 0.5, "top_k": 10},
+    )
+    session = _CapturingSession()
+    llm._session = session
+
+    llm.chat(
+        [ChatMessage(role=MessageRole.USER, content="hello")],
+        temperature=0.4,
+        top_p=0.3,
+        top_k=5,
+    )
+
+    assert session.payload["model"] == model
+    assert {"temperature", "top_p", "top_k"}.isdisjoint(session.payload)
+
+
+@pytest.mark.parametrize("model", ["claude-opus-4-6", "claude-sonnet-4-6"])
+def test_4_6_models_keep_supported_sampling_fields(model):
+    payload = _payload_for(
+        model=model,
+        temperature=0.7,
+        additional_kwargs={"top_p": 0.5, "top_k": 10},
+    )
+
+    assert payload["temperature"] == 0.7
+    assert payload["top_p"] == 0.5
+    assert payload["top_k"] == 10
 
 
 def _chat_payload(messages):

--- a/tests/test_gemini_defaults.py
+++ b/tests/test_gemini_defaults.py
@@ -1,0 +1,36 @@
+import warnings
+
+from mobilerun.agent.utils.llm_picker import load_llm
+from mobilerun.config_manager.config_manager import MobileConfig
+from mobilerun.config_manager.migrations import CURRENT_VERSION
+
+
+def test_explicit_saved_gemini_3_1_flash_lite_profile_remains_usable_and_silent():
+    config = MobileConfig.from_dict(
+        {
+            "_version": CURRENT_VERSION,
+            "llm_profiles": {
+                "manager": {
+                    "provider": "GoogleGenAI",
+                    "model": "gemini-3.1-flash-lite",
+                    "temperature": 0.2,
+                    "kwargs": {
+                        "api_key": "test-key",
+                        "context_window": 1_000_000,
+                        "max_tokens": 1_024,
+                    },
+                }
+            },
+        }
+    )
+    profile = config.llm_profiles["manager"]
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        llm = load_llm(profile.provider, **profile.to_load_llm_kwargs())
+
+    assert profile.model == "gemini-3.1-flash-lite"
+    assert llm.model == "gemini-3.1-flash-lite"
+    assert not any(
+        "gemini-3.1-flash-lite" in str(warning.message) for warning in caught
+    )

--- a/tests/test_gemini_oauth_llm.py
+++ b/tests/test_gemini_oauth_llm.py
@@ -1,3 +1,4 @@
+import pytest
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 
 from mobilerun.agent.providers.registry import resolve_provider_variant
@@ -8,7 +9,17 @@ from mobilerun.agent.providers.setup_service import (
 from mobilerun.agent.utils.llm_picker import load_llm
 
 
-def test_gemini_oauth_profile_sends_gemini_flash_lite_verbatim(tmp_path) -> None:
+@pytest.mark.parametrize(
+    "model",
+    (
+        "gemini-3.6-flash-low",
+        "gemini-3.6-flash-medium",
+        "gemini-3.6-flash-high",
+    ),
+)
+def test_gemini_oauth_profile_sends_new_effort_models_verbatim(
+    tmp_path, model: str
+) -> None:
     variant = resolve_provider_variant("gemini", "oauth")
     profile = create_profile_for_variant(
         variant,
@@ -16,7 +27,7 @@ def test_gemini_oauth_profile_sends_gemini_flash_lite_verbatim(tmp_path) -> None
             family_id="gemini",
             variant_id=variant.id,
             auth_mode="oauth",
-            model="gemini-3.1-flash-lite",
+            model=model,
             credential_path=str(tmp_path / "missing-auth-profiles.json"),
         ),
     )
@@ -32,8 +43,8 @@ def test_gemini_oauth_profile_sends_gemini_flash_lite_verbatim(tmp_path) -> None
     )
 
     assert profile.provider == "gemini_oauth_code_assist"
-    assert profile.model == "gemini-3.1-flash-lite"
-    assert payload["model"] == "gemini-3.1-flash-lite"
+    assert profile.model == model
+    assert payload["model"] == model
 
 
 def _gemini_llm():
@@ -154,7 +165,14 @@ def test_oauth_explicit_default_model_is_honored_not_preset():
 def test_oauth_explicit_agy_models_are_honored():
     from mobilerun.agent.utils.llm_picker import load_llm
 
-    for m in ("gemini-3-flash", "gemini-pro-agent", "gemini-3.1-pro-low"):
+    for m in (
+        "gemini-3-flash",
+        "gemini-pro-agent",
+        "gemini-3.1-pro-low",
+        "gemini-3.6-flash-low",
+        "gemini-3.6-flash-medium",
+        "gemini-3.6-flash-high",
+    ):
         assert load_llm("gemini_oauth_code_assist", model=m).model == m
 
 
@@ -168,14 +186,23 @@ def test_oauth_preset_key_still_resolves():
     )
 
 
-def test_deprecated_models_are_rejected_with_reconfigure_error():
-    import pytest
-
+def test_public_api_model_ids_are_rejected_with_reconfigure_error():
     from mobilerun.agent.utils.llm_picker import load_llm
 
-    for m in ("gemini-2.5-pro", "gemini-2.5-flash", "gemini-3.1-pro-preview"):
+    for m in (
+        "gemini-3.5-flash",
+        "gemini-3-flash-preview",
+        "gemini-3.1-pro-preview",
+    ):
         with pytest.raises(ValueError):
             load_llm("gemini_oauth_code_assist", model=m)
+
+
+def test_live_private_gemini_2_5_aliases_are_not_rejected():
+    from mobilerun.agent.utils.llm_picker import load_llm
+
+    for model in ("gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"):
+        assert load_llm("gemini_oauth_code_assist", model=model).model == model
 
 
 def test_never_sends_project_even_if_passed_as_kwarg():

--- a/tests/test_llm_picker.py
+++ b/tests/test_llm_picker.py
@@ -1,4 +1,7 @@
+import asyncio
 import logging
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -35,6 +38,9 @@ def test_normalize_provider_name_accepts_user_facing_aliases(
     "model",
     [
         "gpt-5.5",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5.4-nano",
@@ -58,9 +64,76 @@ def test_openai_responses_current_reasoning_models_omit_sampling_params(
 
 
 @pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-5.5",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+    ],
+)
+def test_openai_structured_predict_omits_per_call_sampling_params(
+    model: str,
+) -> None:
+    from llama_index.core.prompts import PromptTemplate
+    from pydantic import BaseModel
+
+    class StructuredResult(BaseModel):
+        value: str
+
+    sync_payload: dict[str, Any] = {}
+    async_payload: dict[str, Any] = {}
+
+    def parse_sync(**kwargs: Any) -> Any:
+        sync_payload.update(kwargs)
+        return SimpleNamespace(output_parsed=StructuredResult(value="OK"))
+
+    async def parse_async(**kwargs: Any) -> Any:
+        async_payload.update(kwargs)
+        return SimpleNamespace(output_parsed=StructuredResult(value="OK"))
+
+    llm = load_llm("OpenAIResponses", model=model, api_key="stub")
+    llm._client = SimpleNamespace(responses=SimpleNamespace(parse=parse_sync))
+    llm._aclient = SimpleNamespace(responses=SimpleNamespace(parse=parse_async))
+    prompt = PromptTemplate("Return {value}")
+    call_kwargs = {
+        "temperature": 0.4,
+        "top_p": 0.6,
+        "max_output_tokens": 32,
+    }
+
+    sync_result = llm.structured_predict(
+        StructuredResult,
+        prompt,
+        llm_kwargs=dict(call_kwargs),
+        value="OK",
+    )
+    async_result = asyncio.run(
+        llm.astructured_predict(
+            StructuredResult,
+            prompt,
+            llm_kwargs=dict(call_kwargs),
+            value="OK",
+        )
+    )
+
+    assert sync_result.value == "OK"
+    assert async_result.value == "OK"
+    for payload in (sync_payload, async_payload):
+        assert {"temperature", "top_p"}.isdisjoint(payload)
+        assert payload["max_output_tokens"] == 32
+
+
+@pytest.mark.parametrize(
     ("model", "context_window"),
     [
         ("gpt-5.5", 1_050_000),
+        ("gpt-5.6-sol", 1_050_000),
+        ("gpt-5.6-terra", 1_050_000),
+        ("gpt-5.6-luna", 1_050_000),
         ("gpt-5.4", 1_050_000),
         ("gpt-5.4-mini", 400_000),
         ("gpt-5.4-nano", 400_000),
@@ -123,6 +196,24 @@ def test_openai_responses_profile_loads_with_current_default_metadata() -> None:
     assert llm.metadata.context_window == 1_050_000
 
 
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    [
+        ("OpenAIResponses", "gpt-5.6"),
+        ("OpenAIResponses", "openai/gpt-5.6"),
+        ("OpenAI", "gpt-5.6"),
+    ],
+)
+def test_openai_responses_aliases_load_canonical_sol_model(
+    provider: str, model: str
+) -> None:
+    llm = load_llm(provider, model=model, api_key="stub")
+
+    assert llm.model == "gpt-5.6-sol"
+    assert llm.metadata.model_name == "gpt-5.6-sol"
+    assert llm.metadata.context_window == 1_050_000
+
+
 def test_zai_alias_uses_openai_like_transport_defaults() -> None:
     llm = load_llm(
         "ZAI",
@@ -139,12 +230,277 @@ def test_openai_oauth_rejects_unsupported_codex_model() -> None:
         load_llm("openai_oauth", model="gpt-5.3-codex")
 
 
-def test_gemini_oauth_rejects_unsupported_flash_3_5_model() -> None:
-    with pytest.raises(ValueError, match="deprecated gemini-cli Code Assist"):
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gemini-3.6-flash",
+        "gemini-3.5-flash-lite",
+        "gemini-3.5-flash",
+        "gemini-3-flash-preview",
+        "gemini-3.1-pro-preview",
+    ],
+)
+def test_gemini_oauth_rejects_public_api_model_ids(model: str) -> None:
+    with pytest.raises(ValueError, match="Gemini Developer API id"):
+        load_llm("gemini_oauth_code_assist", model=model)
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"],
+)
+def test_gemini_oauth_allows_live_unadvertised_2_5_ids(model: str) -> None:
+    llm = load_llm(
+        "gemini_oauth_code_assist",
+        model=model,
+        access_token="stub",
+        credential_path=None,
+    )
+
+    assert llm.model == model
+
+
+@pytest.mark.parametrize("model", ["gemini-3.6-flash", "gemini-3.5-flash-lite"])
+def test_new_google_genai_models_omit_sampling_configuration(model: str) -> None:
+    from google.genai import types
+
+    llm = load_llm(
+        "GoogleGenAI",
+        model=model,
+        api_key="stub",
+        max_tokens=64,
+        context_window=1_000_000,
+        temperature=0.4,
+        generation_config=types.GenerateContentConfig(
+            temperature=0.6,
+            top_p=0.8,
+            top_k=20,
+            max_output_tokens=64,
+        ),
+    )
+
+    assert type(llm).__name__ == "MobilerunGoogleGenAI"
+    assert llm._generation_config["max_output_tokens"] == 64
+    assert {"temperature", "top_p", "top_k"}.isdisjoint(llm._generation_config)
+
+    call_kwargs = llm._sanitize_call_kwargs(
+        {
+            "temperature": 0.5,
+            "top_p": 0.7,
+            "top_k": 10,
+            "generation_config": {
+                "temperature": 0.4,
+                "top_p": 0.6,
+                "top_k": 5,
+                "max_output_tokens": 32,
+            },
+        }
+    )
+    assert {"temperature", "top_p", "top_k"}.isdisjoint(call_kwargs)
+    assert call_kwargs["generation_config"] == {"max_output_tokens": 32}
+
+
+class _AsyncChunks:
+    def __init__(self, chunks: list[Any]) -> None:
+        self._chunks = iter(chunks)
+
+    def __aiter__(self) -> "_AsyncChunks":
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return next(self._chunks)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+class _StructuredModelsCapture:
+    def __init__(self, output: Any, calls: list[dict[str, Any]]) -> None:
+        self._output = output
+        self._calls = calls
+
+    def generate_content(self, **kwargs: Any) -> Any:
+        self._calls.append(kwargs)
+        return SimpleNamespace(
+            parsed=self._output,
+            text=self._output.model_dump_json(),
+        )
+
+    def generate_content_stream(self, **kwargs: Any) -> Any:
+        self._calls.append(kwargs)
+        return iter([SimpleNamespace(parsed=self._output, candidates=[])])
+
+
+class _AsyncStructuredModelsCapture:
+    def __init__(self, output: Any, calls: list[dict[str, Any]]) -> None:
+        self._output = output
+        self._calls = calls
+
+    async def generate_content(self, **kwargs: Any) -> Any:
+        self._calls.append(kwargs)
+        return SimpleNamespace(
+            parsed=self._output,
+            text=self._output.model_dump_json(),
+        )
+
+    async def generate_content_stream(self, **kwargs: Any) -> Any:
+        self._calls.append(kwargs)
+        return _AsyncChunks([SimpleNamespace(parsed=self._output, candidates=[])])
+
+
+def _google_structured_llm_with_capture() -> tuple[Any, Any, Any, list[dict[str, Any]]]:
+    from llama_index.core.prompts import PromptTemplate
+    from pydantic import BaseModel
+
+    class StructuredResult(BaseModel):
+        value: str
+
+    output = StructuredResult(value="OK")
+    calls: list[dict[str, Any]] = []
+    llm = load_llm(
+        "GoogleGenAI",
+        model="gemini-3.5-flash-lite",
+        api_key="stub",
+        max_tokens=64,
+        context_window=1_000_000,
+        temperature=0.4,
+        file_mode="inline",
+    )
+    llm._client = SimpleNamespace(
+        models=_StructuredModelsCapture(output, calls),
+        aio=SimpleNamespace(models=_AsyncStructuredModelsCapture(output, calls)),
+    )
+    return llm, StructuredResult, PromptTemplate("Return {value}"), calls
+
+
+def _sampling_llm_kwargs() -> dict[str, Any]:
+    return {
+        "temperature": 0.5,
+        "top_p": 0.7,
+        "top_k": 10,
+        "generation_config": {
+            "temperature": 0.4,
+            "top_p": 0.6,
+            "top_k": 5,
+            "max_output_tokens": 32,
+        },
+    }
+
+
+def _assert_google_request_omits_sampling(request: dict[str, Any]) -> None:
+    sampling_params = {"temperature", "top_p", "top_k"}
+    assert sampling_params.isdisjoint(request)
+    assert sampling_params.isdisjoint(request["config"])
+
+
+def test_google_direct_structured_path_strips_sampling_payload() -> None:
+    llm, output_cls, prompt, calls = _google_structured_llm_with_capture()
+
+    result = llm.structured_predict_without_function_calling(
+        output_cls,
+        prompt,
+        llm_kwargs={"temperature": 0.5, "top_p": 0.7, "top_k": 10},
+        value="OK",
+    )
+
+    assert result.value == "OK"
+    _assert_google_request_omits_sampling(calls[-1])
+
+
+@pytest.mark.parametrize(
+    ("method_name", "streaming"),
+    [
+        ("structured_predict", False),
+        ("stream_structured_predict", True),
+    ],
+)
+def test_google_sync_structured_paths_strip_sampling_payload(
+    method_name: str, streaming: bool
+) -> None:
+    llm, output_cls, prompt, calls = _google_structured_llm_with_capture()
+
+    result = getattr(llm, method_name)(
+        output_cls,
+        prompt,
+        llm_kwargs=_sampling_llm_kwargs(),
+        value="OK",
+    )
+    if streaming:
+        result = list(result)[-1]
+
+    assert result.value == "OK"
+    _assert_google_request_omits_sampling(calls[-1])
+    assert calls[-1]["config"]["max_output_tokens"] == 32
+
+
+def test_google_async_structured_paths_strip_sampling_payload() -> None:
+    async def run() -> None:
+        llm, output_cls, prompt, calls = _google_structured_llm_with_capture()
+
+        result = await llm.astructured_predict(
+            output_cls,
+            prompt,
+            llm_kwargs=_sampling_llm_kwargs(),
+            value="OK",
+        )
+
+        assert result.value == "OK"
+        _assert_google_request_omits_sampling(calls[-1])
+        assert calls[-1]["config"]["max_output_tokens"] == 32
+
+        result_stream = await llm.astream_structured_predict(
+            output_cls,
+            prompt,
+            llm_kwargs=_sampling_llm_kwargs(),
+            value="OK",
+        )
+        streamed = [result async for result in result_stream]
+
+        assert streamed[-1].value == "OK"
+        _assert_google_request_omits_sampling(calls[-1])
+        assert calls[-1]["config"]["max_output_tokens"] == 32
+
+    asyncio.run(run())
+
+
+def test_existing_google_genai_model_keeps_sampling_configuration() -> None:
+    llm = load_llm(
+        "GoogleGenAI",
+        model="gemini-3.5-flash",
+        api_key="stub",
+        max_tokens=64,
+        context_window=1_000_000,
+        temperature=0.4,
+    )
+
+    assert llm._generation_config["temperature"] == 0.4
+
+
+def test_explicit_retired_default_google_profile_remains_loadable() -> None:
+    llm = load_llms_from_profiles(
+        {
+            "manager": LLMProfile(
+                provider="GoogleGenAI",
+                model="gemini-3.1-flash-lite",
+                temperature=0.2,
+                kwargs={
+                    "api_key": "stub",
+                    "max_tokens": 64,
+                    "context_window": 1_000_000,
+                },
+            )
+        }
+    )["manager"]
+
+    assert llm.model == "gemini-3.1-flash-lite"
+
+
+def test_gemini_oauth_supported_choices_come_from_registry() -> None:
+    with pytest.raises(ValueError, match="gemini-3.6-flash-high"):
         load_llm("gemini_oauth_code_assist", model="gemini-3.5-flash")
 
 
-@pytest.mark.parametrize("model", ["claude-opus-4-8", "claude-opus-4-6"])
+@pytest.mark.parametrize("model", ["claude-opus-4-8"])
 def test_anthropic_opus_4_omits_default_temperature(model: str) -> None:
     llm = load_llm(
         "Anthropic",
@@ -160,19 +516,19 @@ def test_anthropic_opus_4_omits_default_temperature(model: str) -> None:
     assert "temperature" not in kwargs
 
 
-def test_anthropic_opus_4_keeps_explicit_additional_temperature() -> None:
+def test_anthropic_opus_4_strips_explicit_additional_sampling() -> None:
     llm = load_llm(
         "Anthropic",
         model="claude-opus-4-8",
         api_key="stub",
         temperature=0.2,
-        additional_kwargs={"temperature": 0.0},
+        additional_kwargs={"temperature": 0.0, "top_p": 0.5, "top_k": 10},
     )
 
-    assert llm._get_all_kwargs()["temperature"] == 0.0
+    assert {"temperature", "top_p", "top_k"}.isdisjoint(llm._get_all_kwargs())
 
 
-def test_anthropic_opus_4_keeps_per_call_temperature() -> None:
+def test_anthropic_opus_4_strips_per_call_sampling() -> None:
     llm = load_llm(
         "Anthropic",
         model="claude-opus-4-8",
@@ -180,7 +536,25 @@ def test_anthropic_opus_4_keeps_per_call_temperature() -> None:
         temperature=0.2,
     )
 
-    assert llm._get_all_kwargs(temperature=0.0)["temperature"] == 0.0
+    kwargs = llm._get_all_kwargs(temperature=0.0, top_p=0.5, top_k=10)
+
+    assert {"temperature", "top_p", "top_k"}.isdisjoint(kwargs)
+
+
+def test_anthropic_opus_4_6_keeps_supported_sampling() -> None:
+    llm = load_llm(
+        "Anthropic",
+        model="claude-opus-4-6",
+        api_key="stub",
+        temperature=0.2,
+        additional_kwargs={"top_p": 0.6},
+    )
+
+    kwargs = llm._get_all_kwargs(top_k=10)
+
+    assert kwargs["temperature"] == 0.2
+    assert kwargs["top_p"] == 0.6
+    assert kwargs["top_k"] == 10
 
 
 def test_anthropic_sonnet_keeps_temperature() -> None:
@@ -236,15 +610,20 @@ def test_anthropic_preserves_explicit_max_tokens(max_tokens: int) -> None:
 
 
 @pytest.mark.parametrize(
-    "model",
+    ("model", "context_window"),
     [
-        "claude-opus-4-8",
-        "claude-sonnet-4-6",
-        "claude-opus-4-6",
-        "claude-haiku-4-5",
+        ("claude-opus-5", 1_000_000),
+        ("claude-sonnet-5", 1_000_000),
+        ("claude-fable-5", 1_000_000),
+        ("claude-opus-4-8", 1_000_000),
+        ("claude-sonnet-4-6", 1_000_000),
+        ("claude-opus-4-6", 1_000_000),
+        ("claude-haiku-4-5", 200_000),
     ],
 )
-def test_anthropic_current_catalog_models_have_metadata(model: str) -> None:
+def test_anthropic_current_catalog_models_have_metadata(
+    model: str, context_window: int
+) -> None:
     llm = load_llm(
         "Anthropic",
         model=model,
@@ -254,7 +633,45 @@ def test_anthropic_current_catalog_models_have_metadata(model: str) -> None:
     metadata = llm.metadata
 
     assert metadata.model_name == model
-    assert metadata.context_window > 0
+    assert metadata.context_window == context_window
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["claude-opus-5", "claude-sonnet-5", "claude-fable-5"],
+)
+def test_anthropic_claude_5_models_strip_all_sampling_overrides(model: str) -> None:
+    llm = load_llm(
+        "Anthropic",
+        model=model,
+        api_key="stub",
+        temperature=0.8,
+        additional_kwargs={"temperature": 0.7, "top_p": 0.6, "top_k": 20},
+    )
+
+    kwargs = llm._get_all_kwargs(temperature=0.5, top_p=0.4, top_k=10)
+
+    assert kwargs["model"] == model
+    assert {"temperature", "top_p", "top_k"}.isdisjoint(kwargs)
+
+
+def test_anthropic_sampling_filter_uses_effective_per_call_model() -> None:
+    llm = load_llm(
+        "Anthropic",
+        model="claude-sonnet-4-6",
+        api_key="stub",
+        temperature=0.2,
+    )
+
+    kwargs = llm._get_all_kwargs(
+        model="claude-sonnet-5",
+        temperature=0.5,
+        top_p=0.4,
+        top_k=10,
+    )
+
+    assert kwargs["model"] == "claude-sonnet-5"
+    assert {"temperature", "top_p", "top_k"}.isdisjoint(kwargs)
 
 
 # --- Ollama kwarg translation (max_tokens / context_window) ------------------

--- a/tests/test_openai_oauth_llm.py
+++ b/tests/test_openai_oauth_llm.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from llama_index.core.base.llms.types import (
     ChatMessage,
     MessageRole,
@@ -7,6 +8,11 @@ from llama_index.core.base.llms.types import (
     ToolCallBlock,
 )
 
+from mobilerun.agent.providers import resolve_provider_variant
+from mobilerun.agent.providers.setup_service import (
+    SetupSelection,
+    create_profile_for_variant,
+)
 from mobilerun.agent.utils.oauth.openai_oauth_llm import OpenAIOAuth
 
 
@@ -26,6 +32,94 @@ def test_openai_oauth_constructs_with_updated_openai_adapter(tmp_path) -> None:
     assert llm.model == "gpt-5.5"
     assert llm.metadata.model_name == "gpt-5.5"
     assert llm.metadata.context_window == 400_000
+
+
+@pytest.mark.parametrize(
+    "model_alias",
+    (
+        "gpt-5.6",
+        "openai/gpt-5.6",
+        "openai-codex/gpt-5.6",
+    ),
+)
+def test_openai_oauth_normalizes_gpt_5_6_aliases(tmp_path, model_alias: str) -> None:
+    llm = OpenAIOAuth(
+        model=model_alias,
+        oauth_access_token="stub-access-token",
+        oauth_expires_at_ms=4_102_444_800_000,
+        oauth_credential_path=str(tmp_path / "auth-profiles.json"),
+    )
+
+    assert llm.model == "gpt-5.6-sol"
+    assert llm.metadata.model_name == "gpt-5.6-sol"
+    assert llm.metadata.context_window == 400_000
+
+
+def test_openai_oauth_normalizes_auth_model_alias(tmp_path) -> None:
+    llm = OpenAIOAuth(
+        auth_model="openai-codex/gpt-5.6",
+        oauth_access_token="stub-access-token",
+        oauth_expires_at_ms=4_102_444_800_000,
+        oauth_credential_path=str(tmp_path / "auth-profiles.json"),
+    )
+
+    assert llm.model == "gpt-5.6-sol"
+
+
+def test_openai_oauth_preserves_explicit_custom_model(tmp_path) -> None:
+    llm = OpenAIOAuth(
+        custom_model="acme/custom-reasoning-model",
+        oauth_access_token="stub-access-token",
+        oauth_expires_at_ms=4_102_444_800_000,
+        oauth_credential_path=str(tmp_path / "auth-profiles.json"),
+    )
+
+    assert llm.model == "acme/custom-reasoning-model"
+
+
+@pytest.mark.parametrize(
+    ("auth_mode", "model_alias"),
+    (
+        ("api_key", "gpt-5.6"),
+        ("api_key", "openai/gpt-5.6"),
+        ("oauth", "gpt-5.6"),
+        ("oauth", "openai/gpt-5.6"),
+        ("oauth", "openai-codex/gpt-5.6"),
+    ),
+)
+def test_openai_setup_profiles_normalize_gpt_5_6_aliases(
+    auth_mode: str, model_alias: str
+) -> None:
+    variant = resolve_provider_variant("openai", auth_mode)
+    profile = create_profile_for_variant(
+        variant,
+        SetupSelection(
+            family_id="openai",
+            variant_id=variant.id,
+            auth_mode=auth_mode,
+            model=model_alias,
+            api_key_source="env",
+        ),
+    )
+
+    assert profile.model == "gpt-5.6-sol"
+    assert profile.provider == variant.runtime_provider_name
+
+
+def test_openai_setup_profile_preserves_unknown_custom_model() -> None:
+    variant = resolve_provider_variant("openai", "api_key")
+    profile = create_profile_for_variant(
+        variant,
+        SetupSelection(
+            family_id="openai",
+            variant_id=variant.id,
+            auth_mode="api_key",
+            model="acme/custom-reasoning-model",
+            api_key_source="env",
+        ),
+    )
+
+    assert profile.model == "acme/custom-reasoning-model"
 
 
 def test_openai_oauth_preserves_text_and_serializes_tool_arguments(tmp_path) -> None:

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,5 +1,8 @@
+import pytest
+
 from mobilerun.agent.providers.registry import (
     list_models_for_variant,
+    normalize_model_id_for_variant,
     resolve_provider_variant,
 )
 from mobilerun.config_manager.config_manager import LLMProfile, MobileConfig
@@ -12,10 +15,12 @@ def test_gemini_api_key_catalog_uses_current_flash_models() -> None:
     assert variant.default_model == "gemini-3.1-pro-preview"
     assert models == (
         "gemini-3.5-flash",
+        "gemini-3.6-flash",
+        "gemini-3.5-flash-lite",
         "gemini-3-flash-preview",
         "gemini-3.1-pro-preview",
-        "gemini-3.1-flash-lite",
     )
+    assert "gemini-3.1-flash-lite" not in models
     assert "gemini-3.1-flash-lite-preview" not in models
 
 
@@ -31,15 +36,20 @@ def test_gemini_oauth_catalog_uses_antigravity_consumer_models() -> None:
         "gemini-3-flash",
         "gemini-pro-agent",
         "gemini-3.1-pro-low",
+        "gemini-3.6-flash-low",
+        "gemini-3.6-flash-medium",
+        "gemini-3.6-flash-high",
     )
-    # Deprecated gemini-cli / Code-Assist-for-individuals models are gone.
+    # Live legacy ids remain custom-only rather than advertised.
     assert "gemini-2.5-pro" not in models
     assert "gemini-2.5-flash" not in models
     assert "gemini-2.5-flash-lite" not in models
     assert "gemini-3.5-flash" not in models
+    assert "gemini-3.1-flash-lite" not in models
+    assert "gemini-3.1-pro-high" not in models
 
 
-def test_anthropic_catalogs_include_opus_4_8_without_changing_defaults() -> None:
+def test_anthropic_catalogs_include_claude_5_without_changing_defaults() -> None:
     api_key_variant = resolve_provider_variant("anthropic", "api_key")
     api_key_models = list_models_for_variant("anthropic", "api_key")
     oauth_variant = resolve_provider_variant("anthropic", "oauth")
@@ -48,6 +58,9 @@ def test_anthropic_catalogs_include_opus_4_8_without_changing_defaults() -> None
     assert api_key_variant.default_model == "claude-sonnet-4-6"
     assert api_key_models == (
         "claude-sonnet-4-6",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
         "claude-opus-4-8",
         "claude-opus-4-6",
         "claude-haiku-4-5",
@@ -55,6 +68,9 @@ def test_anthropic_catalogs_include_opus_4_8_without_changing_defaults() -> None
     assert oauth_variant.default_model == "claude-opus-4-7"
     assert oauth_models == (
         "claude-opus-4-7",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
         "claude-opus-4-8",
         "claude-sonnet-4-6",
         "claude-opus-4-6",
@@ -67,7 +83,14 @@ def test_openai_oauth_catalog_hides_unsupported_codex_model() -> None:
     models = list_models_for_variant("openai", "oauth")
 
     assert variant.default_model == "gpt-5.5"
-    assert models == ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini")
+    assert models == (
+        "gpt-5.5",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+    )
     assert "gpt-5.3-codex" not in models
 
 
@@ -76,13 +99,46 @@ def test_openai_api_key_catalog_uses_current_default_model() -> None:
     models = list_models_for_variant("openai", "api_key")
 
     assert variant.default_model == "gpt-5.5"
-    assert models == ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano")
+    assert models == (
+        "gpt-5.5",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+    )
 
 
 def test_default_profiles_use_stable_gemini_flash_lite() -> None:
     config = MobileConfig()
 
-    assert LLMProfile().model == "gemini-3.1-flash-lite"
+    assert LLMProfile().model == "gemini-3.5-flash-lite"
     assert {profile.model for profile in config.llm_profiles.values()} == {
-        "gemini-3.1-flash-lite"
+        "gemini-3.5-flash-lite"
     }
+
+
+@pytest.mark.parametrize(
+    ("auth_mode", "model", "expected"),
+    [
+        ("api_key", "gpt-5.6", "gpt-5.6-sol"),
+        ("api_key", "openai/gpt-5.6", "gpt-5.6-sol"),
+        ("oauth", "gpt-5.6", "gpt-5.6-sol"),
+        ("oauth", "openai/gpt-5.6", "gpt-5.6-sol"),
+        ("oauth", "openai-codex/gpt-5.6", "gpt-5.6-sol"),
+        ("api_key", "gpt-5.6-terra", "gpt-5.6-terra"),
+        ("oauth", "gpt-5.6-luna", "gpt-5.6-luna"),
+    ],
+)
+def test_openai_model_aliases_normalize_to_catalog_ids(
+    auth_mode: str, model: str, expected: str
+) -> None:
+    assert normalize_model_id_for_variant("openai", auth_mode, model) == expected
+
+
+@pytest.mark.parametrize("auth_mode", ["api_key", "oauth"])
+def test_openai_unknown_models_pass_through(auth_mode: str) -> None:
+    model = "vendor/custom-model"
+
+    assert normalize_model_id_for_variant("openai", auth_mode, model) == model

--- a/tests/test_vision_sizing.py
+++ b/tests/test_vision_sizing.py
@@ -31,6 +31,15 @@ def test_model_effective_dims_per_provider():
     assert model_effective_dims("claude-future-9", 1080, 2400) == (706, 1568)
 
 
+def test_claude_5_models_use_high_resolution_budget():
+    for model in ("claude-opus-5", "claude-sonnet-5", "claude-fable-5"):
+        assert model_effective_dims(model, 1080, 2400) == (922, 2048)
+
+
+def test_unregistered_mythos_model_retains_high_resolution_budget():
+    assert model_effective_dims("claude-mythos-5", 1080, 2400) == (922, 2048)
+
+
 def test_policy_single_model():
     assert VisionResizePolicy(["claude-sonnet-4-6"]).effective_dims(1080, 2400) == (
         706,


### PR DESCRIPTION
## Summary

Refreshes the OpenAI, Anthropic, and Gemini API-key/OAuth catalogs using live provider availability, while preserving existing OpenAI and Anthropic defaults.

- Adds GPT-5.6 Sol, Terra, and Luna to OpenAI API-key and OAuth choices. Bare `gpt-5.6` aliases normalize to Sol in setup and runtime paths.
- Adds Claude Opus 5, Sonnet 5, and Fable 5 to both Anthropic paths. Shared capability metadata now drives context windows, sampling compatibility, and vision sizing.
- Adds Gemini 3.6 Flash and 3.5 Flash-Lite to the API-key catalog, plus Gemini 3.6 Flash low/medium/high to OAuth.
- Removes Gemini 3.1 Flash-Lite from new API-key choices, generated defaults, examples, and docs. Existing saved profiles remain unchanged, silent, and loadable.
- Keeps live private Gemini 2.5 OAuth IDs available as unadvertised explicit choices.

## Compatibility details

- OpenAI and Anthropic defaults are unchanged (`gpt-5.5`, `claude-sonnet-4-6`, and `claude-opus-4-7`).
- GPT-5.6 reports the upstream 1,050,000-token context window and omits unsupported sampling fields, including structured-output requests.
- Current Opus/Sonnet and Claude 5 models report 1,000,000 tokens; Haiku 4.5 remains 200,000.
- Anthropic models that reject sampling controls strip `temperature`, `top_p`, and `top_k` after all overrides are merged. Opus 4.6 retains its supported controls.
- Claude 5 uses the high-resolution vision tier; the existing unadvertised Mythos 5 sizing capability is preserved.
- New public Gemini models suppress unsupported sampling fields in sync, async, streaming, and structured-output request paths.
- Unknown/custom OpenAI models continue to pass through.
- No dependency, lockfile, prompt, credential, streaming, or configuration-schema changes are included.

## Validation

- `pytest -q`: **448 passed**
- unittest discovery: **65 passed**
- Black: **161 files clean**
- changed-file Ruff: passed
- repository-wide Ruff: only the same **9 pre-existing** findings on `main`
- `uv lock --check`: passed; `uv.lock` unchanged
- `git diff --check`: passed
- wheel and sdist built; `twine check`: passed
- clean Python 3.11 and 3.13 wheel installs: `pip check` and catalog/metadata smokes passed

### Live provider validation

- **41/42** registered model/auth pairs returned exact `OK` through the final wheel.
- OpenAI OAuth `gpt-5.6-sol` reached the service but returned the provider's transient `Our servers are currently overloaded` response after the permitted retry. The GPT-5.6 Sol API path and bare-alias Android E2E passed; Terra and Luna OAuth probes passed.
- Gemini 3.6 Flash and 3.1 Pro Preview returned exact `OK` with a 256-token cap after their first 64-token probes ended at `MAX_TOKENS`.
- Explicit saved-profile compatibility for `gemini-3.1-flash-lite` and unadvertised OAuth `gemini-2.5-flash` both returned exact `OK`.

### Android 16 / Portal v0.7.22

All tests used public Portal v0.7.22 in `portal_mode: required` on a disposable API 36 emulator, with strict Portal JSON and no UIAutomator fallback.

Six independent accessibility E2Es passed and returned `Search Settings` with Settings foreground:

- OpenAI API: bare `gpt-5.6` (normalized to Sol)
- OpenAI OAuth: `gpt-5.6-terra`
- Anthropic API: `claude-sonnet-5`
- Anthropic OAuth: `claude-opus-5`
- Gemini API: generated-default `gemini-3.5-flash-lite`
- Gemini OAuth: `gemini-3.6-flash-medium`

Anthropic Sonnet 5 also passed a vision-only perception smoke and correctly identified the Settings search bar as rounded/pill-shaped; the screenshot was independently verified.

Credentials were exposed only to their matching child processes. The real configuration, OAuth profiles, and key files remained byte-for-byte unchanged.