### PR TITLE
chore(release): bump to 0.6.16

### DIFF
--- a/compat/pyproject.toml
+++ b/compat/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "droidrun"
-version = "0.6.15"
+version = "0.6.16"
 description = "Compatibility shim — droidrun has been renamed to mobilerun"
 requires-python = ">=3.11,<3.14"
-dependencies = ["mobilerun==0.6.15"]
+dependencies = ["mobilerun==0.6.16"]
 
 [project.optional-dependencies]
-anthropic = ["mobilerun[anthropic]==0.6.15"]
-deepseek = ["mobilerun[deepseek]==0.6.15"]
-langfuse = ["mobilerun[langfuse]==0.6.15"]
-dev = ["mobilerun[dev]==0.6.15"]
+anthropic = ["mobilerun[anthropic]==0.6.16"]
+deepseek = ["mobilerun[deepseek]==0.6.16"]
+langfuse = ["mobilerun[langfuse]==0.6.16"]
+dev = ["mobilerun[dev]==0.6.16"]
 
 [project.scripts]
 droidrun = "droidrun.cli_shim:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mobilerun"
-version = "0.6.15"
+version = "0.6.16"
 description = "A framework for controlling mobile devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels@droidrun.ai" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1679,7 +1679,7 @@ wheels = [
 
 [[package]]
 name = "mobilerun"
-version = "0.6.15"
+version = "0.6.16"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Release Mobilerun and the `droidrun` compatibility shim as `0.6.16`.

This release includes:

- First-class XAI support for `grok-4.5`, including API-key and OAuth setup, Responses API modes, usage accounting, and synchronized OAuth login deadlines.
- Python 3.11 compatibility for XAI OAuth authorization URL construction.
- Updated Mobilerun iOS installer documentation.
- Removal of the failing automatic Claude PR reviewer while preserving opt-in `@claude` requests.
- Mobile Harness and registry metadata updates.

## Release metadata

- Root package version: `0.6.16`
- Compatibility shim version: `0.6.16`
- Base dependency and all four optional-extra pins: `mobilerun==0.6.16`
- Lockfile change limited to the local `mobilerun` package version
- Portal compatibility map: `0.6.16` → `0.7.22`

## Validation

- Complete test suite: 592 passed, 3 subtests passed
- Unittest discovery: 85 passed
- Python 3.11 package compile-all: passed
- Black 25.9.0, lock, dependency, and diff checks: passed
- Ruff matches the existing `main` baseline with no new findings
- Root and compatibility wheels/sdists built and passed Twine checks
- Fresh Python 3.11 and 3.13 wheel, CLI, import, XAI, and dependency checks passed
- `droidrun[anthropic]==0.6.16` resolves exactly to `mobilerun==0.6.16` on Python 3.11 and 3.13
- Android 16/API 36 Portal 0.7.22 gate passed for XAI/grok-4.5 and OpenAIResponses/gpt-5.5, with positive usage, no device actions, correct Settings title, and final Home