### PR TITLE
Fix XAI OAuth on Python 3.11

### DIFF
--- a/mobilerun/agent/utils/oauth/grok_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/grok_oauth_llm.py
@@ -887,17 +887,18 @@ class GrokOAuth(OpenAIResponses):
     def _build_auth_url(
         *, redirect_uri: str, code_challenge: str, state: str, nonce: str
     ) -> str:
-        return f"{DEFAULT_GROK_OAUTH_AUTHORIZE_URL}?{urlencode({
-            'response_type': 'code',
-            'client_id': DEFAULT_GROK_OAUTH_CLIENT_ID,
-            'redirect_uri': redirect_uri,
-            'scope': ' '.join(DEFAULT_GROK_OAUTH_SCOPES),
-            'code_challenge': code_challenge,
-            'code_challenge_method': 'S256',
-            'state': state,
-            'nonce': nonce,
-            'referrer': 'grok-build',
-        })}"
+        params = {
+            "response_type": "code",
+            "client_id": DEFAULT_GROK_OAUTH_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "scope": " ".join(DEFAULT_GROK_OAUTH_SCOPES),
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+            "nonce": nonce,
+            "referrer": "grok-build",
+        }
+        return f"{DEFAULT_GROK_OAUTH_AUTHORIZE_URL}?{urlencode(params)}"
 
     def login(
         self,

--- a/tests/test_grok_oauth.py
+++ b/tests/test_grok_oauth.py
@@ -9,7 +9,7 @@ import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 import jwt
@@ -453,6 +453,21 @@ def test_authorization_url_is_pinned_pkce_and_complete():
         state="state",
         nonce="nonce",
     )
+    expected_query = urlencode(
+        [
+            ("response_type", "code"),
+            ("client_id", DEFAULT_GROK_OAUTH_CLIENT_ID),
+            ("redirect_uri", "http://127.0.0.1:54321/callback"),
+            ("scope", " ".join(DEFAULT_GROK_OAUTH_SCOPES)),
+            ("code_challenge", "challenge"),
+            ("code_challenge_method", "S256"),
+            ("state", "state"),
+            ("nonce", "nonce"),
+            ("referrer", "grok-build"),
+        ]
+    )
+    assert url == f"{DEFAULT_GROK_OAUTH_ISSUER}/oauth2/authorize?{expected_query}"
+
     parsed = urlparse(url)
     query = parse_qs(parsed.query)
 


### PR DESCRIPTION
## Summary

- Build the XAI OAuth authorization query outside the f-string expression so the module parses on every supported Python version.
- Preserve the exact authorization URL and parameter order.
- Add focused regression coverage for the complete encoded URL.

This is a release prerequisite discovered while validating the `0.6.16` wheel on Python 3.11.

## Validation

- Python 3.11 `py_compile` and package `compileall`
- XAI OAuth and CLI tests: 57 passed
- Complete test suite: 592 passed, 3 subtests passed
- Black 25.9.0
- Scoped Ruff
- `git diff --check`