### PR TITLE
chore(release): bump to 0.6.17

### DIFF
--- a/compat/pyproject.toml
+++ b/compat/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "droidrun"
-version = "0.6.16"
+version = "0.6.17"
 description = "Compatibility shim — droidrun has been renamed to mobilerun"
 requires-python = ">=3.11,<3.14"
-dependencies = ["mobilerun==0.6.16"]
+dependencies = ["mobilerun==0.6.17"]
 
 [project.optional-dependencies]
-anthropic = ["mobilerun[anthropic]==0.6.16"]
-deepseek = ["mobilerun[deepseek]==0.6.16"]
-langfuse = ["mobilerun[langfuse]==0.6.16"]
-dev = ["mobilerun[dev]==0.6.16"]
+anthropic = ["mobilerun[anthropic]==0.6.17"]
+deepseek = ["mobilerun[deepseek]==0.6.17"]
+langfuse = ["mobilerun[langfuse]==0.6.17"]
+dev = ["mobilerun[dev]==0.6.17"]
 
 [project.scripts]
 droidrun = "droidrun.cli_shim:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mobilerun"
-version = "0.6.16"
+version = "0.6.17"
 description = "A framework for controlling mobile devices through LLM agents"
 authors = [{ name = "Niels Schmidt", email = "niels@droidrun.ai" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1679,7 +1679,7 @@ wheels = [
 
 [[package]]
 name = "mobilerun"
-version = "0.6.16"
+version = "0.6.17"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- bump `mobilerun` and compatibility package versions to `0.6.17`
- pin all five `droidrun` compatibility references to `mobilerun==0.6.17`
- update only the local Mobilerun package version in `uv.lock`

No dependency versions change.

## Validation

- pytest: 603 passed, 3 subtests passed
- unittest discovery: 85 passed
- Black: 172 files unchanged
- Ruff: exactly the same nine pre-existing findings as `main`
- `uv lock --check`, `uv pip check`, and `git diff --check`
- root and compatibility wheel/sdist builds plus Twine checks
- fresh Python 3.11 and 3.13 installs, including exact `droidrun[anthropic] -> mobilerun==0.6.17` resolution
- XAI/Gemini catalog, API/OAuth isolation, CLI, and public-import checks

## Android 16 release gate

Built-wheel testing passed on Android 16/API 36 with Portal 0.7.22:

| Provider | Model | Result | Usage | Device actions |
|---|---|---|---:|---:|
| XAI | grok-4.6 | Passed | 12,050 tokens | 2 |
| xai_oauth | grok-4.6 | Passed | 11,904 tokens | 2 |
| GoogleGenAI | gemini-3.7-flash | Passed | 11,687 tokens | 2 |

All cases used exact bindings with no fallback, completed successfully, produced Portal evidence, returned Home, and passed credential/artifact secret checks.

The Portal compatibility resolver now returns `0.7.22` for Mobilerun `0.6.17`.