### PR TITLE
Drive iOS devices through mobilerun-ios --local (portal-HTTP auto-detection)

### DIFF
--- a/docs/guides/device-setup.mdx
+++ b/docs/guides/device-setup.mdx
@@ -518,8 +518,8 @@ result = await agent.run()
     **Solutions:**
     1. Confirm `mobilerun-ios --local <udid>` is still running
     2. Check its startup output for the actual server URL
-    3. If another process uses port 8080, start with `--local-addr 127.0.0.1:9100`
-    4. Test the printed URL with `/ping`
+    3. If another process uses port 8080, choose an available high port, for example: `mobilerun-ios --local --local-addr 127.0.0.1:18080 <udid>`
+    4. Test the printed URL with `/ping`. Because custom ports are not auto-discovered, pass it to the framework explicitly with `--device http://127.0.0.1:18080`
   </Accordion>
 
   <Accordion title="Framework auto-discovery fails">

--- a/docs/guides/device-setup.mdx
+++ b/docs/guides/device-setup.mdx
@@ -317,11 +317,11 @@ The Portal only communicates locally via ADB. No data is sent to external server
 
   </Tab>
 
-  <Tab title="iOS Setup (experimental)">
+  <Tab title="iOS Setup">
 
-<Warning>
-iOS support is currently **experimental**. Functionality is limited compared to Android.
-</Warning>
+<Info>
+iOS support is stable and provides the same core device automation capabilities as Android through `mobilerun-ios`. Platform-specific differences are listed under [Supported Features](#supported-features).
+</Info>
 
 ---
 

--- a/docs/guides/device-setup.mdx
+++ b/docs/guides/device-setup.mdx
@@ -508,6 +508,31 @@ agent = MobileAgent(
 result = await agent.run()
 ```
 
+### Local mode with mobilerun-ios (macOS)
+
+`mobilerun-ios --local` serves the portal HTTP API directly on your Mac — no
+Portal app or iproxy needed:
+
+```bash
+mobilerun-ios --local <udid>          # serves http://127.0.0.1:8080
+mobilerun run --ios "Open Settings"   # auto-discovers the local portal
+```
+
+With several devices attached the port advances per device (8080, 8081, …);
+pass the URL explicitly to pick one:
+
+```bash
+mobilerun run --ios --device http://127.0.0.1:8081 "Open Settings"
+```
+
+Both portal generations are auto-detected from the URL, so the legacy Portal
+app keeps working unchanged.
+
+**Auth:** a loopback server needs no token. If `mobilerun-ios` was started
+with `--local-token` (required for non-loopback binds), set the matching
+token via the `MOBILERUN_DEVICE_TOKEN` env var or `device.auth_token` in
+config.yaml.
+
 ---
 
 ## Supported Features

--- a/docs/guides/device-setup.mdx
+++ b/docs/guides/device-setup.mdx
@@ -327,17 +327,12 @@ iOS support is currently **experimental**. Functionality is limited compared to 
 
 ## Prerequisites
 
-- **macOS** with **Xcode 15+** installed (iOS Portal must be built from source)
-- **Apple Developer account** (free or paid — needed for code signing)
-- **iOS device** (iPhone or iPad) with **Developer Mode** enabled
-- **USB cable** to connect the device to your Mac (for initial build and deployment)
-- **`iproxy`** from `libimobiledevice` (for USB port forwarding)
-
-### Install `iproxy`
-
-```bash
-brew install libimobiledevice
-```
+- **macOS** with **Xcode** installed
+- **Apple ID** with signing capability (a personal team is sufficient)
+- **iPhone** with **Developer Mode** enabled
+- **USB data cable** to connect the iPhone to your Mac
+- **Mobilerun WebDriverAgent** installed and signed on the iPhone
+- **`mobilerun-ios`** installed on your Mac
 
 ### Enable Developer Mode on your device
 
@@ -346,133 +341,98 @@ brew install libimobiledevice
 3. Restart the device when prompted
 4. After restart, confirm the prompt to enable Developer Mode
 
+For the complete device preparation and WebDriverAgent signing instructions, follow the [Connect an iPhone guide](https://docs.mobilerun.ai/guides/connect-iphone). You only need to complete the device, WebDriverAgent, and `mobilerun-ios` installation steps; logging in is not required for local mode.
+
 ---
 
-## Build and Install the iOS Portal
+## Install and Run `mobilerun-ios`
 
-The iOS Portal is an Xcode project that runs as a UI test — it launches an HTTP server on port **6643** that Mobilerun communicates with.
+`mobilerun-ios --local` connects to WebDriverAgent over USB and exposes the device API on your Mac. The framework discovers that API automatically.
 
 <Steps>
-  <Step title="Clone the iOS Portal repository">
+  <Step title="Install the CLI">
+    Choose either Homebrew or the installation script:
+
+    <CodeGroup>
+
+    ```bash Homebrew
+    brew install droidrun/tap/mobilerun-ios
+    ```
+
+    ```bash Installation script
+    curl -fsSL https://media.mobilerun.ai/releases/mobilerun-ios/install.sh | sh
+    ```
+
+    </CodeGroup>
+
+    Verify the installation:
+
     ```bash
-    git clone https://github.com/droidrun/ios-portal.git
-    cd ios-portal
+    mobilerun-ios --version
     ```
   </Step>
 
-  <Step title="Open the project in Xcode">
-    ```bash
-    open mobilerun-ios-portal.xcodeproj
-    ```
-  </Step>
-
-  <Step title="Configure code signing">
-    You must change the signing team and bundle identifier to your own:
-
-    1. In Xcode, select the **mobilerun-ios-portal** project in the navigator
-    2. For **each target** (`mobilerun-ios-portal`, `mobilerun-ios-portalUITests`):
-       - Select the target
-       - Go to the **Signing & Capabilities** tab
-       - Set **Team** to your Apple Developer account
-       - Change the **Bundle Identifier** to something unique, e.g.:
-         - `com.yourname.mobilerun-ios-portal`
-         - `com.yourname.mobilerun-ios-portalUITests`
-    3. Let Xcode automatically manage provisioning profiles
-
-    <Warning>
-    You **must** change the bundle identifiers — the default ones are tied to the Mobilerun team's signing certificate and will fail to build on your machine.
-    </Warning>
-  </Step>
-
-  <Step title="Select your device and run the test">
-    1. Connect your iOS device via USB
-    2. In Xcode, select your device from the device dropdown (top bar)
-    3. If this is your first time deploying to the device, trust the developer certificate:
-       - On the device: **Settings** > **General** > **VPN & Device Management** > tap your developer profile > **Trust**
-    4. Run the portal using either method:
-
-    **Option A — Xcode UI:**
-    - Go to **Product** > **Test** (or press `Cmd + U`)
-    - This builds the app, installs it, and starts the "Mobilerun Server" UI test
-
-    **Option B — Command line:**
-    ```bash
-    # Find your device ID
-    xcrun xctrace list devices
-
-    # Run the portal server
-    ./device.sh YOUR_DEVICE_UDID
-    ```
-
-    The HTTP server starts on port **6643** and keeps running until the test session ends.
-  </Step>
-
-  <Step title="Set up port forwarding with iproxy">
-    The portal server runs on the device's localhost. To reach it from your Mac, forward the port over USB:
+  <Step title="Find the iPhone UDID">
+    Connect and unlock the iPhone, accept the **Trust This Computer** prompt, then run:
 
     ```bash
-    iproxy 6643 6643
+    mobilerun-ios list
     ```
 
-    Keep this running in a separate terminal. The portal is now accessible at `http://127.0.0.1:6643`.
+    Copy the UDID shown for the iPhone you want to control.
+  </Step>
 
-    <Note>
-    `iproxy` forwards over USB, so you don't need WiFi connectivity between your Mac and the device.
-    </Note>
+  <Step title="Start local mode">
+    ```bash
+    mobilerun-ios --local <udid>
+    ```
+
+    Keep this command running. By default, it serves the device API at `http://127.0.0.1:8080`.
   </Step>
 
   <Step title="Verify the connection">
     ```bash
-    # Quick health check
-    curl http://127.0.0.1:6643/device/date
-
-    # Should return something like: {"date": "2026-03-31 10:30:00"}
+    curl http://127.0.0.1:8080/ping
     ```
 
-    Then test with Mobilerun:
+    The response should contain `"result":"pong"`. Then test the framework:
+
     ```bash
-    mobilerun run "take a screenshot" --ios
+    mobilerun run "Take a screenshot" --ios
     ```
 
-    Mobilerun will auto-discover the portal on port 6643. If it's on a different port, pass the URL explicitly:
+    To select the server explicitly, pass its URL:
+
     ```bash
-    mobilerun run "take a screenshot" --ios --device http://127.0.0.1:6643
+    mobilerun run "Take a screenshot" --ios --device http://127.0.0.1:8080
     ```
   </Step>
 </Steps>
 
----
+<Note>
+When several iPhones are attached, ports advance per device (`8080`, `8081`, and so on). Each device URL is printed when `mobilerun-ios` starts. Framework auto-discovery scans ports `8080` through `8089`.
+</Note>
 
-## Running on the Simulator
-
-You can also run the portal on the iOS Simulator (no code signing or physical device needed):
-
-```bash
-# List available simulators
-xcrun simctl list devices available
-
-# Run the portal on a simulator by name
-./simulator.sh "iPhone 16 Pro"
-```
-
-The simulator portal is accessible at `http://127.0.0.1:6643` directly (no `iproxy` needed).
+<Warning>
+Loopback local mode does not require authentication. If you bind to a non-loopback address, `mobilerun-ios` requires `--local-token`. Set the same token in `MOBILERUN_DEVICE_TOKEN` or `device.auth_token` in the framework configuration.
+</Warning>
 
 ---
 
 ## Architecture
 
-iOS Portal uses a different architecture than Android:
+The iOS local driver uses a different architecture than Android:
 
 | Feature | Android | iOS |
 |---------|---------|-----|
-| Communication | ADB + TCP/Content Provider | HTTP server (port 6643) |
-| Portal type | APK (auto-installed) | Xcode UI test (built from source) |
-| Setup tool | `mobilerun setup` | Xcode build + `iproxy` |
-| Accessibility | Android Accessibility API | iOS XCUITest framework |
+| Communication | ADB + TCP/Content Provider | Local HTTP API (port 8080 by default) |
+| Device bridge | Portal APK | `mobilerun-ios` backed by WebDriverAgent |
+| Setup tool | `mobilerun setup` | `mobilerun-ios --local <udid>` |
+| Accessibility | Android Accessibility API | WebDriverAgent / XCUITest |
 | Text Input | Custom keyboard IME | Direct XCUITest text input |
-| Connection | ADB over USB/TCP | USB via `iproxy` or WiFi |
+| Connection | ADB over USB/TCP | USB through `mobilerun-ios` |
 
-The iOS Portal leverages XCUITest to extract accessibility trees, perform gestures, and capture screenshots — all exposed through a REST API.
+`mobilerun-ios` uses WebDriverAgent to extract accessibility trees, perform gestures, manage apps, and capture screenshots. Local mode exposes these operations through the portal HTTP contract used by the framework.
 
 ---
 
@@ -481,11 +441,11 @@ The iOS Portal leverages XCUITest to extract accessibility trees, perform gestur
 ### CLI
 
 ```bash
-# Auto-discovers portal on port 6643
+# Auto-discovers mobilerun-ios on ports 8080-8089
 mobilerun run "your command" --ios
 
-# Explicit portal URL
-mobilerun run "your command" --ios --device http://127.0.0.1:6643
+# Explicit local server URL
+mobilerun run "your command" --ios --device http://127.0.0.1:8080
 ```
 
 ### Python API
@@ -496,7 +456,7 @@ from mobilerun import MobileAgent, MobileConfig, DeviceConfig
 config = MobileConfig(
     device=DeviceConfig(
         platform="ios",
-        serial="http://127.0.0.1:6643",  # optional, auto-discovered if omitted
+        serial="http://127.0.0.1:8080",  # optional, auto-discovered if omitted
     )
 )
 
@@ -507,31 +467,6 @@ agent = MobileAgent(
 
 result = await agent.run()
 ```
-
-### Local mode with mobilerun-ios (macOS)
-
-`mobilerun-ios --local` serves the portal HTTP API directly on your Mac — no
-Portal app or iproxy needed:
-
-```bash
-mobilerun-ios --local <udid>          # serves http://127.0.0.1:8080
-mobilerun run --ios "Open Settings"   # auto-discovers the local portal
-```
-
-With several devices attached the port advances per device (8080, 8081, …);
-pass the URL explicitly to pick one:
-
-```bash
-mobilerun run --ios --device http://127.0.0.1:8081 "Open Settings"
-```
-
-Both portal generations are auto-detected from the URL, so the legacy Portal
-app keeps working unchanged.
-
-**Auth:** a loopback server needs no token. If `mobilerun-ios` was started
-with `--local-token` (required for non-loopback binds), set the matching
-token via the `MOBILERUN_DEVICE_TOKEN` env var or `device.auth_token` in
-config.yaml.
 
 ---
 
@@ -545,48 +480,55 @@ config.yaml.
 | `screenshot()` | ✅ | |
 | `get_state()` | ✅ | Accessibility tree extraction |
 | `start_app()` | ✅ | By bundle identifier |
+| `stop_app()` | ✅ | By bundle identifier |
+| `get_apps()` | ✅ | Includes system-app filtering |
 | `get_date()` | ✅ | |
-| `press_button()` | ✅ | `home` only |
+| `press_button()` | ✅ | `home`, `back`, `enter`, `delete`, and `app_switch` |
 | `drag()` | ❌ | |
-| `install_app()` | ❌ | |
+| `install_app()` | ✅ | From a path or URL accessible to `mobilerun-ios` |
+| `uninstall_app()` | ❌ | Not exposed by the local API |
 
 ---
 
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="Build fails with signing error">
-    **Symptoms:** Xcode shows "Signing for target requires a development team"
+  <Accordion title="`mobilerun-ios list` shows no devices">
+    **Symptoms:** The connected iPhone does not appear in the device list
 
     **Solutions:**
-    1. Make sure you changed the **Team** and **Bundle Identifier** for both targets
-    2. If using a free Apple Developer account, you may need to re-trust the certificate on the device every 7 days (**Settings** > **General** > **VPN & Device Management**)
+    1. Unlock the iPhone and accept the **Trust This Computer** prompt
+    2. Confirm the USB cable supports data, not only charging
+    3. Open Xcode once with the device connected and verify it appears as a run destination
   </Accordion>
 
-  <Accordion title="Portal not reachable">
-    **Symptoms:** `curl http://127.0.0.1:6643/device/date` times out or connection refused
+  <Accordion title="WebDriverAgent does not start">
+    **Symptoms:** `mobilerun-ios --local` times out while waiting for WebDriverAgent
 
     **Solutions:**
-    1. Verify `iproxy 6643 6643` is running
-    2. Check the Xcode test is still running (the portal stops when the test ends)
-    3. Re-run the test with `Cmd + U` in Xcode or `./device.sh UDID`
+    1. Re-sign and build `WebDriverAgentRunner` in Xcode
+    2. Trust the developer certificate under **Settings** > **General** > **VPN & Device Management**
+    3. Keep the device unlocked and run `mobilerun-ios --local <udid>` again
+    4. Review the [Connect an iPhone guide](https://docs.mobilerun.ai/guides/connect-iphone) for the complete signing procedure
   </Accordion>
 
-  <Accordion title="Auto-discovery fails">
-    **Symptoms:** `mobilerun run ... --ios` says "Could not find iOS portal"
+  <Accordion title="Local server not reachable">
+    **Symptoms:** `curl http://127.0.0.1:8080/ping` times out or is refused
 
     **Solutions:**
-    1. Auto-discovery scans ports 6643-6652. Make sure `iproxy` is forwarding to one of these.
-    2. Pass the URL explicitly: `--device http://127.0.0.1:6643`
+    1. Confirm `mobilerun-ios --local <udid>` is still running
+    2. Check its startup output for the actual server URL
+    3. If another process uses port 8080, start with `--local-addr 127.0.0.1:9100`
+    4. Test the printed URL with `/ping`
   </Accordion>
 
-  <Accordion title="Test session keeps stopping">
-    **Symptoms:** The portal server stops after a few minutes
+  <Accordion title="Framework auto-discovery fails">
+    **Symptoms:** `mobilerun run ... --ios` cannot find the iPhone
 
     **Solutions:**
-    1. Keep Xcode open and the test running — closing Xcode ends the test session
-    2. Disable auto-lock on the device (**Settings** > **Display & Brightness** > **Auto-Lock** > **Never**)
-    3. Keep the device plugged in to prevent sleep
+    1. Confirm the local server is on one of the automatically scanned ports, `8080` through `8089`
+    2. Pass the URL explicitly: `--device http://127.0.0.1:8080`
+    3. If the server uses a token, export `MOBILERUN_DEVICE_TOKEN` before starting the framework
   </Accordion>
 </AccordionGroup>
 

--- a/mobilerun/agent/droid/droid_agent.py
+++ b/mobilerun/agent/droid/droid_agent.py
@@ -81,7 +81,11 @@ from mobilerun.telemetry import (
     capture,
     flush,
 )
-from mobilerun_core_local.driver.ios import IOSDriver, discover_ios_portal
+from mobilerun_core_local.driver.ios import (
+    IOSPortalHttpDriver,
+    create_ios_driver,
+    discover_ios_device,
+)
 from mobilerun_core_local.driver.recording import RecordingDriver
 from mobilerun_core_local.driver.stealth import StealthDriver
 from mobilerun_core_local.driver.visual_remote import (
@@ -537,8 +541,11 @@ class MobileAgent(Workflow):
         elif is_ios:
             ios_url = self.resolved_device_config.serial
             if not ios_url:
-                ios_url = await discover_ios_portal()
-            driver = IOSDriver(url=ios_url)
+                ios_url = await discover_ios_device()
+            driver = await create_ios_driver(
+                ios_url,
+                token=self.resolved_device_config.resolve_auth_token(),
+            )
             await driver.connect()
         else:
             device_serial = self.resolved_device_config.serial
@@ -563,6 +570,10 @@ class MobileAgent(Workflow):
             )
             await driver.connect()
 
+        # Captured before the Stealth/Recording wraps: the provider pairing
+        # below must see the concrete driver class.
+        is_ios_portal_http = isinstance(driver, IOSPortalHttpDriver)
+
         # Wrap with StealthDriver if stealth mode enabled
         stealth_enabled = self.config.tools and self.config.tools.stealth
         if stealth_enabled and not is_ios and not is_visual_remote:
@@ -582,6 +593,20 @@ class MobileAgent(Workflow):
         elif self.config.agent.vision_only or is_visual_remote:
             self.state_provider = ScreenshotOnlyStateProvider(
                 driver, vision_resize_policy=vision_resize_policy
+            )
+        elif is_ios_portal_http:
+            # The --local portal serves the Android-shaped state (a11y_tree
+            # node JSON + point-space screen_bounds), so it pairs with the
+            # Android tree pipeline; coordinates stay in points end to end.
+            tree_filter = ConciseFilter() if vision_enabled else DetailedFilter()
+            self.state_provider = AndroidStateProvider(
+                driver,
+                tree_filter=tree_filter,
+                tree_formatter=IndexedFormatter(),
+                use_normalized=self.config.agent.use_normalized_coordinates,
+                stealth=False,
+                vision_enabled=vision_enabled,
+                vision_resize_policy=vision_resize_policy,
             )
         elif is_ios:
             self.state_provider = IOSStateProvider(

--- a/mobilerun/cli/device_commands.py
+++ b/mobilerun/cli/device_commands.py
@@ -171,9 +171,7 @@ async def _create_driver(
             url = validate_ios_portal_url(config.device.serial)
         else:
             url = await discover_ios_device()
-        driver = await create_ios_driver(
-            url, token=config.device.resolve_auth_token()
-        )
+        driver = await create_ios_driver(url, token=config.device.resolve_auth_token())
         await driver.connect()
         return driver, True
 

--- a/mobilerun/cli/device_commands.py
+++ b/mobilerun/cli/device_commands.py
@@ -20,8 +20,8 @@ from rich.console import Console
 
 from mobilerun.config_manager import ConfigLoader
 from mobilerun_core_local.driver.ios import (
-    IOSDriver,
-    discover_ios_portal,
+    create_ios_driver,
+    discover_ios_device,
     validate_ios_portal_url,
 )
 from mobilerun.tools.filters import ConciseFilter
@@ -169,8 +169,10 @@ async def _create_driver(
         if config.device.serial:
             url = validate_ios_portal_url(config.device.serial)
         else:
-            url = await discover_ios_portal()
-        driver = IOSDriver(url=url)
+            url = await discover_ios_device()
+        driver = await create_ios_driver(
+            url, token=config.device.resolve_auth_token()
+        )
         await driver.connect()
         return driver, True
 

--- a/mobilerun/cli/device_commands.py
+++ b/mobilerun/cli/device_commands.py
@@ -20,6 +20,7 @@ from rich.console import Console
 
 from mobilerun.config_manager import ConfigLoader
 from mobilerun_core_local.driver.ios import (
+    IOSPortalHttpDriver,
     create_ios_driver,
     discover_ios_device,
     validate_ios_portal_url,
@@ -256,7 +257,7 @@ async def ui(device, config_path, tcp, ios, cloud, device_id, base_url):
         device, config_path, tcp, ios, cloud, device_id, base_url
     )
     try:
-        if is_ios:
+        if is_ios and not isinstance(driver, IOSPortalHttpDriver):
             provider = IOSStateProvider(driver)
         else:
             provider = AndroidStateProvider(

--- a/mobilerun/cli/main.py
+++ b/mobilerun/cli/main.py
@@ -64,7 +64,7 @@ from mobilerun.config_manager.credential_paths import (
 from mobilerun.log_handlers import CLILogHandler, configure_logging
 from mobilerun.macro.cli import macro_cli
 from mobilerun.telemetry import print_telemetry_message
-from mobilerun_core_local.driver.ios import discover_ios_portal, validate_ios_portal_url
+from mobilerun_core_local.driver.ios import discover_ios_device, validate_ios_portal_url
 from mobilerun_core_local.driver.visual_remote import VISUAL_REMOTE_CONNECTION
 
 # Suppress all warnings
@@ -233,7 +233,7 @@ async def run_command(
                 config.device.serial = validate_ios_portal_url(config.device.serial)
             else:
                 logger.info("🔍 Searching for iOS portal...")
-                config.device.serial = await discover_ios_portal()
+                config.device.serial = await discover_ios_device()
 
         # ================================================================
         # STEP 2: Initialize MobileAgent with config

--- a/mobilerun/config_example.yaml
+++ b/mobilerun/config_example.yaml
@@ -141,6 +141,10 @@ device:
   # Android only: auto-install/update Portal APK and enable accessibility before each run.
   # iOS requires a running iOS Portal URL or discovery through iproxy.
   auto_setup: true
+  # Bearer token for portal-HTTP device URLs (e.g. a `mobilerun-ios --local`
+  # server started with --local-token). Loopback servers need no token.
+  # The MOBILERUN_DEVICE_TOKEN env var overrides this value.
+  auth_token: null
 
 # === Telemetry Settings ===
 telemetry:

--- a/mobilerun/config_manager/config_manager.py
+++ b/mobilerun/config_manager/config_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Literal, Optional
 
@@ -169,6 +170,13 @@ class DeviceConfig:
     platform: str = "android"  # "android" or "ios"
     portal_mode: Literal["auto", "required", "disabled"] = "auto"
     auto_setup: bool = True  # auto-install/fix portal before each run
+    # Bearer token for portal-HTTP device URLs (a mobilerun-ios --local server
+    # started with --local-token). Loopback servers need no token. The
+    # MOBILERUN_DEVICE_TOKEN env var overrides this value.
+    auth_token: Optional[str] = None
+
+    def resolve_auth_token(self) -> Optional[str]:
+        return os.environ.get("MOBILERUN_DEVICE_TOKEN") or self.auth_token
 
 
 @dataclass

--- a/mobilerun/config_manager/loader.py
+++ b/mobilerun/config_manager/loader.py
@@ -107,6 +107,16 @@ class ConfigLoader:
     def _save_dict(cls, config_dict: Dict[str, Any], path: Path) -> Path:
         """Save config dict to path."""
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT, 0o600)
+        try:
+            if os.name != "nt":
+                os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                fd = -1  # fdopen owns the descriptor from here.
+                f.seek(0)
+                f.truncate()
+                yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
+        finally:
+            if fd != -1:
+                os.close(fd)
         return path

--- a/mobilerun/tools/ui/provider.py
+++ b/mobilerun/tools/ui/provider.py
@@ -233,6 +233,11 @@ class AndroidStateProvider(StateProvider):
         # space from convert_point.
         self._vision_contract_intent = vision_enabled and not use_normalized
         self.resize_model_screenshot = self._vision_contract_intent
+        # Hybrid vision exposes click_at when a coordinate contract is
+        # expected, but individual states can still arrive with missing or
+        # zero screen bounds. Refuse coordinate actions for those snapshots
+        # instead of treating model coordinates as native device pixels.
+        self.requires_active_contract_for_coords = self._vision_contract_intent
 
     async def _recover_portal(self) -> None:
         """Restart Portal's accessibility service and TCP socket server."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "llama-index-llms-ollama>=0.7.2",
     "llama-index-llms-openrouter>=0.4.2",
     "mobilerun-sdk>=3.2.0",
-    "mobilerun-core-local[cloud]>=0.5.0",
+    "mobilerun-core-local[cloud]>=0.6.0",
 ]
 requires-python = ">=3.11,<3.14"
 readme = "README.md"

--- a/tests/test_android_vision_coordinate_contract.py
+++ b/tests/test_android_vision_coordinate_contract.py
@@ -215,6 +215,27 @@ def test_missing_screen_bounds_disables_resize_for_that_state():
     assert should_resize_model_screenshot(provider) is True
 
 
+def test_hybrid_vision_zero_bounds_refuses_click_at():
+    from mobilerun.agent.utils.actions import click_at
+
+    provider = _provider(width=0, height=0, vision_enabled=True)
+    provider.driver.tap = AsyncMock()
+    state = _get_state(provider)
+    ctx = SimpleNamespace(
+        ui=state,
+        state_provider=provider,
+        driver=provider.driver,
+        macro_recorder=None,
+    )
+
+    assert state.coordinate_contract_active is False
+    result = asyncio.run(click_at(10, 20, ctx=ctx))
+
+    assert result.success is False
+    assert "unavailable for this step" in result.summary
+    provider.driver.tap.assert_not_awaited()
+
+
 def test_legacy_injected_screenshot_providers_keep_getting_resized():
     """Injected providers that only implement the pre-existing
     ``requires_coordinate_tools`` contract must still get resized screenshots:

--- a/tests/test_config_loader_permissions.py
+++ b/tests/test_config_loader_permissions.py
@@ -1,0 +1,20 @@
+import os
+import stat
+
+import pytest
+import yaml
+
+from mobilerun.config_manager.loader import ConfigLoader
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not available")
+def test_save_dict_restricts_existing_config_to_owner_only(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(f"old: {'value' * 20}\n")
+    os.chmod(config_path, 0o644)
+    config = {"_version": 7, "device": {"auth_token": "secret"}}
+
+    ConfigLoader._save_dict(config, config_path)
+
+    assert yaml.safe_load(config_path.read_text()) == config
+    assert stat.S_IMODE(config_path.stat().st_mode) == 0o600

--- a/tests/test_ios_local_portal_wiring.py
+++ b/tests/test_ios_local_portal_wiring.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import asyncio
 
-import httpx
-
 
 def run(coro):
     return asyncio.run(coro)
@@ -108,6 +106,36 @@ def test_android_state_provider_vision_contract_uses_point_space():
     assert state.coordinate_contract_active
     assert (state.model_screenshot_width, state.model_screenshot_height) == (393, 852)
     assert (state.coordinate_scale_x, state.coordinate_scale_y) == (1.0, 1.0)
+
+
+def test_device_commands_ui_pairs_portal_http_driver_with_android_provider(monkeypatch):
+    """`mobilerun device ui` must not pair IOSPortalHttpDriver with
+    IOSStateProvider: the latter regex-parses a legacy string tree and would
+    silently yield zero elements for the Android-shaped dict the --local
+    portal actually returns."""
+    from click.testing import CliRunner
+    from mobilerun_core_local.driver.ios import IOSPortalHttpDriver
+
+    from mobilerun.cli import device_commands
+
+    class FakePortalHttpDriver(IOSPortalHttpDriver):
+        def __init__(self):  # skip the httpx-client base __init__
+            pass
+
+        async def get_ui_tree(self):
+            return LOCAL_PORTAL_STATE
+
+    driver = FakePortalHttpDriver()
+
+    async def fake_create_driver(*args, **kwargs):
+        return driver, True
+
+    monkeypatch.setattr(device_commands, "_create_driver", fake_create_driver)
+
+    result = CliRunner().invoke(device_commands.device_cli, ["ui"])
+
+    assert result.exit_code == 0, result.output
+    assert "Privacy & Security" in result.output
 
 
 def test_device_commands_route_ios_through_factory(tmp_path, monkeypatch):

--- a/tests/test_ios_local_portal_wiring.py
+++ b/tests/test_ios_local_portal_wiring.py
@@ -108,3 +108,80 @@ def test_android_state_provider_vision_contract_uses_point_space():
     assert state.coordinate_contract_active
     assert (state.model_screenshot_width, state.model_screenshot_height) == (393, 852)
     assert (state.coordinate_scale_x, state.coordinate_scale_y) == (1.0, 1.0)
+
+
+def test_device_commands_route_ios_through_factory(tmp_path, monkeypatch):
+    from mobilerun.cli import device_commands
+
+    created = {}
+
+    class FakeDriver:
+        platform = "iOS"
+
+        async def connect(self):
+            created["connected"] = True
+
+    async def fake_create_ios_driver(url, *, token=None, transport=None):
+        created["url"] = url
+        created["token"] = token
+        return FakeDriver()
+
+    monkeypatch.setattr(device_commands, "create_ios_driver", fake_create_ios_driver)
+    monkeypatch.setenv("MOBILERUN_DEVICE_TOKEN", "sekret")
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("_version: 7\ndevice:\n  platform: ios\n")
+
+    driver, is_ios = run(
+        device_commands._create_driver(
+            device="http://127.0.0.1:8080",
+            config_path=str(cfg),
+            tcp=None,
+            ios=True,
+        )
+    )
+
+    assert is_ios is True
+    assert created == {
+        "url": "http://127.0.0.1:8080",
+        "token": "sekret",
+        "connected": True,
+    }
+
+
+def test_device_commands_discover_when_no_device(tmp_path, monkeypatch):
+    from mobilerun.cli import device_commands
+
+    created = {}
+
+    class FakeDriver:
+        platform = "iOS"
+
+        async def connect(self):
+            pass
+
+    async def fake_discover_ios_device():
+        return "http://127.0.0.1:8081"
+
+    async def fake_create_ios_driver(url, *, token=None, transport=None):
+        created["url"] = url
+        return FakeDriver()
+
+    monkeypatch.setattr(device_commands, "discover_ios_device", fake_discover_ios_device)
+    monkeypatch.setattr(device_commands, "create_ios_driver", fake_create_ios_driver)
+    monkeypatch.delenv("MOBILERUN_DEVICE_TOKEN", raising=False)
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("_version: 7\ndevice:\n  platform: ios\n")
+
+    driver, is_ios = run(
+        device_commands._create_driver(
+            device=None,
+            config_path=str(cfg),
+            tcp=None,
+            ios=True,
+        )
+    )
+
+    assert is_ios is True
+    assert created["url"] == "http://127.0.0.1:8081"

--- a/tests/test_ios_local_portal_wiring.py
+++ b/tests/test_ios_local_portal_wiring.py
@@ -195,7 +195,9 @@ def test_device_commands_discover_when_no_device(tmp_path, monkeypatch):
         created["url"] = url
         return FakeDriver()
 
-    monkeypatch.setattr(device_commands, "discover_ios_device", fake_discover_ios_device)
+    monkeypatch.setattr(
+        device_commands, "discover_ios_device", fake_discover_ios_device
+    )
     monkeypatch.setattr(device_commands, "create_ios_driver", fake_create_ios_driver)
     monkeypatch.delenv("MOBILERUN_DEVICE_TOKEN", raising=False)
 

--- a/tests/test_ios_local_portal_wiring.py
+++ b/tests/test_ios_local_portal_wiring.py
@@ -28,3 +28,83 @@ def test_auth_token_env_overrides_config(monkeypatch):
 
     monkeypatch.setenv("MOBILERUN_DEVICE_TOKEN", "from-env")
     assert DeviceConfig(auth_token="from-config").resolve_auth_token() == "from-env"
+
+
+LOCAL_PORTAL_STATE = {
+    "a11y_tree": {
+        "boundsInScreen": {"left": 0, "top": 0, "right": 393, "bottom": 852},
+        "className": "Application",
+        "resourceId": "",
+        "text": "",
+        "contentDescription": "",
+        "packageName": "com.apple.Preferences",
+        "children": [
+            {
+                "boundsInScreen": {"left": 16, "top": 180, "right": 377, "bottom": 224},
+                "className": "Button",
+                "resourceId": "Privacy",
+                "text": "Privacy & Security",
+                "contentDescription": "",
+                "packageName": "com.apple.Preferences",
+                "children": [],
+            }
+        ],
+    },
+    "phone_state": {
+        "currentApp": "Settings",
+        "packageName": "com.apple.Preferences",
+        "keyboardVisible": False,
+    },
+    "device_context": {
+        "screen_bounds": {"width": 393, "height": 852},
+        "filtering_params": {"min_element_size": 5, "overlay_offset": 0},
+        "display_metrics": {"widthPixels": 393, "heightPixels": 852},
+    },
+}
+
+
+class FakeLocalPortalDriver:
+    """Duck-typed stand-in for IOSPortalHttpDriver in provider tests."""
+
+    platform = "iOS"
+
+    async def get_ui_tree(self):
+        return LOCAL_PORTAL_STATE
+
+
+def test_android_state_provider_consumes_local_portal_state():
+    from mobilerun.tools.filters import DetailedFilter
+    from mobilerun.tools.formatters import IndexedFormatter
+    from mobilerun.tools.ui.provider import AndroidStateProvider
+
+    provider = AndroidStateProvider(
+        FakeLocalPortalDriver(),
+        tree_filter=DetailedFilter(),
+        tree_formatter=IndexedFormatter(),
+    )
+    state = run(provider.get_state())
+
+    assert state.screen_width == 393
+    assert state.screen_height == 852
+    assert state.elements, "expected elements parsed from the portal a11y tree"
+    assert "Privacy & Security" in state.formatted_text
+
+
+def test_android_state_provider_vision_contract_uses_point_space():
+    from mobilerun.tools.filters import ConciseFilter
+    from mobilerun.tools.formatters import IndexedFormatter
+    from mobilerun.tools.ui.provider import AndroidStateProvider
+
+    provider = AndroidStateProvider(
+        FakeLocalPortalDriver(),
+        tree_filter=ConciseFilter(),
+        tree_formatter=IndexedFormatter(),
+        vision_enabled=True,
+    )
+    state = run(provider.get_state())
+
+    # 393x852 points fit under the legacy 2048 max-side cap, so the model
+    # space equals the point space and taps need no rescaling.
+    assert state.coordinate_contract_active
+    assert (state.model_screenshot_width, state.model_screenshot_height) == (393, 852)
+    assert (state.coordinate_scale_x, state.coordinate_scale_y) == (1.0, 1.0)

--- a/tests/test_ios_local_portal_wiring.py
+++ b/tests/test_ios_local_portal_wiring.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_auth_token_defaults_to_none(monkeypatch):
+    from mobilerun.config_manager.config_manager import DeviceConfig
+
+    monkeypatch.delenv("MOBILERUN_DEVICE_TOKEN", raising=False)
+    assert DeviceConfig().resolve_auth_token() is None
+
+
+def test_auth_token_reads_config_value(monkeypatch):
+    from mobilerun.config_manager.config_manager import DeviceConfig
+
+    monkeypatch.delenv("MOBILERUN_DEVICE_TOKEN", raising=False)
+    assert DeviceConfig(auth_token="from-config").resolve_auth_token() == "from-config"
+
+
+def test_auth_token_env_overrides_config(monkeypatch):
+    from mobilerun.config_manager.config_manager import DeviceConfig
+
+    monkeypatch.setenv("MOBILERUN_DEVICE_TOKEN", "from-env")
+    assert DeviceConfig(auth_token="from-config").resolve_auth_token() == "from-env"

--- a/tests/test_vision_only_run_cli.py
+++ b/tests/test_vision_only_run_cli.py
@@ -106,7 +106,7 @@ class RunCliVisionOnlyTest(unittest.TestCase):
                 return_value=MobileConfig(),
             ),
             patch("mobilerun.cli.main.MobileAgent", FakeAgent),
-            patch("mobilerun.cli.main.discover_ios_portal", AsyncMock()) as discover,
+            patch("mobilerun.cli.main.discover_ios_device", AsyncMock()) as discover,
             patch("mobilerun.cli.main.validate_ios_portal_url") as validate,
         ):
             success = asyncio.run(

--- a/uv.lock
+++ b/uv.lock
@@ -1760,7 +1760,7 @@ requires-dist = [
     { name = "llama-index-workflows", specifier = ">=2.16.0,<3.0.0" },
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "mobilerun", extras = ["langfuse"], marker = "extra == 'dev'" },
-    { name = "mobilerun-core-local", extras = ["cloud"], specifier = ">=0.5.0" },
+    { name = "mobilerun-core-local", extras = ["cloud"], specifier = ">=0.6.0" },
     { name = "mobilerun-sdk", specifier = ">=3.2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "openinference-instrumentation-llama-index", marker = "extra == 'langfuse'", specifier = ">=3.0.0" },
@@ -1787,7 +1787,7 @@ dev = [
 
 [[package]]
 name = "mobilerun-core-local"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-adbutils" },
@@ -1795,9 +1795,9 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/08/673a58a645c5b1e4087beed98c79bd92fea247a1f9370f34df6436eb1d91/mobilerun_core_local-0.5.0.tar.gz", hash = "sha256:1c9dafb5d963ca5a1eb0c9d989f58e32d6f4c1f8dad5f54bf3a9a967599c19d9", size = 66006, upload-time = "2026-07-15T10:17:59.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/1a/17331235836f85ebfc7ef652ed392d051c9e8dfbb3f2c224e2f4122100e2/mobilerun_core_local-0.6.0.tar.gz", hash = "sha256:6ee483d1c325c2a9ebd577d05291aacc87ad9bb9483eebd4a7028643f1c4417f", size = 71100, upload-time = "2026-07-31T20:07:15.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/a6/37836c1417fd97b4ae633ca618366d364631406afd71d5e50f44bbb88b1a/mobilerun_core_local-0.5.0-py3-none-any.whl", hash = "sha256:2f42f1bc73f5eea482abf43ea16a264fbbd0ec1bdaec500068e03e886988f9be", size = 46187, upload-time = "2026-07-15T10:17:57.684Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7f/be52c36593c6350bda1f1e78b959b915682790e54c6c28467f57386a246d/mobilerun_core_local-0.6.0-py3-none-any.whl", hash = "sha256:fb67820a44dacef84b6a1baa96817b69e4de13a99ba80338cff85eda41e70cf1", size = 50896, upload-time = "2026-07-31T20:07:14.197Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- `mobilerun run --ios` (and `mobilerun device ...--ios`) now work against a `mobilerun-ios --local` portal HTTP server: the driver is created via core-local's `create_ios_driver`, which auto-detects the portal generation per URL, so the legacy ios-portal app keeps working with zero flag changes.
- Zero-flag discovery scans the `--local` port ladder (8080-8089) before the legacy range (6643-6652) via `discover_ios_device`.
- New `device.auth_token` config + `MOBILERUN_DEVICE_TOKEN` env override (env wins) for `--local-token`-protected servers; loopback needs no token.
- The `--local` driver pairs with `AndroidStateProvider` (the portal serves Android-shaped state in iOS point coordinates; the vision coordinate contract derives from point-space `screen_bounds`, so taps stay in points end to end). The pairing decision is captured before the Stealth/Recording wraps. `mobilerun device ui` uses the same pairing.
- Docs: local-mode section in device-setup; pin bumped to `mobilerun-core-local>=0.6.0`.

Depends on droidrun/mobilerun-core-local#7 — **0.6.0 must be published to PyPI before releasing this**, and `uv.lock` regenerated afterwards (intentionally not regenerated here since 0.6.0 is unpublished; dev runs use an editable install).

## Test plan

- [x] `pytest tests/ -q` — 376 passed (11 new: token resolution, provider pairing incl. vision coordinate contract, CLI factory/discovery routing, `device ui` regression via CliRunner)
- [x] Legacy-path guards: `tests/test_ios_provider.py`, `tests/test_visual_remote_connection.py` green
- [x] On-device: `mobilerun-ios --local <udid>` → `mobilerun run --ios "Open Settings"` (zero-flag + explicit URL), legacy Portal-app regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)