### PR TITLE
docs: add the mobile-harness agent skill section

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,15 @@ Use the framework when you want full local control of the agent runtime. Use [Mo
 
 ## 🧩 Agent Skill
 
-Give Claude Code, Codex, or another coding agent direct control of Android and iOS devices with the [mobile-harness](https://github.com/droidrun/mobile-harness) skill:
+Give Claude Code, Codex, or another coding agent direct control of Android and iOS devices with the [mobile-harness](https://github.com/droidrun/mobile-harness) skill. Copy paste it into your agent:
 
-```bash
-npx skills add droidrun/mobile-harness
+```text
+Set up https://github.com/droidrun/mobile-harness for me.
+
+Read `install.md` and follow the steps to install `mobile-harness`.
 ```
 
-The skill teaches the agent to drive local devices (ADB, Portal, iOS Simulator) and Mobilerun Cloud phones through `mobilerun-core`.
+The skill teaches the agent to drive local devices (ADB, Portal, iOS Simulator) and Mobilerun Cloud phones.
 
 ## 🎬 Demo Videos
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,16 @@ Use the framework when you want full local control of the agent runtime. Use [Mo
 | Cloud Phone (Hosted) | Instantly available cloud-hosted phone | Scalable hosted automation |
 | Physical Phone (Hosted) | Real hardware with stronger identity characteristics | Workflows that need high device authenticity and trust |
 
+## 🧩 Agent Skill
+
+Give Claude Code, Codex, or another coding agent direct control of Android and iOS devices with the [mobile-harness](https://github.com/droidrun/mobile-harness) skill:
+
+```bash
+npx skills add droidrun/mobile-harness
+```
+
+The skill teaches the agent to drive local devices (ADB, Portal, iOS Simulator) and Mobilerun Cloud phones through `mobilerun-core`.
+
 ## 🎬 Demo Videos
 
 ### Book accommodation from a prompt


### PR DESCRIPTION
README gains an "Agent Skill" section between Framework vs Cloud and Demo Videos: a copy-paste agent setup prompt that connects Claude Code, Codex, or another coding agent directly to Android/iOS devices via the [mobile-harness](https://github.com/droidrun/mobile-harness) skill.

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)