### PR TITLE
Refresh XAI and Gemini model catalogs

### DIFF
--- a/docs/guides/cli.mdx
+++ b/docs/guides/cli.mdx
@@ -94,7 +94,7 @@ In screenshot-only mode, Mobilerun does not read an accessibility tree. The agen
 export GOOGLE_API_KEY=your-key
 mobilerun run "Archive old emails" \
   --provider GoogleGenAI \
-  --model gemini-3.5-flash-lite
+  --model gemini-3.7-flash
 
 # OpenAI
 export OPENAI_API_KEY=your-key
@@ -106,7 +106,7 @@ mobilerun run "Create shopping list" \
 export XAI_API_KEY=your-key
 mobilerun run "Open Settings" \
   --provider XAI \
-  --model grok-4.5
+  --model grok-4.6
 
 # Anthropic Claude
 export ANTHROPIC_API_KEY=your-key
@@ -177,10 +177,10 @@ Configure XAI with an API key or OAuth:
 mobilerun configure \
   --provider XAI \
   --auth-mode api_key \
-  --model grok-4.5
+  --model grok-4.6
 
 # OAuth through provider options
-mobilerun configure --provider XAI --auth-mode oauth --model grok-4.5
+mobilerun configure --provider XAI --auth-mode oauth --model grok-4.6
 
 # OAuth shortcut
 mobilerun configure xai
@@ -188,6 +188,9 @@ mobilerun configure xai
 # Device-code login for SSH/headless hosts
 mobilerun configure xai --device-code --no-browser
 ```
+
+Grok 4.6 is the default; Grok 4.5 remains available by selecting
+`--model grok-4.5` explicitly.
 
 ### MiniMax endpoints and credentials
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -129,7 +129,7 @@ mobilerun run "Find a contact named John and send him an email" --reasoning
 
 **Common CLI flags:**
 - `--provider` - LLM provider (GoogleGenAI, OpenAI, XAI, Anthropic, etc.)
-- `--model` - Model name (gemini-3.5-flash-lite, gpt-5.5, etc.)
+- `--model` - Model name (gemini-3.7-flash, gpt-5.5, etc.)
 - `--vision` - Enable screenshot processing
 - `--reasoning` - Enable multi-agent planning mode
 - `--steps N` - Maximum execution steps (default: 15)

--- a/docs/sdk/configuration.mdx
+++ b/docs/sdk/configuration.mdx
@@ -240,7 +240,7 @@ CredentialsConfig(
 ```python
 from mobilerun import MobileAgent, load_llm
 
-llm = load_llm("GoogleGenAI", model="gemini-3.5-flash-lite")
+llm = load_llm("GoogleGenAI", model="gemini-3.7-flash")
 agent = MobileAgent(goal="...", llms=llm)
 ```
 
@@ -254,10 +254,10 @@ agent = MobileAgent(
     goal="...",
     llms={
         "manager": OpenAI(model="gpt-4o"),                    # Planning
-        "executor": load_llm("GoogleGenAI", model="gemini-3.5-flash-lite"),  # Action selection
-        "fast_agent": load_llm("GoogleGenAI", model="gemini-3.5-flash-lite"),   # Fast Agent: Direct execution (XML tool-calling)
+        "executor": load_llm("GoogleGenAI", model="gemini-3.7-flash"),  # Action selection
+        "fast_agent": load_llm("GoogleGenAI", model="gemini-3.7-flash"),   # Fast Agent: Direct execution (XML tool-calling)
         "app_opener": OpenAI(model="gpt-4o-mini"),            # App launching
-        "structured_output": load_llm("GoogleGenAI", model="gemini-3.5-flash-lite"),  # Output extraction
+        "structured_output": load_llm("GoogleGenAI", model="gemini-3.7-flash"),  # Output extraction
     }
 )
 ```
@@ -441,10 +441,10 @@ agent = MobileAgent(
     # LLMs
     llms={
         "manager": OpenAI(model="gpt-4o"),                    # Planning
-        "executor": load_llm("GoogleGenAI", model="gemini-3.5-flash-lite"),  # Action selection
-        "fast_agent": load_llm("GoogleGenAI", model="gemini-3.5-flash-lite"),   # Fast Agent: Direct execution (XML tool-calling)
+        "executor": load_llm("GoogleGenAI", model="gemini-3.7-flash"),  # Action selection
+        "fast_agent": load_llm("GoogleGenAI", model="gemini-3.7-flash"),   # Fast Agent: Direct execution (XML tool-calling)
         "app_opener": OpenAI(model="gpt-4o-mini"),            # App launching
-        "structured_output": load_llm("GoogleGenAI", model="gemini-3.5-flash-lite"),  # Output extraction
+        "structured_output": load_llm("GoogleGenAI", model="gemini-3.7-flash"),  # Output extraction
     },
 
     # Custom tools
@@ -517,21 +517,21 @@ agent:
 llm_profiles:
   manager:
     provider: GoogleGenAI
-    model: gemini-3.5-flash-lite
+    model: gemini-3.7-flash
     temperature: 0.2
     kwargs:
       max_tokens: 8192
 
   executor:
     provider: GoogleGenAI
-    model: gemini-3.5-flash-lite
+    model: gemini-3.7-flash
     temperature: 0.1
     kwargs:
       max_tokens: 4096
 
   fast_agent:  # Fast Agent: Direct execution (XML tool-calling)
     provider: GoogleGenAI
-    model: gemini-3.5-flash-lite
+    model: gemini-3.7-flash
     temperature: 0.2
     kwargs:
       max_tokens: 8192
@@ -543,7 +543,7 @@ llm_profiles:
 
   structured_output:
     provider: GoogleGenAI
-    model: gemini-3.5-flash-lite
+    model: gemini-3.7-flash
     temperature: 0.0
 
 device:
@@ -598,7 +598,7 @@ mobilerun run "Task" --steps 30 --reasoning --vision
 mobilerun run "Task" --device emulator-5554 --tcp
 
 # Override LLM (applies to ALL agents)
-mobilerun run "Task" --provider GoogleGenAI --model gemini-3.5-flash-lite
+mobilerun run "Task" --provider GoogleGenAI --model gemini-3.7-flash
 
 # Override logging
 mobilerun run "Task" --debug --save-trajectory action --tracing

--- a/mobilerun/agent/providers/grok.py
+++ b/mobilerun/agent/providers/grok.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from collections.abc import Mapping, MutableMapping
 from typing import Any
 
-GROK_DEFAULT_MODEL = "grok-4.5"
-GROK_MODELS = (GROK_DEFAULT_MODEL,)
+GROK_DEFAULT_MODEL = "grok-4.6"
+GROK_MODELS = (GROK_DEFAULT_MODEL, "grok-4.5")
 GROK_MODEL_ALIASES = {
-    "grok-4.5-latest": GROK_DEFAULT_MODEL,
-    "grok-build-latest": GROK_DEFAULT_MODEL,
+    "grok-4.5-latest": "grok-4.5",
 }
 
 XAI_API_BASE = "https://api.x.ai/v1"

--- a/mobilerun/agent/providers/registry.py
+++ b/mobilerun/agent/providers/registry.py
@@ -40,6 +40,16 @@ OPENAI_MODEL_ALIASES: dict[str, str] = {
     "gpt-5.6": "gpt-5.6-sol",
 }
 
+GEMINI_API_DEFAULT_MODEL = "gemini-3.7-flash"
+GEMINI_API_MODELS: tuple[str, ...] = (
+    GEMINI_API_DEFAULT_MODEL,
+    "gemini-3.5-flash",
+    "gemini-3.6-flash",
+    "gemini-3.5-flash-lite",
+    "gemini-3-flash-preview",
+    "gemini-3.1-pro-preview",
+)
+
 
 PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
     ProviderFamilySpec(
@@ -50,14 +60,8 @@ PROVIDER_FAMILIES: tuple[ProviderFamilySpec, ...] = (
                 id="GoogleGenAI",
                 runtime_provider_name="GoogleGenAI",
                 auth_mode="api_key",
-                default_model="gemini-3.1-pro-preview",
-                models=(
-                    "gemini-3.5-flash",
-                    "gemini-3.6-flash",
-                    "gemini-3.5-flash-lite",
-                    "gemini-3-flash-preview",
-                    "gemini-3.1-pro-preview",
-                ),
+                default_model=GEMINI_API_DEFAULT_MODEL,
+                models=GEMINI_API_MODELS,
                 requires_api_key=True,
             ),
             ProviderVariantSpec(

--- a/mobilerun/agent/utils/llm_picker.py
+++ b/mobilerun/agent/utils/llm_picker.py
@@ -65,6 +65,7 @@ ZAI_GLOBAL_API_BASE = "https://api.z.ai/api/paas/v4"
 # Antigravity OAuth catalog. Catch these locally so users get the applicable
 # OAuth choices instead of a remote model-not-found response.
 GEMINI_OAUTH_UNSUPPORTED_MODELS = {
+    "gemini-3.7-flash",
     "gemini-3.6-flash",
     "gemini-3.5-flash-lite",
     "gemini-3.5-flash",
@@ -83,6 +84,7 @@ OPENAI_RESPONSES_MODELS_WITHOUT_SAMPLING_PARAMS = {
 }
 OPENAI_RESPONSES_UNSUPPORTED_SAMPLING_PARAMS = {"temperature", "top_p"}
 GOOGLE_GENAI_MODELS_WITHOUT_SAMPLING_PARAMS = {
+    "gemini-3.7-flash",
     "gemini-3.6-flash",
     "gemini-3.5-flash-lite",
 }
@@ -505,7 +507,7 @@ def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM
 
     Args:
         provider_name: Case-sensitive provider name (e.g. "OpenAIResponses", "Ollama").
-        model: Model name (e.g. "gpt-5.5", "gemini-3.5-flash-lite").
+        model: Model name (e.g. "gpt-5.5", "gemini-3.7-flash").
         **kwargs: Keyword arguments for the LLM class constructor.
 
     Returns:
@@ -609,7 +611,7 @@ def load_llm(provider_name: str, model: str | None = None, **kwargs: Any) -> LLM
         # config to redirect the bearer credential to another host.
         kwargs.pop("base_url", None)
         kwargs["api_base"] = XAI_API_BASE
-        # Grok 4.5's catalog context is provider metadata, not a caller-tunable
+        # Grok's catalog context is provider metadata, not a caller-tunable
         # endpoint option. Keep hand-written runtime profiles aligned with the
         # first-class provider catalog as well as generated profiles.
         kwargs["context_window"] = GROK_CONTEXT_WINDOW
@@ -749,7 +751,7 @@ if __name__ == "__main__":
         },
         {
             "name": "GoogleGenAI",
-            "model": "gemini-3.5-flash-lite",
+            "model": "gemini-3.7-flash",
         },
         {
             "name": "OpenAIResponses",

--- a/mobilerun/agent/utils/oauth/grok_oauth_llm.py
+++ b/mobilerun/agent/utils/oauth/grok_oauth_llm.py
@@ -31,6 +31,7 @@ from llama_index.llms.openai.responses import OpenAIResponses
 from llama_index.llms.openai.utils import to_openai_message_dicts
 
 from mobilerun.agent.providers.grok import (
+    GROK_DEFAULT_MODEL,
     GROK_MODELS,
     normalize_grok_model_id,
     sanitize_grok_responses_kwargs,
@@ -42,7 +43,7 @@ from mobilerun.agent.utils.oauth.login_timeout import (
 from mobilerun.config_manager.auth_profile_store import AuthProfileStore
 from mobilerun.config_manager.credential_paths import GROK_OAUTH_CREDENTIAL_PATH
 
-DEFAULT_GROK_MODEL = "grok-4.5"
+DEFAULT_GROK_MODEL = GROK_DEFAULT_MODEL
 DEFAULT_GROK_CONTEXT_WINDOW = 500_000
 DEFAULT_GROK_OAUTH_ISSUER = "https://auth.x.ai"
 DEFAULT_GROK_OAUTH_AUTHORIZE_URL = f"{DEFAULT_GROK_OAUTH_ISSUER}/oauth2/authorize"

--- a/mobilerun/config_example.yaml
+++ b/mobilerun/config_example.yaml
@@ -72,7 +72,7 @@ llm_profiles:
   # Manager: Plans and reasons about task progress
   manager:
     provider: GoogleGenAI
-    model: gemini-3.5-flash-lite
+    model: gemini-3.7-flash
     temperature: 0.2
     # api_key_source: auto  # auto = saved env file first, then shell env; env = shell only; file = saved env file
     # kwargs: # optional kwargs, add api_key in kwargs if not already in .env
@@ -91,7 +91,7 @@ llm_profiles:
   # Executor: Selects and executes atomic actions
   executor:
     provider: GoogleGenAI
-    model: gemini-3.5-flash-lite
+    model: gemini-3.7-flash
     temperature: 0.1
     # api_key_source: auto
     # kwargs:
@@ -100,7 +100,7 @@ llm_profiles:
   # Fast Agent: Direct execution agent (XML tool-calling or code generation)
   fast_agent:
     provider: GoogleGenAI
-    model: gemini-3.5-flash-lite
+    model: gemini-3.7-flash
     temperature: 0.2
     # api_key_source: auto
     # kwargs:
@@ -109,7 +109,7 @@ llm_profiles:
   # App Opener: Opens apps by name/description
   app_opener:
     provider: GoogleGenAI
-    model: gemini-3.5-flash-lite
+    model: gemini-3.7-flash
     temperature: 0.0
     # api_key_source: auto
     # kwargs:
@@ -118,7 +118,7 @@ llm_profiles:
   # Structured Output: Extracts structured data from final answers
   structured_output:
     provider: GoogleGenAI
-    model: gemini-3.5-flash-lite
+    model: gemini-3.7-flash
     temperature: 0.0
     # api_key_source: auto
     # kwargs:

--- a/mobilerun/config_manager/config_manager.py
+++ b/mobilerun/config_manager/config_manager.py
@@ -7,7 +7,10 @@ from typing import Any, Dict, List, Literal, Optional
 import yaml
 
 from mobilerun.agent.providers.minimax import warn_if_legacy_minimax_endpoint
-from mobilerun.agent.providers.registry import VARIANT_ENV_KEY_SLOT
+from mobilerun.agent.providers.registry import (
+    GEMINI_API_DEFAULT_MODEL,
+    VARIANT_ENV_KEY_SLOT,
+)
 from mobilerun.config_manager.env_keys import API_KEY_ENV_VARS, load_env_key_sources
 from mobilerun.config_manager.path_resolver import PathResolver
 from mobilerun.mcp.config import MCPConfig, MCPServerConfig
@@ -22,7 +25,7 @@ class LLMProfile:
     """LLM profile configuration."""
 
     provider: str = "GoogleGenAI"
-    model: str = "gemini-3.5-flash-lite"
+    model: str = GEMINI_API_DEFAULT_MODEL
     temperature: float = 0.2
     api_key_source: Literal["auto", "env", "file"] = "auto"
     base_url: Optional[str] = None
@@ -264,31 +267,31 @@ class MobileConfig:
         return {
             "manager": LLMProfile(
                 provider="GoogleGenAI",
-                model="gemini-3.5-flash-lite",
+                model=GEMINI_API_DEFAULT_MODEL,
                 temperature=0.2,
                 kwargs={},
             ),
             "executor": LLMProfile(
                 provider="GoogleGenAI",
-                model="gemini-3.5-flash-lite",
+                model=GEMINI_API_DEFAULT_MODEL,
                 temperature=0.1,
                 kwargs={},
             ),
             "fast_agent": LLMProfile(
                 provider="GoogleGenAI",
-                model="gemini-3.5-flash-lite",
+                model=GEMINI_API_DEFAULT_MODEL,
                 temperature=0.2,
                 kwargs={},
             ),
             "app_opener": LLMProfile(
                 provider="GoogleGenAI",
-                model="gemini-3.5-flash-lite",
+                model=GEMINI_API_DEFAULT_MODEL,
                 temperature=0.0,
                 kwargs={},
             ),
             "structured_output": LLMProfile(
                 provider="GoogleGenAI",
-                model="gemini-3.5-flash-lite",
+                model=GEMINI_API_DEFAULT_MODEL,
                 temperature=0.0,
                 kwargs={},
             ),

--- a/tests/test_grok_api.py
+++ b/tests/test_grok_api.py
@@ -552,12 +552,6 @@ def test_xai_runtime_aliases_default_to_canonical_model(
     assert llm.model == "grok-4.6"
 
 
-def test_xai_api_preserves_provider_managed_grok_build_latest() -> None:
-    llm = load_llm("XAI", model="grok-build-latest", api_key="stub")
-
-    assert llm.model == "grok-build-latest"
-
-
 def test_xai_oauth_runtime_uses_grok_oauth_adapter(tmp_path) -> None:
     llm = load_llm(
         "xai_oauth",

--- a/tests/test_grok_api.py
+++ b/tests/test_grok_api.py
@@ -22,7 +22,12 @@ from openai.types.responses.response_usage import (
     ResponseUsage,
 )
 
-from mobilerun.agent.providers.grok import XAI_API_BASE
+from mobilerun.agent.providers.grok import (
+    GROK_DEFAULT_MODEL,
+    GROK_MODELS,
+    XAI_API_BASE,
+    normalize_grok_model_id,
+)
 from mobilerun.agent.providers.registry import (
     VARIANT_ENV_KEY_SLOT,
     list_models_for_variant,
@@ -46,7 +51,7 @@ def _xai_completed_response(*, usage: ResponseUsage) -> Response:
         incomplete_details=None,
         instructions=None,
         metadata={},
-        model="grok-4.5",
+        model=GROK_DEFAULT_MODEL,
         object="response",
         output=[
             ResponseFunctionToolCall(
@@ -83,8 +88,11 @@ def test_grok_api_key_variant_is_first_class_xai_responses_provider() -> None:
 
     assert variant.id == "XAI"
     assert variant.runtime_provider_name == "XAI"
-    assert variant.default_model == "grok-4.5"
-    assert list_models_for_variant("xai", "api_key") == ("grok-4.5",)
+    assert variant.default_model == "grok-4.6"
+    assert list_models_for_variant("xai", "api_key") == (
+        "grok-4.6",
+        "grok-4.5",
+    )
     assert variant.requires_api_key is True
     assert variant.base_url == XAI_API_BASE
     assert VARIANT_ENV_KEY_SLOT[variant.id] == "xai"
@@ -96,20 +104,38 @@ def test_grok_oauth_variant_shares_the_canonical_model_catalog() -> None:
 
     assert variant.id == "xai_oauth"
     assert variant.runtime_provider_name == "xai_oauth"
-    assert variant.default_model == "grok-4.5"
-    assert variant.models == ("grok-4.5",)
+    assert variant.default_model == "grok-4.6"
+    assert variant.models == ("grok-4.6", "grok-4.5")
+    assert variant.models == GROK_MODELS
     assert variant.credential_path
 
 
 @pytest.mark.parametrize("auth_mode", ("api_key", "oauth"))
 @pytest.mark.parametrize(
-    "model_alias",
-    ("grok-4.5", "grok-4.5-latest", "grok-build-latest", "xai/grok-4.5"),
+    ("model_alias", "expected_model"),
+    (
+        ("grok-4.6", "grok-4.6"),
+        ("xai/grok-4.6", "grok-4.6"),
+        ("grok-4.5", "grok-4.5"),
+        ("grok-4.5-latest", "grok-4.5"),
+        ("xai/grok-4.5", "grok-4.5"),
+    ),
 )
 def test_grok_model_aliases_normalize_to_canonical_id(
-    auth_mode: str, model_alias: str
+    auth_mode: str, model_alias: str, expected_model: str
 ) -> None:
-    assert normalize_model_id_for_variant("xai", auth_mode, model_alias) == "grok-4.5"
+    assert (
+        normalize_model_id_for_variant("xai", auth_mode, model_alias) == expected_model
+    )
+
+
+@pytest.mark.parametrize("auth_mode", ("api_key", "oauth"))
+def test_grok_build_latest_is_never_rewritten(auth_mode: str) -> None:
+    assert normalize_grok_model_id("grok-build-latest") == "grok-build-latest"
+    assert (
+        normalize_model_id_for_variant("xai", auth_mode, "grok-build-latest")
+        == "grok-build-latest"
+    )
 
 
 @pytest.mark.parametrize("alias", ("xai", "XAI"))
@@ -132,7 +158,7 @@ def test_grok_profile_wires_api_base_context_and_environment_key(monkeypatch) ->
             family_id="xai",
             variant_id="XAI",
             auth_mode="api_key",
-            model="grok-build-latest",
+            model="grok-4.6",
             api_key_source="env",
         ),
         temperature=0.4,
@@ -140,7 +166,7 @@ def test_grok_profile_wires_api_base_context_and_environment_key(monkeypatch) ->
 
     assert profile.provider == "XAI"
     assert profile.provider_family == "xai"
-    assert profile.model == "grok-4.5"
+    assert profile.model == "grok-4.6"
     assert profile.temperature == 0.4
     assert profile.base_url == XAI_API_BASE
     assert profile.api_base == XAI_API_BASE
@@ -258,7 +284,6 @@ def test_xai_sync_chat_pins_final_sdk_wire_body() -> None:
 
     llm = load_llm(
         "XAI",
-        model="grok-4.5",
         api_key="stub",
         http_client=httpx.Client(transport=httpx.MockTransport(handler)),
     )
@@ -285,7 +310,7 @@ def test_xai_sync_chat_pins_final_sdk_wire_body() -> None:
     request = requests[0]
     assert str(request.url) == f"{XAI_API_BASE}/responses"
     payload = json.loads(request.content)
-    assert payload["model"] == "grok-4.5"
+    assert payload["model"] == "grok-4.6"
     assert payload["store"] is False
     assert payload["metadata"] == {"safe": "value"}
     assert {"reasoning", "presence_penalty"}.isdisjoint(payload)
@@ -305,7 +330,7 @@ def test_xai_sync_and_async_chat_send_sanitized_multimodal_tool_payloads() -> No
         async_payload.update(kwargs)
         return response
 
-    llm = load_llm("XAI", model="grok-4.5", api_key="stub")
+    llm = load_llm("XAI", model=GROK_DEFAULT_MODEL, api_key="stub")
     llm._client = SimpleNamespace(responses=SimpleNamespace(create=create_sync))
     llm._aclient = SimpleNamespace(responses=SimpleNamespace(create=create_async))
     messages = [
@@ -352,7 +377,7 @@ def test_xai_sync_and_async_chat_send_sanitized_multimodal_tool_payloads() -> No
 
     for payload in (sync_payload, async_payload):
         assert payload["stream"] is False
-        assert payload["model"] == "grok-4.5"
+        assert payload["model"] == GROK_DEFAULT_MODEL
         assert payload["temperature"] == 0.4
         assert payload["top_p"] == 0.6
         assert payload["store"] is False
@@ -393,7 +418,7 @@ def test_xai_sync_and_async_stream_preserve_completed_usage() -> None:
         async_payload.update(kwargs)
         return event_stream()
 
-    llm = load_llm("XAI", model="grok-4.5", api_key="stub")
+    llm = load_llm("XAI", model=GROK_DEFAULT_MODEL, api_key="stub")
     llm._client = SimpleNamespace(responses=SimpleNamespace(create=create_sync))
     llm._aclient = SimpleNamespace(responses=SimpleNamespace(create=create_async))
     messages = [ChatMessage(role=MessageRole.USER, content="inspect")]
@@ -448,7 +473,7 @@ def test_xai_structured_predict_sanitizes_sync_and_async_call_kwargs() -> None:
         async_payload.update(kwargs)
         return SimpleNamespace(output_parsed=StructuredResult(value="OK"))
 
-    llm = load_llm("XAI", model="grok-4.5", api_key="stub")
+    llm = load_llm("XAI", model=GROK_DEFAULT_MODEL, api_key="stub")
     llm._client = SimpleNamespace(responses=SimpleNamespace(parse=parse_sync))
     llm._aclient = SimpleNamespace(responses=SimpleNamespace(parse=parse_async))
     prompt = PromptTemplate("Return {value}")
@@ -524,7 +549,13 @@ def test_xai_runtime_aliases_default_to_canonical_model(
 
     llm = load_llm(alias)
 
-    assert llm.model == "grok-4.5"
+    assert llm.model == "grok-4.6"
+
+
+def test_xai_api_preserves_provider_managed_grok_build_latest() -> None:
+    llm = load_llm("XAI", model="grok-build-latest", api_key="stub")
+
+    assert llm.model == "grok-build-latest"
 
 
 def test_xai_oauth_runtime_uses_grok_oauth_adapter(tmp_path) -> None:

--- a/tests/test_grok_cli.py
+++ b/tests/test_grok_cli.py
@@ -161,7 +161,7 @@ def test_xai_oauth_action_shares_deadline_and_browser_preference(
     monkeypatch.setattr(oauth_actions, "GrokOAuth", FakeXAI)
     oauth_actions.run_grok_oauth_login(
         str(tmp_path / "auth.json"),
-        "grok-4.5",
+        None,
         timeout=12,
         open_browser=False,
         device_code=True,
@@ -169,6 +169,7 @@ def test_xai_oauth_action_shares_deadline_and_browser_preference(
 
     deadline = observed["login"]["deadline"]
     assert isinstance(deadline, OAuthLoginDeadline)
+    assert observed["init"]["model"] == "grok-4.6"
     assert observed["init"]["timeout"] == 12
     assert observed["login"]["open_browser"] is False
     assert observed["login"]["device_code"] is True
@@ -283,11 +284,11 @@ def test_exact_xai_configure_forms_keep_provider_and_auth_fixed(
     assert result.exit_code == 0, result.output
     assert saved_configs == [config]
     assert login_calls == []
-    assert model_prompts == [(("grok-4.5",), "grok-4.5")]
+    assert model_prompts == [(("grok-4.6", "grok-4.5"), "grok-4.6")]
     assert {
         (profile.provider, profile.provider_family, profile.auth_mode, profile.model)
         for profile in config.llm_profiles.values()
-    } == {(expected_provider, "xai", auth_mode, "grok-4.5")}
+    } == {(expected_provider, "xai", auth_mode, "grok-4.6")}
     assert "xai_oauth" not in result.output
     assert "Provider: XAI" in result.output
 
@@ -375,6 +376,6 @@ def test_fixed_provider_and_auth_model_back_returns_to_top_level_once(
         base_url=None,
     )
 
-    assert model_prompts == [(("grok-4.5",), "grok-4.5")]
+    assert model_prompts == [(("grok-4.6", "grok-4.5"), "grok-4.6")]
     assert menu_calls == ["Configure"]
     assert saved_configs == [config]

--- a/tests/test_grok_oauth.py
+++ b/tests/test_grok_oauth.py
@@ -23,6 +23,7 @@ from llama_index.core.base.llms.types import (
     ToolCallBlock,
 )
 
+from mobilerun.agent.providers.grok import GROK_DEFAULT_MODEL
 from mobilerun.agent.usage import get_usage_from_response
 from mobilerun.agent.utils.oauth.grok_oauth_llm import (
     DEFAULT_GROK_CONTEXT_WINDOW,
@@ -58,6 +59,10 @@ class _AcceptingIDTokenValidator:
     def validate(self, token: str, *, nonce: str | None):  # type: ignore[no-untyped-def]
         self.calls.append((token, nonce))
         return {"sub": "user"}
+
+
+def test_oauth_default_uses_shared_xai_catalog_default() -> None:
+    assert DEFAULT_GROK_MODEL == GROK_DEFAULT_MODEL == "grok-4.6"
 
 
 class _FakeClock:
@@ -1420,8 +1425,9 @@ def test_oauth_adapter_sync_and_async_stream_emit_completed_usage(
         assert {"temperature", "top_p", "reasoning"}.isdisjoint(payload)
 
 
-def test_oauth_adapter_async_responses_request_uses_proxy_auth_headers(
-    tmp_path: Path,
+@pytest.mark.parametrize("model", ("grok-4.6", "grok-4.5"))
+def test_oauth_adapter_async_responses_request_uses_exact_model_in_header_and_body(
+    tmp_path: Path, model: str
 ):
     requests: list[httpx.Request] = []
 
@@ -1432,7 +1438,7 @@ def test_oauth_adapter_async_responses_request_uses_proxy_auth_headers(
             json={
                 "id": "resp_test",
                 "created_at": int(time.time()),
-                "model": DEFAULT_GROK_MODEL,
+                "model": model,
                 "object": "response",
                 "output": [],
                 "parallel_tool_calls": True,
@@ -1445,6 +1451,7 @@ def test_oauth_adapter_async_responses_request_uses_proxy_auth_headers(
     async def run() -> str:
         async_http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         llm = GrokOAuth(
+            model=model,
             oauth_credential_path=str(tmp_path / "auth.json"),
             oauth_access_token="adapter-access",
             oauth_refresh_token="adapter-refresh",
@@ -1453,7 +1460,7 @@ def test_oauth_adapter_async_responses_request_uses_proxy_auth_headers(
         )
         try:
             response = await llm._aclient.responses.create(
-                model=DEFAULT_GROK_MODEL,
+                model=model,
                 input="hello",
                 store=False,
             )
@@ -1467,8 +1474,17 @@ def test_oauth_adapter_async_responses_request_uses_proxy_auth_headers(
     assert str(request.url) == f"{DEFAULT_GROK_OAUTH_PROXY}/responses"
     assert request.headers["Authorization"] == "Bearer adapter-access"
     assert request.headers["X-XAI-Token-Auth"] == "xai-grok-cli"
-    assert request.headers["x-grok-model-override"] == DEFAULT_GROK_MODEL
+    assert request.headers["x-grok-model-override"] == model
     assert request.headers[GROK_CLI_COMPAT_VERSION_HEADER] == GROK_CLI_COMPAT_VERSION
+    assert json.loads(request.content)["model"] == model
+
+
+def test_oauth_rejects_grok_build_latest_without_rewriting_it(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="grok-build-latest"):
+        GrokOAuth(
+            model="grok-build-latest",
+            oauth_credential_path=str(tmp_path / "auth.json"),
+        )
 
 
 def test_oauth_responses_adapter_pins_proxy_and_omits_controls(tmp_path: Path):

--- a/tests/test_llm_picker.py
+++ b/tests/test_llm_picker.py
@@ -233,6 +233,7 @@ def test_openai_oauth_rejects_unsupported_codex_model() -> None:
 @pytest.mark.parametrize(
     "model",
     [
+        "gemini-3.7-flash",
         "gemini-3.6-flash",
         "gemini-3.5-flash-lite",
         "gemini-3.5-flash",
@@ -260,7 +261,10 @@ def test_gemini_oauth_allows_live_unadvertised_2_5_ids(model: str) -> None:
     assert llm.model == model
 
 
-@pytest.mark.parametrize("model", ["gemini-3.6-flash", "gemini-3.5-flash-lite"])
+@pytest.mark.parametrize(
+    "model",
+    ["gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash-lite"],
+)
 def test_new_google_genai_models_omit_sampling_configuration(model: str) -> None:
     from google.genai import types
 
@@ -298,6 +302,106 @@ def test_new_google_genai_models_omit_sampling_configuration(model: str) -> None
     )
     assert {"temperature", "top_p", "top_k"}.isdisjoint(call_kwargs)
     assert call_kwargs["generation_config"] == {"max_output_tokens": 32}
+
+
+def test_gemini_3_7_image_tool_chat_uses_native_payload_without_sampling() -> None:
+    from google.genai import types
+    from llama_index.core.base.llms.types import (
+        ChatMessage,
+        ImageBlock,
+        MessageRole,
+        TextBlock,
+    )
+
+    captured: dict[str, Any] = {}
+    native_response = types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(
+                    role="model",
+                    parts=[
+                        types.Part(
+                            function_call=types.FunctionCall(
+                                name="live_probe", args={"value": "ok"}
+                            )
+                        )
+                    ],
+                ),
+                finish_reason=types.FinishReason.STOP,
+            )
+        ],
+        usage_metadata=types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=7,
+            candidates_token_count=3,
+            total_token_count=10,
+        ),
+    )
+
+    class NativeChat:
+        def send_message(self, parts: Any) -> Any:
+            captured["parts"] = parts
+            return native_response
+
+    class NativeChats:
+        def create(self, **kwargs: Any) -> NativeChat:
+            captured["create"] = kwargs
+            return NativeChat()
+
+    llm = load_llm(
+        "GoogleGenAI",
+        model="gemini-3.7-flash",
+        api_key="stub",
+        context_window=1_048_576,
+        max_tokens=64,
+        file_mode="inline",
+        temperature=0.4,
+    )
+    llm._client = SimpleNamespace(chats=NativeChats())
+    declaration = types.FunctionDeclaration(
+        name="live_probe",
+        description="Record the compatibility probe.",
+        parameters_json_schema={
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
+        },
+    )
+    tool_config = types.ToolConfig(
+        function_calling_config=types.FunctionCallingConfig(
+            mode="ANY", allowed_function_names=["live_probe"]
+        )
+    )
+
+    response = llm._chat(
+        [
+            ChatMessage(
+                role=MessageRole.USER,
+                blocks=[
+                    TextBlock(text="Inspect the image, then call live_probe."),
+                    ImageBlock(image=b"png", image_mimetype="image/png"),
+                ],
+            )
+        ],
+        tools=[types.Tool(function_declarations=[declaration])],
+        tool_config=tool_config,
+        **_sampling_llm_kwargs(),
+    )
+
+    create_kwargs = captured["create"]
+    config = create_kwargs["config"].model_dump(exclude_none=True)
+    assert create_kwargs["model"] == llm.model == "gemini-3.7-flash"
+    assert {"temperature", "top_p", "top_k"}.isdisjoint(config)
+    assert config["max_output_tokens"] == 32
+    assert config["tools"][0]["function_declarations"][0]["name"] == "live_probe"
+    assert config["tool_config"]["function_calling_config"]["mode"].value == "ANY"
+
+    sent_parts = captured["parts"]
+    assert sent_parts[1].inline_data.mime_type == "image/png"
+    assert sent_parts[1].inline_data.data == b"png"
+    tool_calls = llm.get_tool_calls_from_response(response)
+    assert [(call.tool_name, call.tool_kwargs) for call in tool_calls] == [
+        ("live_probe", {"value": "ok"})
+    ]
 
 
 class _AsyncChunks:
@@ -359,7 +463,7 @@ def _google_structured_llm_with_capture() -> tuple[Any, Any, Any, list[dict[str,
     calls: list[dict[str, Any]] = []
     llm = load_llm(
         "GoogleGenAI",
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.7-flash",
         api_key="stub",
         max_tokens=64,
         context_window=1_000_000,
@@ -391,6 +495,61 @@ def _assert_google_request_omits_sampling(request: dict[str, Any]) -> None:
     sampling_params = {"temperature", "top_p", "top_k"}
     assert sampling_params.isdisjoint(request)
     assert sampling_params.isdisjoint(request["config"])
+
+
+def test_gemini_3_7_chat_paths_strip_sampling_payload(monkeypatch) -> None:
+    from llama_index.llms.google_genai import GoogleGenAI
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def capture_chat(_self, _messages, **kwargs: Any) -> str:
+        calls.append(("chat", kwargs))
+        return "chat"
+
+    async def capture_achat(_self, _messages, **kwargs: Any) -> str:
+        calls.append(("achat", kwargs))
+        return "achat"
+
+    def capture_stream_chat(_self, _messages, **kwargs: Any) -> str:
+        calls.append(("stream_chat", kwargs))
+        return "stream_chat"
+
+    async def capture_astream_chat(_self, _messages, **kwargs: Any) -> str:
+        calls.append(("astream_chat", kwargs))
+        return "astream_chat"
+
+    monkeypatch.setattr(GoogleGenAI, "_chat", capture_chat)
+    monkeypatch.setattr(GoogleGenAI, "_achat", capture_achat)
+    monkeypatch.setattr(GoogleGenAI, "_stream_chat", capture_stream_chat)
+    monkeypatch.setattr(GoogleGenAI, "_astream_chat", capture_astream_chat)
+
+    llm = load_llm(
+        "GoogleGenAI",
+        model="gemini-3.7-flash",
+        api_key="stub",
+        max_tokens=64,
+        context_window=1_000_000,
+        temperature=0.4,
+    )
+
+    assert llm._chat([], **_sampling_llm_kwargs()) == "chat"
+    assert llm._stream_chat([], **_sampling_llm_kwargs()) == "stream_chat"
+
+    async def run_async_paths() -> None:
+        assert await llm._achat([], **_sampling_llm_kwargs()) == "achat"
+        assert await llm._astream_chat([], **_sampling_llm_kwargs()) == "astream_chat"
+
+    asyncio.run(run_async_paths())
+
+    assert [name for name, _ in calls] == [
+        "chat",
+        "stream_chat",
+        "achat",
+        "astream_chat",
+    ]
+    for _, call_kwargs in calls:
+        assert {"temperature", "top_p", "top_k"}.isdisjoint(call_kwargs)
+        assert call_kwargs["generation_config"] == {"max_output_tokens": 32}
 
 
 def test_google_direct_structured_path_strips_sampling_payload() -> None:

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -12,8 +12,10 @@ def test_gemini_api_key_catalog_uses_current_flash_models() -> None:
     variant = resolve_provider_variant("gemini", "api_key")
     models = list_models_for_variant("gemini", "api_key")
 
-    assert variant.default_model == "gemini-3.1-pro-preview"
+    assert models[0] == variant.default_model == LLMProfile().model
+    assert variant.default_model == "gemini-3.7-flash"
     assert models == (
+        "gemini-3.7-flash",
         "gemini-3.5-flash",
         "gemini-3.6-flash",
         "gemini-3.5-flash-lite",
@@ -110,12 +112,12 @@ def test_openai_api_key_catalog_uses_current_default_model() -> None:
     )
 
 
-def test_default_profiles_use_stable_gemini_flash_lite() -> None:
+def test_default_profiles_use_gemini_3_7_flash() -> None:
     config = MobileConfig()
 
-    assert LLMProfile().model == "gemini-3.5-flash-lite"
+    assert LLMProfile().model == "gemini-3.7-flash"
     assert {profile.model for profile in config.llm_profiles.values()} == {
-        "gemini-3.5-flash-lite"
+        "gemini-3.7-flash"
     }
 
 


### PR DESCRIPTION
## Summary

- make `grok-4.6` the default for XAI API and OAuth while retaining `grok-4.5`
- stop rewriting the provider-managed `grok-build-latest` identifier to a numbered model
- make `gemini-3.7-flash` the default for the public Gemini API and omit unsupported sampling fields
- keep the Gemini OAuth catalog and its hidden tiered routing identifiers unchanged
- align fresh profiles and primary configuration examples with the new defaults

## Validation

- focused XAI/Gemini suites: 227 passed
- complete suite: 603 passed, 3 subtests passed
- Black 25.9.0, scoped Ruff, `uv lock --check`, `uv pip check`, and `git diff --check`
- live compatibility gate: 17/17 passed with positive usage
  - Grok 4.6 via XAI API and OAuth: text, image, forced tool, structured output, and streaming
  - Gemini 3.7 Flash via API key: text, image, forced tool, structured output, and streaming
  - Grok 4.5 API and OAuth compatibility text calls
- Android 16/API 36 Portal gate: 3/3 passed on `emulator-5558`
  - XAI API / Grok 4.6: 11,625 tokens, 2 successful device actions
  - XAI OAuth / Grok 4.6: 11,913 tokens, 2 successful device actions
  - Gemini API / Gemini 3.7 Flash: 7,210 tokens, 2 successful device actions
  - all three reported the visible Settings screen, returned Home, and passed artifact secret scans

No package versions, dependencies, lockfiles, credential formats, provider identifiers, or Gemini OAuth routing were changed.