### PR TITLE
chore(release): bump to 0.6.14

### DIFF
--- a/compat/pyproject.toml
+++ b/compat/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "droidrun"
-version = "0.6.13"
+version = "0.6.14"
 description = "Compatibility shim — droidrun has been renamed to mobilerun"
 requires-python = ">=3.11,<3.14"
-dependencies = ["mobilerun==0.6.13"]
+dependencies = ["mobilerun==0.6.14"]
 
 [project.optional-dependencies]
-anthropic = ["mobilerun[anthropic]==0.6.13"]
-deepseek = ["mobilerun[deepseek]==0.6.13"]
-langfuse = ["mobilerun[langfuse]==0.6.13"]
-dev = ["mobilerun[dev]==0.6.13"]
+anthropic = ["mobilerun[anthropic]==0.6.14"]
+deepseek = ["mobilerun[deepseek]==0.6.14"]
+langfuse = ["mobilerun[langfuse]==0.6.14"]
+dev = ["mobilerun[dev]==0.6.14"]
 
 [project.scripts]
 droidrun = "droidrun.cli_shim:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mobilerun"
-version = "0.6.13"
+version = "0.6.14"
 description = "A framework for controlling mobile devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels@droidrun.ai" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1679,7 +1679,7 @@ wheels = [
 
 [[package]]
 name = "mobilerun"
-version = "0.6.13"
+version = "0.6.14"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- bump `mobilerun` to `0.6.14`
- bump the `droidrun` compatibility shim, its base dependency, and all four optional-extra pins to `0.6.14`
- regenerate `uv.lock` without dependency-version drift

This release ships the provider catalog refresh from #402. Users upgrading to
`0.6.14` will see the new OpenAI, Anthropic, and Gemini choices in
`mobilerun configure`. Public Portal compatibility remains pinned to `0.7.22`.

## Validation

- full pytest: 448 passed
- unittest discovery: 65 passed
- Black 25.9.0: 161 files unchanged
- `uv lock --check`, compat pin assertions, and `git diff --check`: passed
- full Ruff: exactly the nine pre-existing findings, unchanged from `main`
- root and compatibility wheels/sdists built; `twine check` passed
- clean Python 3.11 and 3.13 installs passed, including `droidrun[anthropic]`
- exact LlamaIndex versions, provider imports, model catalogs, metadata, and GPT-5.6 alias normalization verified from the wheel
- API-key and OAuth transport probes passed for OpenAI, Anthropic, and Gemini
- local Docker image built and passed CLI, import, registry, resource, and dependency checks
- Android 16 smoke with Portal v0.7.22 required: bare `gpt-5.6` normalized to Sol, opened Settings in two steps, and returned `Search Settings`
- strict Portal state remained valid before and after; Settings stayed foreground and no UIAutomator fallback was used
