### PR TITLE
chore(release): bump to 0.6.15

### DIFF
--- a/compat/pyproject.toml
+++ b/compat/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "droidrun"
-version = "0.6.14"
+version = "0.6.15"
 description = "Compatibility shim — droidrun has been renamed to mobilerun"
 requires-python = ">=3.11,<3.14"
-dependencies = ["mobilerun==0.6.14"]
+dependencies = ["mobilerun==0.6.15"]
 
 [project.optional-dependencies]
-anthropic = ["mobilerun[anthropic]==0.6.14"]
-deepseek = ["mobilerun[deepseek]==0.6.14"]
-langfuse = ["mobilerun[langfuse]==0.6.14"]
-dev = ["mobilerun[dev]==0.6.14"]
+anthropic = ["mobilerun[anthropic]==0.6.15"]
+deepseek = ["mobilerun[deepseek]==0.6.15"]
+langfuse = ["mobilerun[langfuse]==0.6.15"]
+dev = ["mobilerun[dev]==0.6.15"]
 
 [project.scripts]
 droidrun = "droidrun.cli_shim:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mobilerun"
-version = "0.6.14"
+version = "0.6.15"
 description = "A framework for controlling mobile devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels@droidrun.ai" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1679,7 +1679,7 @@ wheels = [
 
 [[package]]
 name = "mobilerun"
-version = "0.6.14"
+version = "0.6.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Release MobileRun and the `droidrun` compatibility shim as `0.6.15`.

This release contains:

- PR #404: stable local iOS Portal-HTTP routing, device-token support, coordinate-contract protection, and secure config persistence.
- PR #411: provider-neutral containment for repeated malformed XML tool calls.

This release does **not** add native DeepSeek tool support or attempt to repair/normalize DSML.

## Release metadata

- Root package version: `0.6.15`
- Compatibility shim version: `0.6.15`
- Base dependency and all four optional-extra pins: `mobilerun==0.6.15`
- Lockfile change limited to the local `mobilerun` package version

## Validation

- PR #404/#411 impact set: 138 passed, plus 3 subtests
- Full pytest suite: 485 passed, plus 3 subtests
- Unittest discovery: 85 passed
- Installed-wheel boundary tests on Python 3.11 and 3.13: 69 passed, plus 3 subtests on each
- Lock check, frozen sync dry-run, dependency check, Black, and diff checks passed
- Ruff matches the existing `main` baseline with no new findings
- Root and compatibility wheels/sdists built and passed Twine checks
- `droidrun[anthropic]==0.6.15` resolves exactly to `mobilerun==0.6.15`
- Local container version/import/dependency/non-root checks passed
- Live Android validation passed, including no-action completion and hybrid-vision `click_at` navigation